### PR TITLE
test: cover utilities

### DIFF
--- a/UTILS_TEST_COVERAGE.md
+++ b/UTILS_TEST_COVERAGE.md
@@ -1,0 +1,26 @@
+# Utils Test Coverage
+
+The following utilities previously lacked tests. Dedicated Jest suites now cover each module listed below:
+
+- utils/apiSync/galactapedia.js
+- utils/apiSync/galactapediaDetail.js
+- utils/apiSync/manufacturers.js
+- utils/apiSync/syncApiData.js
+- utils/apiSync/syncUexCategories.js
+- utils/apiSync/syncUexCommodityPrices.js
+- utils/apiSync/syncUexFuelPrices.js
+- utils/apiSync/syncUexItemPrices.js
+- utils/apiSync/syncUexPoi.js
+- utils/apiSync/syncUexTerminals.js
+- utils/apiSync/syncUexVehiclePurchasePrices.js
+- utils/apiSync/syncUexVehicleRentalPrices.js
+- utils/apiSync/syncUexVehicles.js
+- utils/apiSync/vehicles.js
+- utils/trade/tradeHandlers.js
+- utils/trade/handlers/bestCircuit.js
+- utils/trade/handlers/commodities.js
+- utils/trade/handlers/find.js
+- utils/trade/handlers/locations.js
+- utils/trade/handlers/price.js
+- utils/trade/handlers/route.js
+- utils/trade/handlers/ship.js

--- a/__tests__/utils/apiSync/galactapedia.test.js
+++ b/__tests__/utils/apiSync/galactapedia.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchSCData', () => ({ fetchSCData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ GalactapediaEntry: { upsert: jest.fn() } }));
+
+const { fetchSCData } = require('../../../utils/fetchSCData');
+const { GalactapediaEntry } = require('../../../config/database');
+const { syncGalactapedia } = require('../../../utils/apiSync/galactapedia');
+
+describe('syncGalactapedia', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts entries', async () => {
+    fetchSCData.mockResolvedValue([{ id: 1, title: 'A', slug: 'a' }]);
+    GalactapediaEntry.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncGalactapedia();
+    expect(fetchSCData).toHaveBeenCalledWith('galactapedia');
+    expect(GalactapediaEntry.upsert).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchSCData.mockResolvedValue(null);
+    await expect(syncGalactapedia()).rejects.toThrow('Expected an array of Galactapedia entries');
+  });
+});

--- a/__tests__/utils/apiSync/galactapediaDetail.test.js
+++ b/__tests__/utils/apiSync/galactapediaDetail.test.js
@@ -1,0 +1,30 @@
+jest.mock('../../../utils/fetchSCData', () => ({ fetchSCDataByUrl: jest.fn() }));
+jest.mock('../../../config/database', () => ({
+  GalactapediaDetail: { upsert: jest.fn() },
+  GalactapediaTag: { destroy: jest.fn(), bulkCreate: jest.fn() },
+  GalactapediaProperty: { destroy: jest.fn(), bulkCreate: jest.fn() },
+  GalactapediaRelatedArticle: { destroy: jest.fn(), bulkCreate: jest.fn() },
+}));
+
+const { fetchSCDataByUrl } = require('../../../utils/fetchSCData');
+const db = require('../../../config/database');
+const { syncGalactapediaDetail } = require('../../../utils/apiSync/galactapediaDetail');
+
+describe('syncGalactapediaDetail', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('saves details and related data', async () => {
+    fetchSCDataByUrl.mockResolvedValue({ data: { id: 1, translations: { en_EN: 'text' }, tags: [], properties: [], related_articles: [] } });
+
+    const res = await syncGalactapediaDetail({ api_url: 'url', id: 1 });
+    expect(fetchSCDataByUrl).toHaveBeenCalledWith('url');
+    expect(db.GalactapediaDetail.upsert).toHaveBeenCalled();
+    expect(res).toBe(true);
+  });
+
+  test('returns false when no detail content', async () => {
+    fetchSCDataByUrl.mockResolvedValue({ data: null });
+    const res = await syncGalactapediaDetail({ api_url: 'url', id: 2 });
+    expect(res).toBe(false);
+  });
+});

