### PR TITLE
Ensure org tag fallback for verified nickname

### DIFF
--- a/__tests__/utils/evaluateAndFixNickname.test.js
+++ b/__tests__/utils/evaluateAndFixNickname.test.js
@@ -60,4 +60,17 @@ describe('evaluateAndFixNickname', () => {
     expect(member.setNickname).toHaveBeenCalledWith('Foo ⛔');
     expect(updated).toBe(true);
   });
+
+  test('falls back to rsiOrgId when org tag record missing', async () => {
+    const member = createMember('5', 'Tester', 'Tester');
+    VerifiedUser.findByPk.mockResolvedValue({ discordUserId: '5', rsiOrgId: 'TST' });
+    OrgTag.findByPk.mockResolvedValue(null);
+    formatVerifiedNickname.mockReturnValue('[TST] Tester');
+
+    const updated = await evaluateAndFixNickname(member);
+
+    expect(formatVerifiedNickname).toHaveBeenCalledWith('Tester', true, 'TST');
+    expect(member.setNickname).toHaveBeenCalledWith('[TST] Tester');
+    expect(updated).toBe(true);
+  });
 });

--- a/utils/evaluateAndFixNickname.js
+++ b/utils/evaluateAndFixNickname.js
@@ -42,7 +42,7 @@ async function evaluateAndFixNickname(member, {
     } else if (verifiedRecord?.rsiOrgId) {
       const org = await OrgTag.findByPk(verifiedRecord.rsiOrgId.toUpperCase());
       // Fallback to the org ID itself if no tag entry exists
-      tag = org?.tag || verifiedRecord.rsiOrgId.toUpperCase() || null;
+      tag = org?.tag || verifiedRecord.rsiOrgId.toUpperCase();
     }
   }
   


### PR DESCRIPTION
## Summary
- ensure evaluateAndFixNickname uses org ID when OrgTag lookup fails
- test nickname handling when OrgTag.findByPk returns null

## Testing
- `npm test` *(fails: jest not found)*