### PR TITLE
Improve RSI profile fetch error handling

### DIFF
--- a/__mocks__/utils/rsiProfileScraper.js
+++ b/__mocks__/utils/rsiProfileScraper.js
@@ -57,7 +57,9 @@ module.exports = {
 
     const profile = mockProfiles[rsiHandle];
     if (!profile) {
-      throw new Error(`Mock profile not found for handle: ${rsiHandle}`);
+      const error = new Error(`Mock profile not found for handle: ${rsiHandle}`);
+      error.code = 'PROFILE_NOT_FOUND';
+      throw error;
     }
     return Promise.resolve(profile);
   })

--- a/__tests__/botactions/orgTagSync/syncOrgTags.test.js
+++ b/__tests__/botactions/orgTagSync/syncOrgTags.test.js
@@ -136,7 +136,9 @@ describe('syncOrgTags', () => {
       { discordUserId: 'user1', rsiHandle: 'VerifiedUser', rsiOrgId: 'PFCS' }
     ]);
 
-    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(new Error('Unable to fetch RSI profile for handle: VerifiedUser'));
+    const err = new Error('Profile not found');
+    err.code = 'PROFILE_NOT_FOUND';
+    rsiProfileScraper.fetchRsiProfileInfo.mockRejectedValue(err);
 
     await syncOrgTags(mockClient);
 

--- a/__tests__/utils/rsiProfileScraper.test.js
+++ b/__tests__/utils/rsiProfileScraper.test.js
@@ -176,12 +176,12 @@ describe('rsiProfileScraper - fetchRsiProfileInfo edge cases', () => {
     expect(result.orgRank).toBeNull();
   });
 
-  it('throws an error if handle is not found (HTTP 404)', async () => {
+  it('throws an error with code PROFILE_NOT_FOUND if handle is not found (HTTP 404)', async () => {
     fetch.mockResolvedValue(new Response('Not Found', { status: 404 }));
 
     await expect(fetchRsiProfileInfo('NonExistentHandle'))
       .rejects
-      .toThrow('Unable to fetch RSI profile for handle: NonExistentHandle');
+      .toMatchObject({ code: 'PROFILE_NOT_FOUND' });
   });
 
   it('throws an error if profile page structure is invalid (no handle found)', async () => {

--- a/botactions/orgTagSync/syncOrgTags.js
+++ b/botactions/orgTagSync/syncOrgTags.js
@@ -44,7 +44,7 @@ async function syncOrgTags(client) {
 
     } catch (error) {
       // Handle profile not found case
-      if (error.message && error.message.includes('Unable to fetch RSI profile')) {
+      if (error.code === 'PROFILE_NOT_FOUND') {
         console.warn(`⚠️ RSI profile not found for ${user.rsiHandle}. Removing verification.`);
 
         // Remove from the database

--- a/utils/rsiProfileScraper.js
+++ b/utils/rsiProfileScraper.js
@@ -9,9 +9,25 @@ const cheerio = require('cheerio');
 async function fetchRsiProfileInfo(rsiHandle) {
   const url = `https://robertsspaceindustries.com/citizens/${rsiHandle}`;
 
-  const res = await fetch(url);
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    const error = new Error(`Failed to fetch ${url}: ${err.message}`);
+    error.code = 'FETCH_FAILED';
+    throw error;
+  }
+
+  if (res.status === 404) {
+    const error = new Error(`RSI profile not found for handle: ${rsiHandle}`);
+    error.code = 'PROFILE_NOT_FOUND';
+    throw error;
+  }
+
   if (!res.ok) {
-    throw new Error(`Unable to fetch RSI profile for handle: ${rsiHandle}`);
+    const error = new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+    error.code = 'FETCH_FAILED';
+    throw error;
   }
 
   const html = await res.text();


### PR DESCRIPTION
## Summary
- handle network errors in `rsiProfileScraper`
- adjust org tag sync to use new error codes
- update mocks and tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*