--- a/__tests__/utils/apiSync/manufacturers.test.js
+++ b/__tests__/utils/apiSync/manufacturers.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchSCData', () => ({ fetchSCData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ Manufacturer: { upsert: jest.fn() } }));
+
+const { fetchSCData } = require('../../../utils/fetchSCData');
+const { Manufacturer } = require('../../../config/database');
+const { syncManufacturers } = require('../../../utils/apiSync/manufacturers');
+
+describe('syncManufacturers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts manufacturers', async () => {
+    fetchSCData.mockResolvedValue([{ code: 'MISC', name: 'misc', link: 'x' }]);
+    Manufacturer.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncManufacturers();
+    expect(fetchSCData).toHaveBeenCalledWith('manufacturers');
+    expect(Manufacturer.upsert).toHaveBeenCalledWith(expect.objectContaining({ code: 'MISC' }));
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchSCData.mockResolvedValue(null);
+    await expect(syncManufacturers()).rejects.toThrow('Expected an array of manufacturers');
+  });
+});

--- a/__tests__/utils/apiSync/syncApiData.test.js
+++ b/__tests__/utils/apiSync/syncApiData.test.js
@@ -1,0 +1,35 @@
+const syncEndpoints = require('../../../botactions/api/syncEndpoints');
+const { runFullApiSync } = require('../../../utils/apiSync/syncApiData');
+
+jest.mock('../../../botactions/api/syncEndpoints', () => ({
+  syncManufacturers: jest.fn().mockResolvedValue({}),
+  syncUexTerminals: jest.fn().mockResolvedValue({}),
+  syncVehicles: jest.fn().mockResolvedValue({}),
+  syncGalactapedia: jest.fn().mockResolvedValue({}),
+  syncUexVehicles: jest.fn().mockResolvedValue({}),
+  syncUexItemPrices: jest.fn().mockResolvedValue({}),
+  syncUexCategories: jest.fn().mockResolvedValue({}),
+  syncUexCommodityPrices: jest.fn().mockResolvedValue({}),
+  syncUexFuelPrices: jest.fn().mockResolvedValue({}),
+  syncUexVehiclePurchasePrices: jest.fn().mockResolvedValue({}),
+  syncUexVehicleRentalPrices: jest.fn().mockResolvedValue({}),
+  syncUexPois: jest.fn().mockResolvedValue({}),
+}));
+
+describe('runFullApiSync', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('calls all sync endpoints', async () => {
+    const results = await runFullApiSync();
+    for (const fn of Object.values(syncEndpoints)) {
+      expect(fn).toHaveBeenCalled();
+    }
+    expect(results).toHaveProperty('Shops');
+  });
+
+  test('handles errors from an endpoint', async () => {
+    syncEndpoints.syncVehicles.mockRejectedValueOnce(new Error('fail'));
+    const results = await runFullApiSync();
+    expect(results['Vehicles (wiki)']).toEqual({ error: true });
+  });
+});

