### PR TITLE
Add tests for uncovered modules

### DIFF
--- a/__tests__/botactions/scheduling/scheduleHandler.test.js
+++ b/__tests__/botactions/scheduling/scheduleHandler.test.js
@@ -1,0 +1,62 @@
+jest.mock('../../../config/database', () => ({
+  ScheduledAnnouncement: {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    destroy: jest.fn()
+  }
+}));
+
+jest.mock('../../../botactions/utilityFunctions', () => ({
+  getChannelNameById: jest.fn(),
+  getGuildNameById: jest.fn()
+}));
+
+const db = require('../../../config/database');
+const utils = require('../../../botactions/utilityFunctions');
+const {
+  saveAnnouncementToDatabase,
+  getScheduledAnnouncements,
+  deleteScheduledAnnouncement
+} = require('../../../botactions/scheduling/scheduleHandler');
+
+describe('scheduleHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('saveAnnouncementToDatabase stores and logs', async () => {
+    utils.getChannelNameById.mockResolvedValue('chan');
+    utils.getGuildNameById.mockResolvedValue('guild');
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await saveAnnouncementToDatabase('c1', 'g1', { title: 't' }, 'time', {});
+
+    expect(db.ScheduledAnnouncement.create).toHaveBeenCalledWith({
+      channelId: 'c1',
+      guildId: 'g1',
+      embedData: JSON.stringify({ title: 't' }),
+      time: 'time'
+    });
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  test('getScheduledAnnouncements returns records', async () => {
+    db.ScheduledAnnouncement.findAll.mockResolvedValue(['a']);
+    const res = await getScheduledAnnouncements();
+    expect(res).toEqual(['a']);
+  });
+
+  test('getScheduledAnnouncements returns empty array on error', async () => {
+    db.ScheduledAnnouncement.findAll.mockRejectedValue(new Error('fail'));
+    const res = await getScheduledAnnouncements();
+    expect(res).toEqual([]);
+  });
+
+  test('deleteScheduledAnnouncement deletes record', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await deleteScheduledAnnouncement(5);
+    expect(db.ScheduledAnnouncement.destroy).toHaveBeenCalledWith({ where: { id: 5 } });
+    log.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/listannouncements.test.js
+++ b/__tests__/commands/admin/listannouncements.test.js
@@ -1,0 +1,49 @@
+jest.mock('../../../botactions/scheduling/scheduleHandler', () => ({
+  getScheduledAnnouncements: jest.fn()
+}));
+
+const { getScheduledAnnouncements } = require('../../../botactions/scheduling/scheduleHandler');
+const { MessageFlags } = require('discord.js');
+const { execute } = require('../../../commands/admin/listannouncements');
+
+function createInteraction(roleNames = ['Admiral']) {
+  return {
+    member: {
+      roles: {
+        cache: { map: fn => roleNames.map(name => fn({ name })) }
+      }
+    },
+    reply: jest.fn()
+  };
+}
+
+describe('/listannouncements command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('blocks users without required role', async () => {
+    const interaction = createInteraction(['Member']);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'You do not have permission to use this command.',
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('informs when no announcements', async () => {
+    const interaction = createInteraction();
+    getScheduledAnnouncements.mockResolvedValue([]);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith('There are no scheduled announcements.');
+  });
+
+  test('lists announcements when present', async () => {
+    const interaction = createInteraction();
+    getScheduledAnnouncements.mockResolvedValue([
+      { id: 1, embedData: JSON.stringify({ title: 'Hello' }), time: 't' }
+    ]);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.stringContaining('ID: 1'));
+  });
+});

--- a/__tests__/components/embedBuilders/uexAvailabilityEmbed.test.js
+++ b/__tests__/components/embedBuilders/uexAvailabilityEmbed.test.js
@@ -1,0 +1,21 @@
+const { EmbedBuilder } = require('../../../__mocks__/discord.js');
+const { buildUexAvailabilityEmbed } = require('../../../components/embedBuilders/uexAvailabilityEmbed');
+
+describe('buildUexAvailabilityEmbed', () => {
+  test('returns "no results" embed when records empty', () => {
+    const embed = buildUexAvailabilityEmbed('item', []);
+    const data = embed.toJSON();
+    expect(data.title).toContain('No results');
+  });
+
+  test('builds embed with fields for each record', () => {
+    const records = [
+      { description: 'Item A', terminal: { name: 'T1', type: 'Commodity' }, price: 1.23, quantity: 10 }
+    ];
+    const embed = buildUexAvailabilityEmbed('item', records);
+    const data = embed.toJSON();
+    expect(data.title).toContain('Locations for: Item A');
+    expect(data.fields.length).toBe(1);
+    expect(data.fields[0].name).toContain('T1');
+  });
+});

