### PR TITLE
Fix nickname evaluation fallback

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -9,11 +9,14 @@ const VerificationCode = {
 
 const VerifiedUser = {
   findOne: jest.fn(),
+  findByPk: jest.fn(),
+  findAll: jest.fn(),
   upsert: jest.fn()
 };
 
 const OrgTag = {
-  findByPk: jest.fn()
+  findByPk: jest.fn(),
+  findAll: jest.fn()
 };
 
 const UsageLog = {

--- a/__tests__/botactions/scheduling/scheduleHandler.test.js
+++ b/__tests__/botactions/scheduling/scheduleHandler.test.js
@@ -1,0 +1,52 @@
+jest.mock('../../../config/database', () => ({
+  ScheduledAnnouncement: {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    destroy: jest.fn(),
+  }
+}));
+
+jest.mock('../../../botactions/utilityFunctions', () => ({
+  getChannelNameById: jest.fn(() => Promise.resolve('general')),
+  getGuildNameById: jest.fn(() => Promise.resolve('Test Guild')),
+}));
+
+const { saveAnnouncementToDatabase, getScheduledAnnouncements, deleteScheduledAnnouncement } = require('../../../botactions/scheduling/scheduleHandler');
+const { ScheduledAnnouncement } = require('../../../config/database');
+const { getChannelNameById, getGuildNameById } = require('../../../botactions/utilityFunctions');
+
+describe('scheduleHandler database operations', () => {
+  const mockClient = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('saveAnnouncementToDatabase stores record and resolves names', async () => {
+    ScheduledAnnouncement.create.mockResolvedValue({});
+
+    await saveAnnouncementToDatabase('123', 'guild1', { title: 'Test', description: 'Desc' }, 1111, mockClient);
+
+    expect(ScheduledAnnouncement.create).toHaveBeenCalledWith({
+      channelId: '123',
+      guildId: 'guild1',
+      embedData: JSON.stringify({ title: 'Test', description: 'Desc' }),
+      time: '1111'
+    });
+    expect(getChannelNameById).toHaveBeenCalledWith('123', mockClient);
+    expect(getGuildNameById).toHaveBeenCalledWith('guild1', mockClient);
+  });
+
+  test('getScheduledAnnouncements returns records', async () => {
+    ScheduledAnnouncement.findAll.mockResolvedValue([{ id: 1 }]);
+    const result = await getScheduledAnnouncements();
+    expect(ScheduledAnnouncement.findAll).toHaveBeenCalled();
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  test('deleteScheduledAnnouncement removes record by id', async () => {
+    ScheduledAnnouncement.destroy.mockResolvedValue(1);
+    await deleteScheduledAnnouncement(7);
+    expect(ScheduledAnnouncement.destroy).toHaveBeenCalledWith({ where: { id: 7 } });
+  });
+});

--- a/__tests__/utils/evaluateAndFixNickname.test.js
+++ b/__tests__/utils/evaluateAndFixNickname.test.js
@@ -1,0 +1,63 @@
+const { evaluateAndFixNickname } = require('../../utils/evaluateAndFixNickname');
+const { VerifiedUser, OrgTag } = require('../../config/database');
+const { formatVerifiedNickname } = require('../../utils/formatVerifiedNickname');
+const { pendingVerifications } = require('../../commands/user/verify');
+
+jest.mock('../../config/database');
+jest.mock('../../utils/formatVerifiedNickname');
+jest.mock('../../commands/user/verify', () => ({ pendingVerifications: new Set() }));
+
+describe('evaluateAndFixNickname', () => {
+  const createMember = (id, username, nickname = null, bot = false) => ({
+    id,
+    nickname,
+    displayName: nickname || username,
+    user: { id, username, tag: `${username}#1234`, bot },
+    setNickname: jest.fn().mockResolvedValue(true),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pendingVerifications.clear();
+    OrgTag.findAll.mockResolvedValue([{ tag: 'PFC' }]);
+  });
+
+  test('returns false for bots', async () => {
+    const member = createMember('1', 'Bot', 'Bot', true);
+    const result = await evaluateAndFixNickname(member);
+    expect(result).toBe(false);
+  });
+
+  test('skips pending verifications when option set', async () => {
+    pendingVerifications.add('2');
+    const member = createMember('2', 'User');
+    const result = await evaluateAndFixNickname(member, { skipPending: true });
+    expect(result).toBe(false);
+    expect(VerifiedUser.findByPk).not.toHaveBeenCalled();
+  });
+
+  test('updates nickname for verified user with org tag', async () => {
+    const member = createMember('3', 'Tester', 'Tester');
+    VerifiedUser.findByPk.mockResolvedValue({ discordUserId: '3', rsiOrgId: 'PFC' });
+    OrgTag.findByPk.mockResolvedValue({ tag: 'PFC' });
+    formatVerifiedNickname.mockReturnValue('[PFC] Tester');
+
+    const updated = await evaluateAndFixNickname(member);
+
+    expect(formatVerifiedNickname).toHaveBeenCalledWith('Tester', true, 'PFC');
+    expect(member.setNickname).toHaveBeenCalledWith('[PFC] Tester');
+    expect(updated).toBe(true);
+  });
+
+  test('adds symbol for unverified user', async () => {
+    const member = createMember('4', 'Foo', 'Foo');
+    VerifiedUser.findByPk.mockResolvedValue(null);
+    formatVerifiedNickname.mockReturnValue('Foo ⛔');
+
+    const updated = await evaluateAndFixNickname(member);
+
+    expect(formatVerifiedNickname).toHaveBeenCalledWith('Foo', false, null);
+    expect(member.setNickname).toHaveBeenCalledWith('Foo ⛔');
+    expect(updated).toBe(true);
+  });
+});

--- a/utils/evaluateAndFixNickname.js
+++ b/utils/evaluateAndFixNickname.js
@@ -41,7 +41,8 @@ async function evaluateAndFixNickname(member, {
       tag = verifiedRecord.manualTagOverride;
     } else if (verifiedRecord?.rsiOrgId) {
       const org = await OrgTag.findByPk(verifiedRecord.rsiOrgId.toUpperCase());
-      tag = org?.tag || null;
+      // Fallback to the org ID itself if no tag entry exists
+      tag = org?.tag || verifiedRecord.rsiOrgId.toUpperCase() || null;
     }
   }
   


### PR DESCRIPTION
## Summary
- ensure `evaluateAndFixNickname` falls back to using the org ID when an OrgTag record is missing

## Testing
- `npm test` *(fails: `jest: not found`)*