--- a/__tests__/utils/apiSync/syncUexCategories.test.js
+++ b/__tests__/utils/apiSync/syncUexCategories.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexCategory: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexCategory } = require('../../../config/database');
+const { syncUexCategories } = require('../../../utils/apiSync/syncUexCategories');
+
+describe('syncUexCategories', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts categories', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, name: 'C' }] });
+    UexCategory.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexCategories();
+    expect(fetchUexData).toHaveBeenCalledWith('categories');
+    expect(UexCategory.upsert).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexCategories()).rejects.toThrow('Expected an array of categories');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexCommodityPrices.test.js
+++ b/__tests__/utils/apiSync/syncUexCommodityPrices.test.js
@@ -1,0 +1,28 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({
+  UexCommodityPrice: { upsert: jest.fn() },
+  UexTerminal: { findByPk: jest.fn().mockResolvedValue(true) }
+}));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const db = require('../../../config/database');
+const { syncUexCommodityPrices } = require('../../../utils/apiSync/syncUexCommodityPrices');
+
+describe('syncUexCommodityPrices', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts commodity prices', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, commodity_name: 'X', id_terminal: 2 }] });
+    db.UexCommodityPrice.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexCommodityPrices();
+    expect(fetchUexData).toHaveBeenCalledWith('commodities_prices_all');
+    expect(db.UexCommodityPrice.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexCommodityPrices()).rejects.toThrow('Expected an array of commodity price entries');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexFuelPrices.test.js
+++ b/__tests__/utils/apiSync/syncUexFuelPrices.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexFuelPrice: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexFuelPrice } = require('../../../config/database');
+const { syncUexFuelPrices } = require('../../../utils/apiSync/syncUexFuelPrices');
+
+describe('syncUexFuelPrices', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts fuel prices', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, commodity_name: 'Fuel' }] });
+    UexFuelPrice.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexFuelPrices();
+    expect(fetchUexData).toHaveBeenCalledWith('fuel_prices_all');
+    expect(UexFuelPrice.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexFuelPrices()).rejects.toThrow('Expected an array of fuel price entries');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexItemPrices.test.js
+++ b/__tests__/utils/apiSync/syncUexItemPrices.test.js
@@ -1,0 +1,28 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({
+  UexItemPrice: { upsert: jest.fn() },
+  UexTerminal: { findByPk: jest.fn().mockResolvedValue(true) }
+}));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const db = require('../../../config/database');
+const { syncUexItemPrices } = require('../../../utils/apiSync/syncUexItemPrices');
+
+describe('syncUexItemPrices', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts item prices', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, item_name: 'Foo', id_terminal: 3 }] });
+    db.UexItemPrice.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexItemPrices();
+    expect(fetchUexData).toHaveBeenCalledWith('items_prices_all');
+    expect(db.UexItemPrice.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexItemPrices()).rejects.toThrow('Expected an array of item prices');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexPoi.test.js
+++ b/__tests__/utils/apiSync/syncUexPoi.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexPoi: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexPoi } = require('../../../config/database');
+const { syncUexPois } = require('../../../utils/apiSync/syncUexPoi');
+
+describe('syncUexPois', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts pois', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, name: 'poi' }] });
+    UexPoi.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexPois();
+    expect(fetchUexData).toHaveBeenCalledWith('poi');
+    expect(UexPoi.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexPois()).rejects.toThrow('Expected an array of POIs');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexTerminals.test.js
+++ b/__tests__/utils/apiSync/syncUexTerminals.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexTerminal: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexTerminal } = require('../../../config/database');
+const { syncUexTerminals } = require('../../../utils/apiSync/syncUexTerminals');
+
+describe('syncUexTerminals', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts terminals', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, name: 'T' }] });
+    UexTerminal.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexTerminals();
+    expect(fetchUexData).toHaveBeenCalledWith('terminals');
+    expect(UexTerminal.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexTerminals()).rejects.toThrow('Expected an array of terminals');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexVehiclePurchasePrices.test.js
+++ b/__tests__/utils/apiSync/syncUexVehiclePurchasePrices.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexVehiclePurchasePrice: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexVehiclePurchasePrice } = require('../../../config/database');
+const { syncUexVehiclePurchasePrices } = require('../../../utils/apiSync/syncUexVehiclePurchasePrices');
+
+describe('syncUexVehiclePurchasePrices', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts vehicle purchase prices', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, vehicle_name: 'ship', id_vehicle: 1, id_terminal: 1 }] });
+    UexVehiclePurchasePrice.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexVehiclePurchasePrices();
+    expect(fetchUexData).toHaveBeenCalledWith('vehicles_purchases_prices_all');
+    expect(UexVehiclePurchasePrice.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexVehiclePurchasePrices()).rejects.toThrow('Expected an array of vehicle purchase price entries');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexVehicleRentalPrices.test.js
+++ b/__tests__/utils/apiSync/syncUexVehicleRentalPrices.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexVehicleRentalPrice: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexVehicleRentalPrice } = require('../../../config/database');
+const { syncUexVehicleRentalPrices } = require('../../../utils/apiSync/syncUexVehicleRentalPrices');
+
+describe('syncUexVehicleRentalPrices', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts vehicle rental prices', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, vehicle_name: 'ship', id_vehicle: 1, id_terminal: 1 }] });
+    UexVehicleRentalPrice.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexVehicleRentalPrices();
+    expect(fetchUexData).toHaveBeenCalledWith('vehicles_rentals_prices_all');
+    expect(UexVehicleRentalPrice.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexVehicleRentalPrices()).rejects.toThrow('Expected an array of vehicle rental price entries');
+  });
+});

