### PR TITLE
Fix addaccolade permission handling

### DIFF
--- a/__tests__/commands/admin/addaccolade.test.js
+++ b/__tests__/commands/admin/addaccolade.test.js
@@ -29,7 +29,7 @@ function createInteraction({ isAdmin = true, emoji = '<:medal:12345>' } = {}) {
   };
 
   const guild = {
-    channels: { fetch: jest.fn().mockResolvedValue(channel) },
+    channels: { fetch: jest.fn().mockReturnValue(channel) },
     members: {
       fetch: jest.fn().mockResolvedValue(),
       cache: { filter: jest.fn(() => membersCollection) },

--- a/commands/admin/addaccolade.js
+++ b/commands/admin/addaccolade.js
@@ -22,6 +22,13 @@ module.exports = {
   help: 'Registers a role as an accolade and posts it to the Wall of Fame. Includes optional emoji and description. Only members with the role will be shown. This is typically used to spotlight achievements or honors.',
   category: 'Admin',
   async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+      return interaction.reply({
+        content: '❌ Only administrators can use this command.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
     const role = interaction.options.getRole('role');
     const rawEmoji = interaction.options.getString('emoji')?.trim() || '';
     const isValidEmoji = /^<a?:\w+:\d+>$|^\p{Extended_Pictographic}$/u.test(rawEmoji);


### PR DESCRIPTION
## Summary
- check administrator perms in `/addaccolade`
- update tests to mock guild channel fetching

## Testing
- `npm test __tests__/commands/admin/addaccolade.test.js --silent` *(fails: jest not found)*