### PR TITLE
test: improve utils coverage

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -22,7 +22,12 @@ const OrgTag = {
 };
 
 const UsageLog = {
-  create: jest.fn()
+  create: jest.fn(),
+  findAll: jest.fn()
+};
+
+const VoiceLog = {
+  findAll: jest.fn()
 };
 
 // Simple mock Sequelize-like instance
@@ -31,7 +36,10 @@ const sequelize = {
     MockModelA: { sync: jest.fn() },
     MockModelB: { sync: jest.fn() },
     MockModelC: { sync: jest.fn() },
-  }
+  },
+  fn: jest.fn((name, col) => `${name}(${col})`),
+  col: jest.fn(name => name),
+  literal: jest.fn(value => value)
 };
 
 /**
@@ -61,6 +69,7 @@ module.exports = {
   VerifiedUser,
   OrgTag,
   UsageLog,
+  VoiceLog,
   sequelize,
   initializeDatabase
 };

--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -58,6 +58,10 @@ const EmbedBuilder = jest.fn().mockImplementation(() => {
       data.fields.push(...flatFields);
       return embed;
     }),
+    setThumbnail: jest.fn().mockImplementation(url => {
+      data.thumbnail = { url };
+      return embed;
+    }),
     setFooter: jest.fn().mockImplementation(footer => { data.footer = footer; return embed; }),
     setTimestamp: jest.fn().mockImplementation(() => { data.timestamp = Date.now(); return embed; }),
     toJSON: jest.fn(() => data),

--- a/__tests__/utils/accoladeEmbedBuilder.test.js
+++ b/__tests__/utils/accoladeEmbedBuilder.test.js
@@ -1,0 +1,33 @@
+const { buildAccoladeEmbed } = require('../../utils/accoladeEmbedBuilder');
+const { EmbedBuilder } = require('discord.js');
+
+describe('buildAccoladeEmbed', () => {
+  test('handles no recipients', () => {
+    const embed = buildAccoladeEmbed({ name: 'Test', description: 'Desc' }, []);
+    const data = embed.toJSON();
+    expect(data.title).toBe('  **Test**');
+    expect(data.fields[0]).toEqual(
+      expect.objectContaining({ name: 'Recipients', value: '_No current recipients_' })
+    );
+  });
+
+  test('formats recipients and details', () => {
+    const recipients = [
+      { displayName: '[TAG] Alice Bob' },
+      { displayName: 'Bob' },
+      { displayName: 'Charlie' }
+    ];
+
+    const embed = buildAccoladeEmbed({ name: 'Medal', description: 'Great', emoji: ':star:', color: 0xabcdef, thumbnail_url: 'https://img', footer_icon_url: 'https://footer' }, recipients);
+    const data = embed.toJSON();
+
+    expect(data.title).toBe(':star:  **Medal**');
+    expect(data.description).toBe('*Great*');
+    expect(data.color).toBe(0xabcdef);
+    expect(data.thumbnail.url).toBe('https://img');
+    expect(data.footer.iconURL).toBe('https://footer');
+    expect(data.fields.length).toBe(3);
+    expect(data.fields[0].value).toContain('Alice');
+    expect(data.fields[0].value).toContain('\u00A0');
+  });
+});

--- a/__tests__/utils/generateAnalytics.test.js
+++ b/__tests__/utils/generateAnalytics.test.js
@@ -1,0 +1,19 @@
+jest.mock('../../utils/usageReport', () => ({ generateUsageReport: jest.fn(() => 'u') }));
+jest.mock('../../utils/voiceActivityReport', () => ({ generateVoiceActivityReport: jest.fn(() => 'v') }));
+jest.mock('../../utils/reportByChannel', () => ({ generateReportByChannel: jest.fn(() => 'c') }));
+
+const analytics = require('../../utils/generateAnalytics');
+const { generateUsageReport } = require('../../utils/usageReport');
+const { generateVoiceActivityReport } = require('../../utils/voiceActivityReport');
+const { generateReportByChannel } = require('../../utils/reportByChannel');
+
+describe('generateAnalytics module', () => {
+  test('re-exports reporting helpers', () => {
+    expect(analytics.generateUsageReport()).toBe('u');
+    expect(analytics.generateVoiceActivityReport()).toBe('v');
+    expect(analytics.generateReportByChannel()).toBe('c');
+    expect(generateUsageReport).toHaveBeenCalled();
+    expect(generateVoiceActivityReport).toHaveBeenCalled();
+    expect(generateReportByChannel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/utils/pendingSelections.test.js
+++ b/__tests__/utils/pendingSelections.test.js
@@ -1,0 +1,11 @@
+const first = require('../../utils/pendingSelections');
+const second = require('../../utils/pendingSelections');
+
+describe('pendingChannelSelection', () => {
+  test('exports singleton object', () => {
+    expect(first.pendingChannelSelection).toBe(second.pendingChannelSelection);
+    expect(first.pendingChannelSelection).toEqual({});
+    first.pendingChannelSelection.foo = 'bar';
+    expect(second.pendingChannelSelection.foo).toBe('bar');
+  });
+});

--- a/__tests__/utils/reportByChannel.test.js
+++ b/__tests__/utils/reportByChannel.test.js
@@ -1,0 +1,26 @@
+jest.mock('../../config/database', () => require('../../__mocks__/config/database'));
+
+const { generateReportByChannel } = require('../../utils/reportByChannel');
+const { UsageLog } = require('../../config/database');
+
+describe('generateReportByChannel', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns event counts', async () => {
+    UsageLog.findAll.mockResolvedValue([
+      { get: () => ({ event_type: 'a', event_count: 2 }) },
+    ]);
+
+    const res = await generateReportByChannel('guild', 'chan');
+    expect(UsageLog.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ server_id: 'guild', channel_id: 'chan' }),
+      group: ['event_type'],
+    }));
+    expect(res).toEqual([{ event_type: 'a', event_count: 2 }]);
+  });
+
+  test('propagates errors', async () => {
+    UsageLog.findAll.mockRejectedValue(new Error('oops'));
+    await expect(generateReportByChannel('g', 'c')).rejects.toThrow('oops');
+  });
+});

--- a/__tests__/utils/rsiScrapeOrgMembers.test.js
+++ b/__tests__/utils/rsiScrapeOrgMembers.test.js
@@ -1,0 +1,35 @@
+const fetch = require('node-fetch');
+const { Response } = jest.requireActual('node-fetch');
+jest.mock('node-fetch');
+
+const rsiScrapeOrgMembers = require('../../utils/rsiScrapeOrgMembers');
+
+describe('rsiScrapeOrgMembers', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('collects members across pages', async () => {
+    const page1 = `
+      <div class="member-item"><div class="name-wrap"><span class="nick">User1</span></div><span class="rank">Recruit</span></div>
+      <div class="member-item"><div class="name-wrap"><span class="nick">User2</span></div><span class="rank">Scout</span></div>
+    `;
+    fetch
+      .mockResolvedValueOnce(new Response(page1, { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 200 }));
+
+    const result = await rsiScrapeOrgMembers('PFC');
+    expect(result).toEqual({
+      members: [
+        { handle: 'User1', rank: 'Recruit' },
+        { handle: 'User2', rank: 'Scout' }
+      ],
+      redactedCount: 0
+    });
+  });
+
+  test('throws on http error', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'err' });
+    await expect(rsiScrapeOrgMembers('PFC')).rejects.toThrow('Failed to fetch page 1');
+  });
+});

--- a/__tests__/utils/usageReport.test.js
+++ b/__tests__/utils/usageReport.test.js
@@ -1,0 +1,32 @@
+jest.mock('../../config/database', () => require('../../__mocks__/config/database'));
+
+const { generateUsageReport } = require('../../utils/usageReport');
+const { UsageLog } = require('../../config/database');
+
+describe('generateUsageReport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns channel counts', async () => {
+    UsageLog.findAll.mockResolvedValue([
+      { get: () => ({ channel_id: '1', event_count: 5 }) },
+      { get: () => ({ channel_id: '2', event_count: 3 }) },
+    ]);
+
+    const res = await generateUsageReport('guild');
+    expect(UsageLog.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ server_id: 'guild' }),
+      group: ['channel_id'],
+    }));
+    expect(res).toEqual([
+      { channel_id: '1', event_count: 5 },
+      { channel_id: '2', event_count: 3 },
+    ]);
+  });
+
+  test('propagates errors', async () => {
+    UsageLog.findAll.mockRejectedValue(new Error('fail'));
+    await expect(generateUsageReport('guild')).rejects.toThrow('fail');
+  });
+});

--- a/__tests__/utils/voiceActivityReport.test.js
+++ b/__tests__/utils/voiceActivityReport.test.js
@@ -1,0 +1,44 @@
+jest.mock('../../config/database', () => require('../../__mocks__/config/database'));
+
+const { generateVoiceActivityReport } = require('../../utils/voiceActivityReport');
+const { VoiceLog } = require('../../config/database');
+
+describe('generateVoiceActivityReport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2021-01-01T01:30:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('computes stats for voice events', async () => {
+    VoiceLog.findAll
+      .mockResolvedValueOnce([
+        { get: () => ({ channel_id: 'c', user_id: 'u', timestamp: new Date('2021-01-01T00:00:00Z') }) },
+        { get: () => ({ channel_id: 'c', user_id: 'u', timestamp: new Date('2021-01-01T01:00:00Z') }) },
+      ])
+      .mockResolvedValueOnce([
+        { get: () => ({ channel_id: 'c', user_id: 'u', timestamp: new Date('2021-01-01T00:10:00Z') }) },
+      ]);
+
+    const res = await generateVoiceActivityReport('guild');
+
+    expect(VoiceLog.findAll).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      where: expect.objectContaining({ server_id: 'guild', event_type: 'voice_join' })
+    }));
+    expect(VoiceLog.findAll).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      where: expect.objectContaining({ server_id: 'guild', event_type: 'voice_leave' })
+    }));
+    expect(res).toEqual([
+      {
+        channel_id: 'c',
+        peak_users: 1,
+        average_users: 1,
+        total_duration: '00:40:00'
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add new mocks for `VoiceLog` and extend sequelize helpers
- support thumbnails in the Discord.js EmbedBuilder mock
- test accolade embed builder
- test analytics aggregator exports
- cover pending selections singleton
- add voice and usage reporting tests
- test RSI org member scraping

## Testing
- `npm test`