### PR TITLE
Add manual verify command

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -72,7 +72,9 @@ const EmbedBuilder = jest.fn().mockImplementation(() => {
 });
 
 const PermissionFlagsBits = {
-  Administrator: 0x00000008
+  Administrator: 0x00000008,
+  ManageGuild: 0x00000020,
+  ManageRoles: 0x00010000
 };
 
 const MessageFlags = {

--- a/__tests__/commands/admin/manual-verify.test.js
+++ b/__tests__/commands/admin/manual-verify.test.js
@@ -1,0 +1,92 @@
+jest.mock('../../../config/database', () => require('../../../__mocks__/config/database'));
+jest.mock('../../../utils/rsiProfileScraper');
+
+const { execute } = require('../../../commands/admin/manual-verify');
+const { VerifiedUser, OrgTag } = require('../../../config/database');
+const { fetchRsiProfileInfo } = require('../../../utils/rsiProfileScraper');
+const { MessageFlags } = require('discord.js');
+
+const createInteraction = (hasPerm = true) => {
+  const memberObj = {
+    displayName: 'Tester',
+    setNickname: jest.fn(),
+    roles: { cache: { has: jest.fn().mockReturnValue(true), remove: jest.fn(), add: jest.fn() } }
+  };
+  return {
+    member: { permissions: { has: jest.fn(() => hasPerm) } },
+    options: {
+      getUser: jest.fn(() => ({ id: 'u1', username: 'Tester' })),
+      getString: jest.fn(() => 'TestHandle')
+    },
+    guild: {
+      members: { fetch: jest.fn(() => memberObj) },
+      roles: { cache: { find: jest.fn(fn => [
+        { name: 'Recruit', id: 'r1' },
+        { name: 'Ensign', id: 'r2' },
+        { name: 'Pyro Freelancer Corps', id: 'r3' }
+      ].find(fn)) } }
+    },
+    reply: jest.fn()
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/manual-verify command', () => {
+  it('rejects when user lacks permission', async () => {
+    const interaction = createInteraction(false);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Only moderators or administrators'),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+
+  it('rejects when handle already linked', async () => {
+    const interaction = createInteraction(true);
+    VerifiedUser.findOne.mockResolvedValue({ discordUserId: 'other' });
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('already linked'),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+
+  it('verifies user successfully', async () => {
+    const interaction = createInteraction(true);
+    VerifiedUser.findOne.mockResolvedValue(null);
+    fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS' });
+    OrgTag.findByPk.mockResolvedValue({ tag: 'PFC' });
+    VerifiedUser.upsert.mockResolvedValue();
+
+    await execute(interaction);
+
+    expect(fetchRsiProfileInfo).toHaveBeenCalledWith('TestHandle');
+    expect(VerifiedUser.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      discordUserId: 'u1',
+      rsiHandle: 'TestHandle',
+      rsiOrgId: 'PFCS'
+    }));
+    expect(interaction.guild.members.fetch).toHaveBeenCalledWith('u1');
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('manually verified'),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+
+  it('handles database failures gracefully', async () => {
+    const interaction = createInteraction(true);
+    VerifiedUser.findOne.mockResolvedValue(null);
+    fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS' });
+    VerifiedUser.upsert.mockRejectedValue(new Error('fail'));
+
+    await execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Failed to manually verify'),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+});

--- a/commands/admin/manual-verify.js
+++ b/commands/admin/manual-verify.js
@@ -1,0 +1,89 @@
+const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { VerifiedUser, OrgTag } = require('../../config/database');
+const { fetchRsiProfileInfo } = require('../../utils/rsiProfileScraper');
+const { formatVerifiedNickname } = require('../../utils/formatVerifiedNickname');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('manual-verify')
+    .setDescription('Manually verify a user by RSI handle (mods & admins).')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addUserOption(option =>
+      option.setName('user')
+        .setDescription('Discord user to verify')
+        .setRequired(true))
+    .addStringOption(option =>
+      option.setName('rsi_handle')
+        .setDescription('RSI handle to link')
+        .setRequired(true)),
+  help: 'Links a Discord user to their RSI profile without requiring a verification code.',
+  category: 'Admin',
+
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
+      return interaction.reply({
+        content: '❌ Only moderators or administrators can use this command.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const targetUser = interaction.options.getUser('user');
+    const rsiHandle = interaction.options.getString('rsi_handle');
+
+    try {
+      const existing = await VerifiedUser.findOne({ where: { rsiHandle } });
+      if (existing && existing.discordUserId !== targetUser.id) {
+        return interaction.reply({
+          content: '❌ This RSI profile is already linked to another Discord user.',
+          flags: MessageFlags.Ephemeral
+        });
+      }
+
+      const { orgId } = await fetchRsiProfileInfo(rsiHandle);
+      await VerifiedUser.upsert({
+        discordUserId: targetUser.id,
+        rsiHandle,
+        rsiOrgId: orgId,
+        verifiedAt: new Date()
+      });
+
+      const tag = orgId ? (await OrgTag.findByPk(orgId.toUpperCase()))?.tag || null : null;
+      const member = await interaction.guild.members.fetch(targetUser.id);
+
+      if (orgId === 'PFCS') {
+        const recruitRole = interaction.guild.roles.cache.find(r => r.name === 'Recruit');
+        const ensignRole = interaction.guild.roles.cache.find(r => r.name === 'Ensign');
+        const pfcRole = interaction.guild.roles.cache.find(r => r.name === 'Pyro Freelancer Corps');
+        if (recruitRole && ensignRole && member.roles.cache.has(recruitRole.id)) {
+          try {
+            await member.roles.remove(recruitRole);
+            await member.roles.add(ensignRole);
+            await member.roles.add(pfcRole);
+          } catch (err) {
+            console.warn('[MANUAL VERIFY] Role update failed:', err.message);
+          }
+        }
+      }
+
+      if (tag) {
+        const newNick = formatVerifiedNickname(member.displayName, true, tag);
+        try {
+          await member.setNickname(newNick);
+        } catch (err) {
+          // ignore failures
+        }
+      }
+
+      await interaction.reply({
+        content: `✅ ${targetUser.username} has been manually verified as **${rsiHandle}**.`,
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (err) {
+      console.error('[MANUAL VERIFY] Error:', err);
+      await interaction.reply({
+        content: '❌ Failed to manually verify user. Try again later.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `/manual-verify` command for moderators/admins to link a Discord user to an RSI handle without profile code
- support new permission bits in Discord mock
- test `/manual-verify` behaviour

## Testing
- `npm test`