### PR TITLE
Fix failing tests and improve mocks

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -79,15 +79,22 @@ const ActionRowBuilder = jest.fn().mockImplementation(() => ({
   addComponents: jest.fn().mockReturnThis(),
 }));
 
-const StringSelectMenuBuilder = jest.fn().mockImplementation(() => {
+const StringSelectMenuBuilder = jest.fn().mockImplementation(function () {
   const data = { options: [], customId: undefined, placeholder: undefined };
-  const builder = {
-    setCustomId: jest.fn(id => { data.customId = id; return builder; }),
-    setPlaceholder: jest.fn(ph => { data.placeholder = ph; return builder; }),
-    addOptions: jest.fn(opts => { data.options.push(...opts); return builder; }),
-    data
-  };
-  return builder;
+  this.setCustomId = jest.fn(id => {
+    data.customId = id;
+    return this;
+  });
+  this.setPlaceholder = jest.fn(ph => {
+    data.placeholder = ph;
+    return this;
+  });
+  this.addOptions = jest.fn(opts => {
+    data.options.push(...opts);
+    return this;
+  });
+  this.data = data;
+  return this;
 });
 
 const ButtonBuilder = jest.fn().mockImplementation(() => ({

--- a/__tests__/jobs/scheduler.test.js
+++ b/__tests__/jobs/scheduler.test.js
@@ -17,6 +17,8 @@ describe('scheduleDailyApiSync', () => {
     const baseTime = new Date('2023-01-01T23:59:30.000Z');
     jest.useFakeTimers();
     jest.setSystemTime(baseTime);
+    jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setInterval');
 
     scheduleDailyApiSync(0, 0);
 

--- a/utils/trade/resolveBestMatchingTerminal.js
+++ b/utils/trade/resolveBestMatchingTerminal.js
@@ -7,7 +7,7 @@
  function resolveBestMatchingTerminal(input, terminals) {
     const normInput = input.trim().toLowerCase();
     let bestMatch = null;
-    let bestScore = -1;
+    let bestScore = 0;
   
     for (const terminal of terminals) {
       const candidates = [
@@ -43,7 +43,7 @@
       }
     }
   
-    return bestMatch;
+    return bestScore > 0 ? bestMatch : null;
   }
   
   module.exports = {


### PR DESCRIPTION
## Summary
- fix custom `StringSelectMenuBuilder` so mock instances expose data
- return `null` in `resolveBestMatchingTerminal` when no score
- spy on timers in scheduler tests to work with modern fake timers

## Testing
- `npx jest __tests__/utils/trade/tradeComponents.test.js __tests__/utils/trade/resolveBestMatchingTerminal.test.js __tests__/jobs/scheduler.test.js --runInBand`