### PR TITLE
Fix addaccolade command tests

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -122,6 +122,16 @@ const SlashCommandBuilder = jest.fn(() => {
       this.options.push(option);
       return this;
     },
+    addRoleOption(fn) {
+      const option = { type: 'role', name: undefined, description: undefined, required: false };
+      fn({
+        setName(name) { option.name = name; return this; },
+        setDescription(desc) { option.description = desc; return this; },
+        setRequired(req) { option.required = req; return this; },
+      });
+      this.options.push(option);
+      return this;
+    },
     setDefaultMemberPermissions() {
       return this;
     },


### PR DESCRIPTION
## Summary
- extend `SlashCommandBuilder` mock to support `addRoleOption`

## Testing
- `npm test` *(fails: jest not installed)*