### PR TITLE
Improve logical coverage of various tests

### DIFF
--- a/__tests__/botactions/maintenance/logCleanup.test.js
+++ b/__tests__/botactions/maintenance/logCleanup.test.js
@@ -44,4 +44,15 @@ describe('deleteOldLogs', () => {
     expect(remaining).toContain('new.log');
     expect(remaining).not.toContain('old.log');
   });
+
+  it('logs an error if readdir fails', async () => {
+    const spy = jest.spyOn(fs, 'readdir').mockImplementation((_, cb) => cb(new Error('fail')));
+
+    deleteOldLogs(tempDir, 7);
+
+    await new Promise(r => setTimeout(r, 50));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('❌ Failed to read log directory:', expect.any(Error));
+
+    spy.mockRestore();
+  });
 });

--- a/__tests__/utils/trade/tradeQueries.test.js
+++ b/__tests__/utils/trade/tradeQueries.test.js
@@ -37,6 +37,12 @@ describe('tradeQueries', () => {
     expect(res).toBe(mockResults);
   });
 
+  test('getCommodityTradeOptions returns empty array on error', async () => {
+    UexCommodityPrice.findAll.mockRejectedValue(new Error('db'));
+    const res = await getCommodityTradeOptions('Foo');
+    expect(res).toEqual([]);
+  });
+
   test('getSellOptionsAtLocation returns DB results', async () => {
     const mockResults = [{ commodity_name: 'Laranite', terminal: {} }];
     UexCommodityPrice.findAll.mockResolvedValue(mockResults);
@@ -59,6 +65,12 @@ describe('tradeQueries', () => {
     const res = await getVehicleByName('Cutlass');
     expect(UexVehicle.findAll).toHaveBeenCalled();
     expect(res).toBe(mockVehicles);
+  });
+
+  test('getVehicleByName returns empty array on error', async () => {
+    UexVehicle.findAll.mockRejectedValue(new Error('fail'));
+    const res = await getVehicleByName('Bad');
+    expect(res).toEqual([]);
   });
 
   test('getAllShipNames maps vehicle names', async () => {


### PR DESCRIPTION
## Notes
- Added detailed assertions and edge cases for log flushing
- Verified error handling in log cleanup routine
- Exercised trade query helpers on rejection paths

## Testing
- `npm test`