### PR TITLE
Implement trade subcommand handlers

### DIFF
--- a/__tests__/commands/tools/trade/circuit.test.js
+++ b/__tests__/commands/tools/trade/circuit.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeBestCircuit: jest.fn()
+}));
+
+const { handleTradeBestCircuit } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/circuit');
+
+describe('/trade circuit subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeBestCircuit', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A' } });
+    await command.execute(interaction);
+    expect(handleTradeBestCircuit).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/commodities.test.js
+++ b/__tests__/commands/tools/trade/commodities.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeCommodities: jest.fn()
+}));
+
+const { handleTradeCommodities } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/commodities');
+
+describe('/trade commodities subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeCommodities', async () => {
+    const interaction = new MockInteraction({});
+    await command.execute(interaction);
+    expect(handleTradeCommodities).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/find.test.js
+++ b/__tests__/commands/tools/trade/find.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeFind: jest.fn()
+}));
+
+const { handleTradeFind } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/find');
+
+describe('/trade find subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeFind', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    await command.execute(interaction);
+    expect(handleTradeFind).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/price.test.js
+++ b/__tests__/commands/tools/trade/price.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradePrice: jest.fn()
+}));
+
+const { handleTradePrice } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/price');
+
+describe('/trade price subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradePrice', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'A' } });
+    await command.execute(interaction);
+    expect(handleTradePrice).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/route.test.js
+++ b/__tests__/commands/tools/trade/route.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/handlers/route', () => ({
+  handleTradeRoute: jest.fn()
+}));
+
+const { handleTradeRoute } = require('../../../../utils/trade/handlers/route');
+const command = require('../../../../commands/tools/trade/route');
+
+describe('/trade route subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeRoute', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    await command.execute(interaction, {});
+    expect(handleTradeRoute).toHaveBeenCalledWith(interaction, {}, { from: 'A', to: 'B' });
+  });
+});

--- a/commands/tools/trade/circuit.js
+++ b/commands/tools/trade/circuit.js
@@ -1,10 +1,22 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeBestCircuit } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('circuit')
-    .setDescription('Dummy /trade circuit subcommand.'),
+    .setDescription('Plan a basic trade circuit')
+    .addStringOption(opt =>
+      opt.setName('from')
+        .setDescription('Starting location')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('with')
+        .setDescription('Ship name'))
+    .addIntegerOption(opt =>
+      opt.setName('cash')
+        .setDescription('Available cash for trading')),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade circuit.', ephemeral: true });
+    await handleTradeBestCircuit(interaction);
   }
 };

--- a/commands/tools/trade/commodities.js
+++ b/commands/tools/trade/commodities.js
@@ -1,10 +1,12 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeCommodities } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('commodities')
-    .setDescription('Dummy /trade commodities subcommand.'),
+    .setDescription('List known commodities'),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade commodities.', ephemeral: true });
+    await handleTradeCommodities(interaction);
   }
 };

--- a/commands/tools/trade/find.js
+++ b/commands/tools/trade/find.js
@@ -1,10 +1,20 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeFind } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('find')
-    .setDescription('Dummy /trade find subcommand.'),
+    .setDescription('Find profitable trades between two locations')
+    .addStringOption(opt =>
+      opt.setName('from')
+        .setDescription('Origin location')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('to')
+        .setDescription('Destination location')
+        .setRequired(true)),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade find.', ephemeral: true });
+    await handleTradeFind(interaction);
   }
 };

--- a/commands/tools/trade/price.js
+++ b/commands/tools/trade/price.js
@@ -1,10 +1,19 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradePrice } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('price')
-    .setDescription('Dummy /trade price subcommand.'),
+    .setDescription('Get commodity prices')
+    .addStringOption(opt =>
+      opt.setName('commodity')
+        .setDescription('Commodity name')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('location')
+        .setDescription('Optional location to check')),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade price.', ephemeral: true });
+    await handleTradePrice(interaction);
   }
 };


### PR DESCRIPTION
## Notes
- Added real logic for `/trade` subcommands instead of placeholder replies
- New tests ensure each subcommand delegates to the appropriate trade handler

## Summary
- hook `/trade circuit`, `commodities`, `find`, and `price` to trade handlers
- add options for these subcommands
- tests verifying handler delegation for all trade subcommands

## Testing
- `npm test`