### PR TITLE
Enhance user verification resilience

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -9,7 +9,11 @@ const VerificationCode = {
 
 const VerifiedUser = {
   findOne: jest.fn(),
-  upsert: jest.fn()
+  upsert: jest.fn(),
+  findAll: jest.fn(),
+  update: jest.fn(),
+  destroy: jest.fn(),
+  findByPk: jest.fn()
 };
 
 const OrgTag = {

--- a/__tests__/botactions/orgTagSync/syncOrgTags.test.js
+++ b/__tests__/botactions/orgTagSync/syncOrgTags.test.js
@@ -35,7 +35,7 @@ describe('syncOrgTags', () => {
 
   it('updates rsiOrgId and corrects nickname if org changed', async () => {
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'OLDORG' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'OLDORG', failedProfileChecks: 0 }
     ]);
   
     rsiProfileScraper.fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS' });
@@ -44,7 +44,7 @@ describe('syncOrgTags', () => {
     await syncOrgTags(mockClient);
   
     expect(VerifiedUser.update).toHaveBeenCalledWith(
-      { rsiOrgId: 'PFCS' },
+      expect.objectContaining({ rsiOrgId: 'PFCS', failedProfileChecks: 0 }),
       { where: { discordUserId: 'user1' } }
     );
     expect(mockMember.setNickname).toHaveBeenCalledWith('[PFC] WrongName');
@@ -52,9 +52,9 @@ describe('syncOrgTags', () => {
 
   it('does not update nickname if already correct', async () => {
     mockMember.displayName = '[PFC] WrongName';
-  
+
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 0 }
     ]);
   
     rsiProfileScraper.fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS' });
@@ -62,13 +62,13 @@ describe('syncOrgTags', () => {
   
     await syncOrgTags(mockClient);
   
-    expect(VerifiedUser.update).not.toHaveBeenCalled();
+    expect(VerifiedUser.update).toHaveBeenCalled();
     expect(mockMember.setNickname).not.toHaveBeenCalled();
   });
 
   it('skips nickname changes for users outside predefined orgs but updates DB', async () => {
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 0 }
     ]);
   
     rsiProfileScraper.fetchRsiProfileInfo.mockResolvedValue({ orgId: 'OUTLAW' });  // Not in predefined orgs
@@ -77,7 +77,7 @@ describe('syncOrgTags', () => {
     await syncOrgTags(mockClient);
   
     expect(VerifiedUser.update).toHaveBeenCalledWith(
-      { rsiOrgId: 'OUTLAW' },
+      expect.objectContaining({ rsiOrgId: 'OUTLAW' }),
       { where: { discordUserId: 'user1' } }
     );
     expect(mockMember.setNickname).not.toHaveBeenCalled();
@@ -88,7 +88,7 @@ describe('syncOrgTags', () => {
     const clientWithNoGuild = { guilds: { cache: { first: () => undefined } } };
 
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 0 }
     ]);
 
     await syncOrgTags(clientWithNoGuild);
@@ -101,23 +101,23 @@ describe('syncOrgTags', () => {
     mockGuild.members.fetch = jest.fn().mockRejectedValue(new Error('Member not found'));
 
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 0 }
     ]);
 
     rsiProfileScraper.fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS' });
 
     await expect(syncOrgTags(mockClient)).resolves.not.toThrow();
-    expect(VerifiedUser.update).not.toHaveBeenCalled(); 
+    expect(VerifiedUser.update).toHaveBeenCalled();
   });
 
   it('continues processing if scraping fails for a user', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 0 }
     ]);
 
-    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(new Error('Scrape failed'));  
+    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(new Error('Scrape failed'));
 
     await syncOrgTags(mockClient);
 
@@ -125,18 +125,22 @@ describe('syncOrgTags', () => {
       expect.stringContaining('❌ Failed to process VerifiedUser:'),
       expect.any(Error)
     );
+    expect(VerifiedUser.update).toHaveBeenCalledWith(
+      expect.objectContaining({ failedProfileChecks: 1 }),
+      { where: { discordUserId: 'user1' } }
+    );
     consoleSpy.mockRestore();
   });
 
   // 🟢 New test for "profile not found → remove + unverify"
-  it('removes user from DB and updates nickname if RSI profile not found', async () => {
+  it('removes user from DB after repeated profile not found errors', async () => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     VerifiedUser.findAll.mockResolvedValue([
-      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
+      { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS', failedProfileChecks: 2 }
     ]);
 
-    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(new Error('Unable to fetch RSI profile for handle: VerifiedUser'));
+    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(new rsiProfileScraper.ProfileNotFoundError('not found'));
 
     await syncOrgTags(mockClient);
 
@@ -144,9 +148,7 @@ describe('syncOrgTags', () => {
       where: { discordUserId: 'user1' }
     });
     expect(mockMember.setNickname).toHaveBeenCalledWith('WrongName ⛔');
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('RSI profile not found for VerifiedUser')
-    );
+    expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 });

--- a/__tests__/utils/rsiProfileScraper.test.js
+++ b/__tests__/utils/rsiProfileScraper.test.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch');
 const { Response } = jest.requireActual('node-fetch');
 jest.mock('node-fetch');
 
-const { fetchRsiProfileInfo } = require('../../utils/rsiProfileScraper');
+const { fetchRsiProfileInfo, ProfileNotFoundError } = require('../../utils/rsiProfileScraper');
 
 describe('rsiProfileScraper - fetchRsiProfileInfo edge cases', () => {
   afterEach(() => {
@@ -176,12 +176,12 @@ describe('rsiProfileScraper - fetchRsiProfileInfo edge cases', () => {
     expect(result.orgRank).toBeNull();
   });
 
-  it('throws an error if handle is not found (HTTP 404)', async () => {
+  it('throws ProfileNotFoundError if handle is not found (HTTP 404)', async () => {
     fetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
 
     await expect(fetchRsiProfileInfo('NonExistentHandle'))
       .rejects
-      .toThrow('Unable to fetch RSI profile for handle: NonExistentHandle');
+      .toBeInstanceOf(ProfileNotFoundError);
   });
 
   it('throws an error if profile page structure is invalid (no handle found)', async () => {

--- a/models/verifiedUser.js
+++ b/models/verifiedUser.js
@@ -16,9 +16,18 @@ module.exports = (sequelize) => {
       type: DataTypes.STRING,
       allowNull: true
     },
-    manualTagOverride: { 
+    manualTagOverride: {
       type: DataTypes.STRING,
       allowNull: true
+    },
+    lastProfileCheck: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    failedProfileChecks: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
     verifiedAt: {
       type: DataTypes.DATE,


### PR DESCRIPTION
## Notes
- Added fields to track profile check timestamps and failure counts.
- Scraper now distinguishes 404 errors and other fetch failures.
- Sync job increments failure count and only removes users after repeated profile-not-found results.
- Updated tests and mocks for new behaviour.

## Testing
- `npm test` *(fails: jest not found)*