### PR TITLE
Fix org tag sync failure handling

### DIFF
--- a/botactions/orgTagSync/syncOrgTags.js
+++ b/botactions/orgTagSync/syncOrgTags.js
@@ -71,7 +71,6 @@ async function syncOrgTags(client) {
         console.warn(`⚠️ Temporary failure fetching profile for ${user.rsiHandle}. (${failures}/${FAILURE_THRESHOLD})`);
       } else {
         console.error(`❌ Failed to process ${user.rsiHandle}:`, error);
-        continue;
       }
 
       await VerifiedUser.update(


### PR DESCRIPTION
## Summary
- don't skip DB update when scraping fails in orgTagSync

## Testing
- `npm test` *(fails: jest not found)*