### PR TITLE
Fix admin addaccolade test

### DIFF
--- a/__tests__/commands/admin/addaccolade.test.js
+++ b/__tests__/commands/admin/addaccolade.test.js
@@ -67,7 +67,7 @@ describe('/addaccolade command', () => {
 
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringContaining('permission'),
+        content: expect.stringContaining('administrators'),
         flags: MessageFlags.Ephemeral,
       }),
     );


### PR DESCRIPTION
## Summary
- adjust expectation for non-admin error in `addaccolade` test

## Testing
- `npm test --silent` *(fails: Cannot find module '../databaseConfig.json' from 'config/database.js')*