--- a/__tests__/utils/apiSync/syncUexVehicles.test.js
+++ b/__tests__/utils/apiSync/syncUexVehicles.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchUexData', () => ({ fetchUexData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ UexVehicle: { upsert: jest.fn() } }));
+
+const { fetchUexData } = require('../../../utils/fetchUexData');
+const { UexVehicle } = require('../../../config/database');
+const { syncUexVehicles } = require('../../../utils/apiSync/syncUexVehicles');
+
+describe('syncUexVehicles', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts vehicles', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 1, name: 'ship' }] });
+    UexVehicle.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncUexVehicles();
+    expect(fetchUexData).toHaveBeenCalledWith('vehicles');
+    expect(UexVehicle.upsert).toHaveBeenCalled();
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchUexData.mockResolvedValue({});
+    await expect(syncUexVehicles()).rejects.toThrow('Expected an array of vehicles');
+  });
+});

--- a/__tests__/utils/apiSync/vehicles.test.js
+++ b/__tests__/utils/apiSync/vehicles.test.js
@@ -1,0 +1,25 @@
+jest.mock('../../../utils/fetchSCData', () => ({ fetchSCData: jest.fn() }));
+jest.mock('../../../config/database', () => ({ Vehicle: { upsert: jest.fn() } }));
+
+const { fetchSCData } = require('../../../utils/fetchSCData');
+const { Vehicle } = require('../../../config/database');
+const { syncVehicles } = require('../../../utils/apiSync/vehicles');
+
+describe('syncVehicles', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('upserts vehicles', async () => {
+    fetchSCData.mockResolvedValue([{ uuid: 'u1', name: 'ship' }]);
+    Vehicle.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncVehicles();
+    expect(fetchSCData).toHaveBeenCalledWith('vehicles');
+    expect(Vehicle.upsert).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'u1' }));
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('throws on invalid data', async () => {
+    fetchSCData.mockResolvedValue(null);
+    await expect(syncVehicles()).rejects.toThrow('Expected an array of vehicles');
+  });
+});

--- a/__tests__/utils/trade/handlers/bestCircuit.test.js
+++ b/__tests__/utils/trade/handlers/bestCircuit.test.js
@@ -1,0 +1,8 @@
+jest.mock('../../../../utils/trade/tradeQueries', () => ({}));
+const { handleTradeBestCircuit } = require('../../../../utils/trade/handlers/bestCircuit');
+
+describe('handleTradeBestCircuit', () => {
+  test('exports function', () => {
+    expect(typeof handleTradeBestCircuit).toBe('function');
+  });
+});

--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -1,0 +1,41 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getAllShipNames: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildCommoditiesEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+}));
+
+const { handleTradeCommodities } = require('../../../../utils/trade/handlers/commodities');
+const { getAllShipNames } = require('../../../../utils/trade/tradeQueries');
+const { buildCommoditiesEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradeCommodities', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sends commodities embed', async () => {
+    const interaction = new MockInteraction({});
+    getAllShipNames.mockResolvedValue(['A', 'B']);
+    buildCommoditiesEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradeCommodities(interaction);
+
+    expect(buildCommoditiesEmbed).toHaveBeenCalledWith(['A', 'B']);
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('warns when no commodities', async () => {
+    const interaction = new MockInteraction({});
+    getAllShipNames.mockResolvedValue([]);
+
+    await handleTradeCommodities(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No known commodities'));
+  });
+});

--- a/__tests__/utils/trade/handlers/find.test.js
+++ b/__tests__/utils/trade/handlers/find.test.js
@@ -1,0 +1,48 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getSellOptionsAtLocation: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeCalculations', () => ({
+  calculateProfitOptions: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildBestTradesEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+}));
+
+const { handleTradeFind } = require('../../../../utils/trade/handlers/find');
+const { getSellOptionsAtLocation } = require('../../../../utils/trade/tradeQueries');
+const { calculateProfitOptions } = require('../../../../utils/trade/tradeCalculations');
+const { buildBestTradesEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradeFind', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns trades embed when results found', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getSellOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'B' }, price_buy: 10, scu_buy: 1 }]);
+    calculateProfitOptions.mockReturnValue([{ totalProfit: 10 }]);
+    buildBestTradesEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradeFind(interaction);
+
+    expect(buildBestTradesEmbed).toHaveBeenCalled();
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('warns when no trades found', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getSellOptionsAtLocation.mockResolvedValue([]);
+    calculateProfitOptions.mockReturnValue([]);
+
+    await handleTradeFind(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No trades found'));
+  });
+});

