### PR TITLE
Fix nickname update in manual-verify

### DIFF
--- a/__tests__/commands/admin/manual-verify.test.js
+++ b/__tests__/commands/admin/manual-verify.test.js
@@ -8,7 +8,7 @@ const { MessageFlags } = require('discord.js');
 
 const createInteraction = (hasPerm = true) => {
   const memberObj = {
-    displayName: 'Tester',
+    displayName: 'Tester ⛔',
     setNickname: jest.fn(),
     roles: { cache: { has: jest.fn().mockReturnValue(true), remove: jest.fn(), add: jest.fn() } }
   };
@@ -70,6 +70,8 @@ describe('/manual-verify command', () => {
       rsiOrgId: 'PFCS'
     }));
     expect(interaction.guild.members.fetch).toHaveBeenCalledWith('u1');
+    const fetchedMember = interaction.guild.members.fetch.mock.results[0].value;
+    expect(fetchedMember.setNickname).toHaveBeenCalledWith('[PFC] Tester');
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
       content: expect.stringContaining('manually verified'),
       flags: MessageFlags.Ephemeral
@@ -88,5 +90,18 @@ describe('/manual-verify command', () => {
       content: expect.stringContaining('Failed to manually verify'),
       flags: MessageFlags.Ephemeral
     }));
+  });
+
+  it('updates nickname even when org tag is unknown', async () => {
+    const interaction = createInteraction(true);
+    VerifiedUser.findOne.mockResolvedValue(null);
+    fetchRsiProfileInfo.mockResolvedValue({ orgId: 'UNKNOWN' });
+    OrgTag.findByPk.mockResolvedValue(null);
+    VerifiedUser.upsert.mockResolvedValue();
+
+    await execute(interaction);
+
+    const fetchedMember = interaction.guild.members.fetch.mock.results[0].value;
+    expect(fetchedMember.setNickname).toHaveBeenCalledWith('Tester');
   });
 });

--- a/commands/admin/manual-verify.js
+++ b/commands/admin/manual-verify.js
@@ -65,12 +65,13 @@ module.exports = {
         }
       }
 
-      if (tag) {
-        const newNick = formatVerifiedNickname(member.displayName, true, tag);
+      // Always attempt to clean up the nickname using the formatter
+      const newNick = formatVerifiedNickname(member.displayName, true, tag);
+      if (newNick !== member.displayName) {
         try {
           await member.setNickname(newNick);
         } catch (err) {
-          // ignore failures
+          // Nickname updates may fail due to permissions; ignore silently
         }
       }
 


### PR DESCRIPTION
## Summary
- ensure `/manual-verify` always cleans up nickname via `formatVerifiedNickname`
- expect nickname changes in tests
- cover nickname update when org tag is unknown

## Testing
- `npm test`