### PR TITLE
Add tests for utilities and update config

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -9,11 +9,13 @@ const VerificationCode = {
 
 const VerifiedUser = {
   findOne: jest.fn(),
-  upsert: jest.fn()
+  upsert: jest.fn(),
+  findByPk: jest.fn()
 };
 
 const OrgTag = {
-  findByPk: jest.fn()
+  findByPk: jest.fn(),
+  findAll: jest.fn()
 };
 
 const UsageLog = {

--- a/__tests__/jobs/flushLogs.test.js
+++ b/__tests__/jobs/flushLogs.test.js
@@ -1,0 +1,37 @@
+const { flushLogs } = require('../../jobs/flushLogs');
+const logState = require('../../jobs/logState');
+
+describe('flushLogs', () => {
+  beforeEach(() => {
+    logState.pendingLogs.length = 0;
+    logState.isFlushingLogs.value = false;
+    global.origConsoleError = jest.fn();
+  });
+
+  test('sends logs when channel exists', async () => {
+    logState.pendingLogs.push('one', 'two');
+    const send = jest.fn().mockResolvedValue();
+    const client = {
+      chanBotLog: '1',
+      channels: { cache: new Map([['1', { send }]]) }
+    };
+
+    await flushLogs(client);
+    expect(send).toHaveBeenCalled();
+    expect(logState.pendingLogs.length).toBe(0);
+    expect(logState.isFlushingLogs.value).toBe(false);
+  });
+
+  test('handles send errors', async () => {
+    logState.pendingLogs.push('oops');
+    const send = jest.fn().mockRejectedValue(new Error('fail'));
+    const client = {
+      chanBotLog: '1',
+      channels: { cache: new Map([['1', { send }]]) }
+    };
+
+    await flushLogs(client);
+    expect(global.origConsoleError).toHaveBeenCalled();
+    expect(logState.isFlushingLogs.value).toBe(false);
+  });
+});

--- a/__tests__/utils/commandRegistration.test.js
+++ b/__tests__/utils/commandRegistration.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { loadCommandsRecursively } = require('../../utils/commandRegistration');
+
+describe('loadCommandsRecursively', () => {
+  let tempDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(__dirname, 'cmds'));
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test('loads valid command files', () => {
+    const content = `module.exports = { data: { name: 'ping', toJSON() { return {name: 'ping'}; } } };`;
+    fs.writeFileSync(path.join(tempDir, 'ping.js'), content);
+
+    const { commandList, commandMap } = loadCommandsRecursively(tempDir);
+    expect(commandList).toEqual([{ name: 'ping' }]);
+    expect(commandMap.get('ping')).toBeDefined();
+  });
+
+  test('skips invalid command files without throwing', () => {
+    fs.writeFileSync(path.join(tempDir, 'bad.js'), 'module.exports = {}');
+    const { commandList, commandMap } = loadCommandsRecursively(tempDir);
+    expect(commandList).toEqual([]);
+    expect(commandMap.size).toBe(0);
+  });
+});

--- a/__tests__/utils/evaluateAndFixNickname.test.js
+++ b/__tests__/utils/evaluateAndFixNickname.test.js
@@ -1,0 +1,80 @@
+const { evaluateAndFixNickname } = require('../../utils/evaluateAndFixNickname');
+const { VerifiedUser, OrgTag } = require('../../config/database');
+const { pendingVerifications } = require('../../commands/user/verify');
+const { formatVerifiedNickname } = require('../../utils/formatVerifiedNickname');
+
+jest.mock('../../config/database');
+jest.mock('../../utils/formatVerifiedNickname');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  pendingVerifications.clear();
+});
+
+describe('evaluateAndFixNickname', () => {
+  test('returns false for bot members', async () => {
+    const member = { user: { bot: true } };
+    const result = await evaluateAndFixNickname(member);
+    expect(result).toBe(false);
+    expect(VerifiedUser.findByPk).not.toHaveBeenCalled();
+  });
+
+  test('skips members pending verification when skipPending is true', async () => {
+    const member = { id: '123', user: { bot: false } };
+    pendingVerifications.add('123');
+    const result = await evaluateAndFixNickname(member, { skipPending: true });
+    expect(result).toBe(false);
+    expect(VerifiedUser.findByPk).not.toHaveBeenCalled();
+  });
+
+  test('uses provided verifiedUsersMap', async () => {
+    const member = {
+      id: '123',
+      user: { bot: false, tag: 'User#1', username: 'User' },
+      displayName: 'User',
+      nickname: 'User',
+      setNickname: jest.fn().mockResolvedValue()
+    };
+    const map = new Map([
+      ['123', { manualTagOverride: null }]
+    ]);
+    formatVerifiedNickname.mockReturnValue('User');
+    OrgTag.findAll.mockResolvedValue([]);
+
+    const result = await evaluateAndFixNickname(member, { verifiedUsersMap: map });
+    expect(result).toBe(false);
+    expect(VerifiedUser.findByPk).not.toHaveBeenCalled();
+  });
+
+  test('applies manual tag override', async () => {
+    const member = {
+      id: '123',
+      user: { bot: false, tag: 'User#1', username: 'User' },
+      displayName: 'User',
+      nickname: 'User',
+      setNickname: jest.fn().mockResolvedValue()
+    };
+
+    VerifiedUser.findByPk.mockResolvedValue({ manualTagOverride: 'PFC' });
+    OrgTag.findAll.mockResolvedValue([{ tag: 'PFC' }]);
+    formatVerifiedNickname.mockReturnValue('[PFC] User');
+
+    const updated = await evaluateAndFixNickname(member);
+    expect(updated).toBe(true);
+    expect(member.setNickname).toHaveBeenCalledWith('[PFC] User');
+  });
+
+  test('propagates database errors', async () => {
+    const member = {
+      id: '123',
+      user: { bot: false, tag: 'User#1', username: 'User' },
+      displayName: 'User',
+      nickname: 'User',
+      setNickname: jest.fn()
+    };
+
+    VerifiedUser.findByPk.mockRejectedValue(new Error('db fail'));
+
+    await expect(evaluateAndFixNickname(member)).rejects.toThrow('db fail');
+  });
+});