--- a/__tests__/utils/trade/handlers/locations.test.js
+++ b/__tests__/utils/trade/handlers/locations.test.js
@@ -1,0 +1,41 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getTerminalsAtLocation: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildLocationsEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+}));
+
+const { handleTradeLocations } = require('../../../../utils/trade/handlers/locations');
+const { getTerminalsAtLocation } = require('../../../../utils/trade/tradeQueries');
+const { buildLocationsEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradeLocations', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sends locations embed', async () => {
+    const interaction = new MockInteraction({});
+    getTerminalsAtLocation.mockResolvedValue([{ name: 'T1' }]);
+    buildLocationsEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradeLocations(interaction);
+
+    expect(buildLocationsEmbed).toHaveBeenCalled();
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('warns when no terminals', async () => {
+    const interaction = new MockInteraction({});
+    getTerminalsAtLocation.mockResolvedValue([]);
+
+    await handleTradeLocations(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No known terminals'));
+  });
+});

--- a/__tests__/utils/trade/handlers/price.test.js
+++ b/__tests__/utils/trade/handlers/price.test.js
@@ -1,0 +1,41 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getCommodityTradeOptions: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildPriceEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+}));
+
+const { handleTradePrice } = require('../../../../utils/trade/handlers/price');
+const { getCommodityTradeOptions } = require('../../../../utils/trade/tradeQueries');
+const { buildPriceEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradePrice', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sends price embed', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'Laranite', location: 'Area18' } });
+    getCommodityTradeOptions.mockResolvedValue([{ terminal: { name: 'Area18' } }]);
+    buildPriceEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradePrice(interaction);
+
+    expect(buildPriceEmbed).toHaveBeenCalled();
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('warns when no prices', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'Laranite', location: 'Area18' } });
+    getCommodityTradeOptions.mockResolvedValue([]);
+
+    await handleTradePrice(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No price data'));
+  });
+});

--- a/__tests__/utils/trade/handlers/route.test.js
+++ b/__tests__/utils/trade/handlers/route.test.js
@@ -1,0 +1,66 @@
+const { MockInteraction, MessageFlags } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getBuyOptionsAtLocation: jest.fn(),
+  getSellOptionsAtLocation: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/resolveBestMatchingTerminal', () => ({
+  resolveBestMatchingTerminal: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeCalculations', () => ({
+  calculateProfitOptions: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildBestTradesEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeComponents', () => ({
+  buildLocationSelectMenu: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+  TradeStateCache: { set: jest.fn() }
+}));
+
+const { handleTradeRoute } = require('../../../../utils/trade/handlers/route');
+const { getBuyOptionsAtLocation, getSellOptionsAtLocation } = require('../../../../utils/trade/tradeQueries');
+const { resolveBestMatchingTerminal } = require('../../../../utils/trade/resolveBestMatchingTerminal');
+const { calculateProfitOptions } = require('../../../../utils/trade/tradeCalculations');
+const { buildBestTradesEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradeRoute', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sends route embed on success', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getBuyOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'A' }, commodity_name: 'X', price_buy: 10, scu_buy: 1 }]);
+    getSellOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'B' }, commodity_name: 'X', price_sell: 20 }]);
+    resolveBestMatchingTerminal.mockReturnValueOnce({ name: 'A' }).mockReturnValueOnce({ name: 'B' });
+    calculateProfitOptions.mockReturnValue([{ totalProfit: 10 }]);
+    buildBestTradesEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradeRoute(interaction, {}, { from: 'A', to: 'B' });
+
+    expect(buildBestTradesEmbed).toHaveBeenCalled();
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('responds with error if terminals cannot be resolved', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getBuyOptionsAtLocation.mockResolvedValue([]);
+    getSellOptionsAtLocation.mockResolvedValue([]);
+    resolveBestMatchingTerminal.mockReturnValue(null);
+
+    await handleTradeRoute(interaction, {}, { from: 'A', to: 'B' });
+
+    expect(safeReply).toHaveBeenCalledWith(interaction, {
+      content: expect.stringContaining('Could not confidently resolve'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+});

--- a/__tests__/utils/trade/handlers/ship.test.js
+++ b/__tests__/utils/trade/handlers/ship.test.js
@@ -1,0 +1,41 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeQueries', () => ({
+  getVehicleByName: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
+  buildShipEmbed: jest.fn(),
+}));
+
+jest.mock('../../../../utils/trade/handlers/shared', () => ({
+  safeReply: jest.fn(),
+}));
+
+const { handleTradeShip } = require('../../../../utils/trade/handlers/ship');
+const { getVehicleByName } = require('../../../../utils/trade/tradeQueries');
+const { buildShipEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { safeReply } = require('../../../../utils/trade/handlers/shared');
+
+describe('handleTradeShip', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('sends ship embed', async () => {
+    const interaction = new MockInteraction({ options: { name: 'Cutlass' } });
+    getVehicleByName.mockResolvedValue({ name: 'Cutlass', scu: 46 });
+    buildShipEmbed.mockReturnValue({ title: 'embed' });
+
+    await handleTradeShip(interaction);
+
+    expect(buildShipEmbed).toHaveBeenCalled();
+    expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
+  });
+
+  test('warns when ship not found', async () => {
+    const interaction = new MockInteraction({ options: { name: 'Ghost' } });
+    getVehicleByName.mockResolvedValue(null);
+
+    await handleTradeShip(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('not found'));
+  });
+});

