### PR TITLE
Fix fromTerminal assertion in tradeCalculation test

### DIFF
--- a/__tests__/utils/trade/tradeCalculations.test.js
+++ b/__tests__/utils/trade/tradeCalculations.test.js
@@ -53,7 +53,7 @@ const {
           terminal: null // missing terminal
         }];
         const results = calculateProfitOptions(records, 66, 100_000);
-        expect(results[0].terminal).toBeUndefined();
+        expect(results[0].fromTerminal).toBeUndefined();
         expect(results[0].location).toBeUndefined();
       });
       


### PR DESCRIPTION
## Summary
- fix expectation for missing terminal in tradeCalculations test

## Testing
- `npm test` *(fails: jest not found)*