--- a/__tests__/utils/fetchHelpers.test.js
+++ b/__tests__/utils/fetchHelpers.test.js
@@ -1,0 +1,63 @@
+const { fetchSCData } = require('../../utils/fetchSCData');
+const { fetchUexData } = require('../../utils/fetchUexData');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch');
+
+describe('fetch helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchSCData', () => {
+    test('returns data on success', async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 1 }], links: { next: null } })
+      });
+      const result = await fetchSCData('ships');
+      expect(result).toEqual([{ id: 1 }]);
+    });
+
+    test('returns empty array on http error', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 500, statusText: 'err' });
+      const result = await fetchSCData('ships');
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array on malformed json', async () => {
+      fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+      const result = await fetchSCData('ships');
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array on network error', async () => {
+      fetch.mockRejectedValue(new Error('net'));
+      const result = await fetchSCData('ships');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchUexData', () => {
+    test('returns json on success', async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ foo: 'bar' })
+      });
+      const data = await fetchUexData('items');
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
+    test('returns empty object on http error', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 500, statusText: 'fail' });
+      const data = await fetchUexData('items');
+      expect(data).toEqual({});
+    });
+
+    test('returns empty object on network error', async () => {
+      fetch.mockRejectedValue(new Error('net'));
+      const data = await fetchUexData('items');
+      expect(data).toEqual({});
+    });
+  });
+});

--- a/__tests__/utils/verifyGuard.test.js
+++ b/__tests__/utils/verifyGuard.test.js
@@ -1,0 +1,25 @@
+const { isUserVerified } = require('../../utils/verifyGuard');
+const { VerifiedUser } = require('../../config/database');
+
+jest.mock('../../config/database');
+
+describe('isUserVerified', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns true when record exists', async () => {
+    VerifiedUser.findByPk.mockResolvedValue({ id: '1' });
+    await expect(isUserVerified('1')).resolves.toBe(true);
+  });
+
+  test('returns false when no record', async () => {
+    VerifiedUser.findByPk.mockResolvedValue(null);
+    await expect(isUserVerified('1')).resolves.toBe(false);
+  });
+
+  test('propagates database errors', async () => {
+    VerifiedUser.findByPk.mockRejectedValue(new Error('db'));
+    await expect(isUserVerified('1')).rejects.toThrow('db');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     testEnvironment: 'node',
     roots: ['<rootDir>/__tests__'],
-    moduleFileExtensions: ['js', 'json'],
+    moduleFileExtensions: ['js', 'json', 'ts'],
     moduleDirectories: ['node_modules', '<rootDir>'],
     moduleNameMapper: {
       // Force any import of 'discord.js' to use your custom mock
@@ -10,7 +10,11 @@ module.exports = {
       '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
     },
     collectCoverageFrom: [
-      'utils/**/*.js',
+      'utils/**/*.{js,ts}',
+      'commands/**/*.{js,ts}',
+      'botactions/**/*.{js,ts}',
+      'jobs/**/*.{js,ts}',
+      'models/**/*.{js,ts}',
       '!**/node_modules/**',
       '!**/__mocks__/**'
     ],

--- a/utils/commandRegistration.js
+++ b/utils/commandRegistration.js
@@ -71,4 +71,7 @@ async function registerCommands(client) {
     }
 }
 
-module.exports = registerCommands;
+module.exports = {
+    registerCommands,
+    loadCommandsRecursively,
+};


### PR DESCRIPTION
## Summary
- extend coverage directories and TypeScript support in Jest config
- expose `loadCommandsRecursively` for testing
- expand mock database helpers
- add unit tests for nickname evaluation, verify guard, command loader, fetch helpers and log flushing

## Testing
- `npm test` *(fails: jest not found)*