--- a/__tests__/utils/trade/tradeHandlers.test.js
+++ b/__tests__/utils/trade/tradeHandlers.test.js
@@ -1,0 +1,50 @@
+
+jest.mock('../../../utils/trade/handlers/best', () => ({ handleTradeBest: jest.fn(), handleTradeBestCore: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/bestCircuit', () => ({ handleTradeBestCircuit: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/route', () => ({ handleTradeRoute: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/find', () => ({ handleTradeFind: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/price', () => ({ handleTradePrice: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/ship', () => ({ handleTradeShip: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/locations', () => ({ handleTradeLocations: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/commodities', () => ({ handleTradeCommodities: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/shared', () => ({ safeReply: jest.fn(), pendingBest: {} }));
+
+const handlersBest = require('../../../utils/trade/handlers/best');
+const handlersBestCircuit = require('../../../utils/trade/handlers/bestCircuit');
+const handlersRoute = require('../../../utils/trade/handlers/route');
+const handlersFind = require('../../../utils/trade/handlers/find');
+const handlersPrice = require('../../../utils/trade/handlers/price');
+const handlersShip = require('../../../utils/trade/handlers/ship');
+const handlersLocations = require('../../../utils/trade/handlers/locations');
+const handlersCommodities = require('../../../utils/trade/handlers/commodities');
+const shared = require('../../../utils/trade/handlers/shared');
+
+jest.mock('../../../utils/trade/handlers/best', () => ({ handleTradeBest: jest.fn(), handleTradeBestCore: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/bestCircuit', () => ({ handleTradeBestCircuit: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/route', () => ({ handleTradeRoute: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/find', () => ({ handleTradeFind: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/price', () => ({ handleTradePrice: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/ship', () => ({ handleTradeShip: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/locations', () => ({ handleTradeLocations: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/commodities', () => ({ handleTradeCommodities: jest.fn() }));
+jest.mock('../../../utils/trade/handlers/shared', () => ({ safeReply: jest.fn(), pendingBest: {}, }));
+
+const tradeHandlers = require('../../../utils/trade/tradeHandlers');
+
+describe('tradeHandlers exports', () => {
+  test('re-exports all handler functions', () => {
+    expect(tradeHandlers).toMatchObject({
+      handleTradeBest: handlersBest.handleTradeBest,
+      handleTradeBestCore: handlersBest.handleTradeBestCore,
+      handleTradeBestCircuit: handlersBestCircuit.handleTradeBestCircuit,
+      handleTradeRoute: handlersRoute.handleTradeRoute,
+      handleTradeFind: handlersFind.handleTradeFind,
+      handleTradePrice: handlersPrice.handleTradePrice,
+      handleTradeShip: handlersShip.handleTradeShip,
+      handleTradeLocations: handlersLocations.handleTradeLocations,
+      handleTradeCommodities: handlersCommodities.handleTradeCommodities,
+      safeReply: shared.safeReply,
+      pendingBest: shared.pendingBest,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add UTILS_TEST_COVERAGE list
- add test suites for previously uncovered util modules in `utils/apiSync`
- add tests for remaining trade handler utilities

## Testing
- `npm test`