--- a/__tests__/jobs/index.test.js
+++ b/__tests__/jobs/index.test.js
@@ -1,0 +1,39 @@
+jest.mock('../../jobs/scheduler', () => ({ scheduleDailyApiSync: jest.fn() }));
+jest.mock('../../jobs/flushLogs', () => ({ flushLogs: jest.fn() }));
+jest.mock('../../botactions/scheduling', () => ({ checkEvents: jest.fn() }));
+jest.mock('../../botactions/maintenance/logCleanup', () => ({ deleteOldLogs: jest.fn() }));
+const { scheduleDailyApiSync } = require('../../jobs/scheduler');
+const { flushLogs } = require('../../jobs/flushLogs');
+const { checkEvents } = require('../../botactions/scheduling');
+const { deleteOldLogs } = require('../../botactions/maintenance/logCleanup');
+const { startAllScheduledJobs } = require('../../jobs');
+
+describe('startAllScheduledJobs', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setInterval');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  test('schedules jobs and intervals', () => {
+    const intervals = [];
+    setInterval.mockImplementation((fn, delay) => {
+      intervals.push({ fn, delay });
+    });
+
+    const client = { id: 'c' };
+    startAllScheduledJobs(client);
+
+    expect(scheduleDailyApiSync).toHaveBeenCalledWith(4, 0);
+    expect(intervals.map(i => i.delay)).toEqual([2000, 60000, 86400000]);
+
+    intervals.forEach(i => i.fn());
+    expect(flushLogs).toHaveBeenCalledWith(client);
+    expect(checkEvents).toHaveBeenCalledWith(client);
+    expect(deleteOldLogs).toHaveBeenCalledWith(client);
+  });
+});

--- a/__tests__/jobs/logState.test.js
+++ b/__tests__/jobs/logState.test.js
@@ -1,0 +1,8 @@
+const logState = require('../../jobs/logState');
+
+describe('logState module', () => {
+  test('exports default properties', () => {
+    expect(Array.isArray(logState.pendingLogs)).toBe(true);
+    expect(logState.isFlushingLogs).toEqual({ value: false });
+  });
+});

--- a/__tests__/models/config.test.js
+++ b/__tests__/models/config.test.js
@@ -1,0 +1,18 @@
+const defineConfig = require('../../models/config');
+
+describe('Config model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineConfig(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('Config');
+    expect(attrs).toHaveProperty('key');
+    expect(attrs).toHaveProperty('value');
+    expect(attrs).toHaveProperty('botType');
+    expect(opts.tableName).toBe('Configs');
+    expect(opts.uniqueKeys.unique_key.fields).toEqual(['key', 'botType']);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/utils/getGuildMembersWithRoles.test.js
+++ b/__tests__/utils/getGuildMembersWithRoles.test.js
@@ -1,0 +1,29 @@
+const getGuildMembersWithRoles = require('../../utils/getGuildMembersWithRoles');
+
+describe('getGuildMembersWithRoles', () => {
+  const makeCollection = arr => ({
+    filter: fn => makeCollection(arr.filter(fn)),
+    map: fn => arr.map(fn)
+  });
+
+  test('returns members whose roles match provided names', async () => {
+    const roles = [{ id: '1', name: 'Admin' }, { id: '2', name: 'Pilot' }];
+    const membersArr = [
+      { id: 'm1', roles: { cache: [{ id: '1' }] } },
+      { id: 'm2', roles: { cache: [{ id: '2' }] } },
+      { id: 'm3', roles: { cache: [] } }
+    ];
+    const guild = {
+      roles: { cache: makeCollection(roles) },
+      members: {
+        fetch: jest.fn().mockResolvedValue(),
+        cache: makeCollection(membersArr)
+      }
+    };
+
+    const res = await getGuildMembersWithRoles(guild, ['Admin', 'Pilot']);
+
+    expect(guild.members.fetch).toHaveBeenCalled();
+    expect(res).toEqual([membersArr[0], membersArr[1]]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for scheduleHandler DB helpers
- cover listannouncements command
- test UEX embed builder component
- add missing job and util tests
- verify Config model definition

## Testing
- `npm test`