### PR TITLE
Add tests for trade components

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -79,6 +79,17 @@ const ActionRowBuilder = jest.fn().mockImplementation(() => ({
   addComponents: jest.fn().mockReturnThis(),
 }));
 
+const StringSelectMenuBuilder = jest.fn().mockImplementation(() => {
+  const data = { options: [], customId: undefined, placeholder: undefined };
+  const builder = {
+    setCustomId: jest.fn(id => { data.customId = id; return builder; }),
+    setPlaceholder: jest.fn(ph => { data.placeholder = ph; return builder; }),
+    addOptions: jest.fn(opts => { data.options.push(...opts); return builder; }),
+    data
+  };
+  return builder;
+});
+
 const ButtonBuilder = jest.fn().mockImplementation(() => ({
   setCustomId: jest.fn().mockReturnThis(),
   setLabel: jest.fn().mockReturnThis(),
@@ -134,6 +145,7 @@ module.exports = {
   MessageFlags,
   ActionRowBuilder,
   ButtonBuilder,
+  StringSelectMenuBuilder,
   ButtonStyle,
   SlashCommandBuilder,
   EmbedBuilder,

--- a/__tests__/utils/trade/tradeComponents.test.js
+++ b/__tests__/utils/trade/tradeComponents.test.js
@@ -1,0 +1,53 @@
+const { buildShipSelectMenu } = require('../../../utils/trade/tradeComponents');
+const { StringSelectMenuBuilder } = require('discord.js');
+
+// Silence console warnings during tests
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  console.warn.mockRestore();
+});
+
+describe('buildShipSelectMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('creates menu options for given vehicles', () => {
+    const vehicles = [
+      { id: 1, name: 'Cutlass', name_full: 'Drake Cutlass', company_name: 'Drake', scu: 46 },
+      { id: 2, name: 'Freelancer', company_name: 'MISC', scu: 66 }
+    ];
+
+    const row = buildShipSelectMenu(vehicles);
+
+    const menu = StringSelectMenuBuilder.mock.instances[0];
+    expect(row).toBeDefined();
+    expect(menu.data.options).toHaveLength(2);
+    expect(menu.data.options[0]).toMatchObject({
+      label: 'Drake Cutlass',
+      description: 'Drake (46 SCU)',
+      value: '1'
+    });
+    expect(menu.data.options[1]).toMatchObject({
+      label: 'Freelancer',
+      description: 'MISC (66 SCU)',
+      value: '2'
+    });
+  });
+
+  test('limits options to 25 entries', () => {
+    const vehicles = Array.from({ length: 30 }, (_, i) => ({ id: i, name: `Ship${i}`, scu: i }));
+    buildShipSelectMenu(vehicles);
+    const menu = StringSelectMenuBuilder.mock.instances[0];
+    expect(menu.data.options).toHaveLength(25);
+  });
+
+  test('returns null and warns when vehicle list empty', () => {
+    const result = buildShipSelectMenu([]);
+    expect(console.warn).toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- mock `StringSelectMenuBuilder` in `__mocks__/discord.js`
- test trade component builder to verify options and empty input handling

## Testing
- `npm test` *(fails: jest not found)*