### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Install dependencies:
 npm install
 ```
 
+Run the full setup (install + tests):
+
+```bash
+npm run setup
+```
+
 ## 🛠️ Configuration
 
 Create a `config.json` file in the project root with the following structure:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prestart": "node -e \"process.stdout.write('\\x1Bc')\" && npm install",
     "start": "node bot.js",
-    "test": "node --no-deprecation -e \"process.stdout.write('\\x1Bc')\" && jest"
+    "test": "node --no-deprecation -e \"process.stdout.write('\\x1Bc')\" && jest",
+    "setup": "node -e \"process.stdout.write('\\x1Bc')\" && npm ci --no-audit && npm test"
   },
   "author": "Kenneth Hart",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- update README with instructions for the new setup script
- add `setup` command in `package.json` so Codex can run setup before tests

## Testing
- `npm test` *(fails: `jest` not found)*