### PR TITLE
Implement trade query enhancements

### DIFF
--- a/__tests__/commands/tools/trade/circuit.test.js
+++ b/__tests__/commands/tools/trade/circuit.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeBestCircuit: jest.fn()
+}));
+
+const { handleTradeBestCircuit } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/circuit');
+
+describe('/trade circuit subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeBestCircuit', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A' } });
+    await command.execute(interaction);
+    expect(handleTradeBestCircuit).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/commodities.test.js
+++ b/__tests__/commands/tools/trade/commodities.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeCommodities: jest.fn()
+}));
+
+const { handleTradeCommodities } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/commodities');
+
+describe('/trade commodities subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeCommodities', async () => {
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+    await command.execute(interaction);
+    expect(handleTradeCommodities).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/find.test.js
+++ b/__tests__/commands/tools/trade/find.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeFind: jest.fn()
+}));
+
+const { handleTradeFind } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/find');
+
+describe('/trade find subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeFind', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'Laranite', type: 'buy' } });
+    await command.execute(interaction);
+    expect(handleTradeFind).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/price.test.js
+++ b/__tests__/commands/tools/trade/price.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradePrice: jest.fn()
+}));
+
+const { handleTradePrice } = require('../../../../utils/trade/tradeHandlers');
+const command = require('../../../../commands/tools/trade/price');
+
+describe('/trade price subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradePrice', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'A' } });
+    await command.execute(interaction);
+    expect(handleTradePrice).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/commands/tools/trade/route.test.js
+++ b/__tests__/commands/tools/trade/route.test.js
@@ -1,0 +1,18 @@
+const { MockInteraction } = require('../../../../__mocks__/discord.js');
+
+jest.mock('../../../../utils/trade/handlers/route', () => ({
+  handleTradeRoute: jest.fn()
+}));
+
+const { handleTradeRoute } = require('../../../../utils/trade/handlers/route');
+const command = require('../../../../commands/tools/trade/route');
+
+describe('/trade route subcommand', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('delegates to handleTradeRoute', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    await command.execute(interaction, {});
+    expect(handleTradeRoute).toHaveBeenCalledWith(interaction, {}, { from: 'A', to: 'B' });
+  });
+});

--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -1,11 +1,11 @@
 const { MockInteraction } = require('../../../../__mocks__/discord.js');
 
 jest.mock('../../../../utils/trade/tradeQueries', () => ({
-  getAllShipNames: jest.fn(),
+  getCommodityPricesAtLocation: jest.fn(),
 }));
 
 jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
-  buildCommoditiesEmbed: jest.fn(),
+  buildCommodityPricesEmbed: jest.fn(),
 }));
 
 jest.mock('../../../../utils/trade/handlers/shared', () => ({
@@ -13,8 +13,8 @@ jest.mock('../../../../utils/trade/handlers/shared', () => ({
 }));
 
 const { handleTradeCommodities } = require('../../../../utils/trade/handlers/commodities');
-const { getAllShipNames } = require('../../../../utils/trade/tradeQueries');
-const { buildCommoditiesEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { getCommodityPricesAtLocation } = require('../../../../utils/trade/tradeQueries');
+const { buildCommodityPricesEmbed } = require('../../../../utils/trade/tradeEmbeds');
 const { safeReply } = require('../../../../utils/trade/handlers/shared');
 
 describe('handleTradeCommodities', () => {
@@ -29,22 +29,21 @@ describe('handleTradeCommodities', () => {
   });
 
   test('sends commodities embed', async () => {
-    const interaction = new MockInteraction({});
-    getAllShipNames.mockResolvedValue(['A', 'B']);
-    buildCommoditiesEmbed.mockReturnValue({ title: 'embed' });
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+    getCommodityPricesAtLocation.mockResolvedValue([{ commodity_name: 'A' }]);
+    buildCommodityPricesEmbed.mockReturnValue({ title: 'embed' });
 
     await handleTradeCommodities(interaction);
 
-    expect(buildCommoditiesEmbed).toHaveBeenCalledWith(['A', 'B']);
+    expect(buildCommodityPricesEmbed).toHaveBeenCalled();
     expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
   });
 
   test('warns when no commodities', async () => {
-    const interaction = new MockInteraction({});
-    getAllShipNames.mockResolvedValue([]);
-
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+    getCommodityPricesAtLocation.mockResolvedValue([]);
     await handleTradeCommodities(interaction);
-    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No known commodities'));
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('commodity data')); 
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/trade/handlers/find.test.js
+++ b/__tests__/utils/trade/handlers/find.test.js
@@ -1,15 +1,11 @@
 const { MockInteraction } = require('../../../../__mocks__/discord.js');
 
 jest.mock('../../../../utils/trade/tradeQueries', () => ({
-  getSellOptionsAtLocation: jest.fn(),
-}));
-
-jest.mock('../../../../utils/trade/tradeCalculations', () => ({
-  calculateProfitOptions: jest.fn(),
+  getCommodityTradeOptions: jest.fn(),
 }));
 
 jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
-  buildBestTradesEmbed: jest.fn(),
+  buildPriceEmbed: jest.fn(),
 }));
 
 jest.mock('../../../../utils/trade/handlers/shared', () => ({
@@ -17,9 +13,8 @@ jest.mock('../../../../utils/trade/handlers/shared', () => ({
 }));
 
 const { handleTradeFind } = require('../../../../utils/trade/handlers/find');
-const { getSellOptionsAtLocation } = require('../../../../utils/trade/tradeQueries');
-const { calculateProfitOptions } = require('../../../../utils/trade/tradeCalculations');
-const { buildBestTradesEmbed } = require('../../../../utils/trade/tradeEmbeds');
+const { getCommodityTradeOptions } = require('../../../../utils/trade/tradeQueries');
+const { buildPriceEmbed } = require('../../../../utils/trade/tradeEmbeds');
 const { safeReply } = require('../../../../utils/trade/handlers/shared');
 
 describe('handleTradeFind', () => {
@@ -33,25 +28,23 @@ describe('handleTradeFind', () => {
     warnSpy.mockRestore();
   });
 
-  test('returns trades embed when results found', async () => {
-    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
-    getSellOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'B' }, price_buy: 10, scu_buy: 1 }]);
-    calculateProfitOptions.mockReturnValue([{ totalProfit: 10 }]);
-    buildBestTradesEmbed.mockReturnValue({ title: 'embed' });
+  test('returns price embed when results found', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'Laranite', type: 'buy' } });
+    getCommodityTradeOptions.mockResolvedValue([{ price_buy: 10, terminal: { name: 'Area18' } }]);
+    buildPriceEmbed.mockReturnValue({ title: 'embed' });
 
     await handleTradeFind(interaction);
 
-    expect(buildBestTradesEmbed).toHaveBeenCalled();
+    expect(buildPriceEmbed).toHaveBeenCalled();
     expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
   });
 
-  test('warns when no trades found', async () => {
-    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
-    getSellOptionsAtLocation.mockResolvedValue([]);
-    calculateProfitOptions.mockReturnValue([]);
+  test('warns when no locations', async () => {
+    const interaction = new MockInteraction({ options: { commodity: 'Laranite', type: 'buy' } });
+    getCommodityTradeOptions.mockResolvedValue([]);
 
     await handleTradeFind(interaction);
-    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No trades found'));
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No buy locations'));
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/commands/tools/trade/circuit.js
+++ b/commands/tools/trade/circuit.js
@@ -1,10 +1,30 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeBestCircuit } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('circuit')
-    .setDescription('Dummy /trade circuit subcommand.'),
+    .setDescription('Plan a basic trade circuit')
+    .addStringOption(opt =>
+      opt.setName('start')
+        .setDescription('Starting location'))
+    .addIntegerOption(opt =>
+      opt.setName('cargo_capacity')
+        .setDescription('Ship cargo capacity in SCU'))
+    .addStringOption(opt =>
+      opt.setName('priority')
+        .setDescription('Optimisation priority')
+        .addChoices(
+          { name: 'profit', value: 'profit' },
+          { name: 'time', value: 'time' },
+          { name: 'low-risk', value: 'low-risk' },
+          { name: 'high-volume', value: 'high-volume' }
+        ))
+    .addIntegerOption(opt =>
+      opt.setName('max_stops')
+        .setDescription('Maximum stops in loop')), 
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade circuit.', ephemeral: true });
+    await handleTradeBestCircuit(interaction);
   }
 };

--- a/commands/tools/trade/commodities.js
+++ b/commands/tools/trade/commodities.js
@@ -1,10 +1,19 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeCommodities } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('commodities')
-    .setDescription('Dummy /trade commodities subcommand.'),
+    .setDescription('Show commodity prices at a location')
+    .addStringOption(opt =>
+      opt.setName('location')
+        .setDescription('Location to query')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('filter')
+        .setDescription('Optional filter')),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade commodities.', ephemeral: true });
+    await handleTradeCommodities(interaction);
   }
 };

--- a/commands/tools/trade/find.js
+++ b/commands/tools/trade/find.js
@@ -1,10 +1,30 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradeFind } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('find')
-    .setDescription('Dummy /trade find subcommand.'),
+    .setDescription('Search best places to buy or sell a commodity')
+    .addStringOption(opt =>
+      opt.setName('commodity')
+        .setDescription('Commodity to search for')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('type')
+        .setDescription('buy or sell')
+        .setRequired(true)
+        .addChoices(
+          { name: 'buy', value: 'buy' },
+          { name: 'sell', value: 'sell' }
+        ))
+    .addStringOption(opt =>
+      opt.setName('near')
+        .setDescription('Optional location to filter'))
+    .addIntegerOption(opt =>
+      opt.setName('max_distance')
+        .setDescription('Maximum distance filter')),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade find.', ephemeral: true });
+    await handleTradeFind(interaction);
   }
 };

--- a/commands/tools/trade/price.js
+++ b/commands/tools/trade/price.js
@@ -1,10 +1,19 @@
 const { SlashCommandSubcommandBuilder } = require('discord.js');
+const { handleTradePrice } = require('../../../utils/trade/tradeHandlers');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('price')
-    .setDescription('Dummy /trade price subcommand.'),
+    .setDescription('Get commodity prices')
+    .addStringOption(opt =>
+      opt.setName('commodity')
+        .setDescription('Commodity name')
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('location')
+        .setDescription('Optional location to check')),
+
   async execute(interaction) {
-    await interaction.reply({ content: '✅ Dummy response for /trade price.', ephemeral: true });
+    await handleTradePrice(interaction);
   }
 };

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -2,34 +2,11 @@
 const DEBUG_TRADE = false;
 
 const {
-  getSellOptionsAtLocation,
-  getBuyOptionsAtLocation,
-  getCommodityTradeOptions,
-  getVehicleByName,
-  getAllShipNames,
-  getReturnOptions,
-  getTerminalsAtLocation,
-  getSellPricesForCommodityElsewhere
+  getCommodityPricesAtLocation
 } = require('../tradeQueries');
 
-const {
-  calculateProfitOptions,
-  calculateCircuitTotalProfit
-} = require('../tradeCalculations');
+const { buildCommodityPricesEmbed } = require('../tradeEmbeds');
 
-const {
-  buildBestTradesEmbed,
-  buildRouteEmbed,
-  buildCircuitEmbed,
-  buildPriceEmbed,
-  buildShipEmbed,
-  buildLocationsEmbed,
-  buildCommoditiesEmbed
-} = require('../tradeEmbeds');
-
-const {
-  buildShipSelectMenu
-} = require('../tradeComponents');
 
 const { safeReply } = require('./shared');
 
@@ -38,16 +15,17 @@ const { safeReply } = require('./shared');
 async function handleTradeCommodities(interaction) {
     try {
       if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] handleTradeCommodities triggered`);
-      const commodities = await getAllShipNames();
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Found ${commodities.length} commodities`);
-  
-      if (!commodities.length) {
-        console.warn(`[TRADE HANDLERS] No commodities found`);
-        await safeReply(interaction, `❌ No known commodities.`);
+      const location = interaction.options.getString('location');
+      const prices = await getCommodityPricesAtLocation(location);
+      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Found ${prices.length} price records`);
+
+      if (!prices.length) {
+        console.warn(`[TRADE HANDLERS] No commodity prices found at ${location}`);
+        await safeReply(interaction, `❌ No commodity data found for **${location}**.`);
         return;
       }
-  
-      const embed = buildCommoditiesEmbed(commodities);
+
+      const embed = buildCommodityPricesEmbed(location, prices);
       if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for commodities`);
       await safeReply(interaction, { embeds: [embed] });
   

--- a/utils/trade/handlers/find.js
+++ b/utils/trade/handlers/find.js
@@ -1,35 +1,12 @@
 
 const DEBUG_TRADE = false;
 
-const {
-  getSellOptionsAtLocation,
-  getBuyOptionsAtLocation,
-  getCommodityTradeOptions,
-  getVehicleByName,
-  getAllShipNames,
-  getReturnOptions,
-  getTerminalsAtLocation,
-  getSellPricesForCommodityElsewhere
-} = require('../tradeQueries');
+const { getCommodityTradeOptions } = require('../tradeQueries');
 
-const {
-  calculateProfitOptions,
-  calculateCircuitTotalProfit
-} = require('../tradeCalculations');
 
-const {
-  buildBestTradesEmbed,
-  buildRouteEmbed,
-  buildCircuitEmbed,
-  buildPriceEmbed,
-  buildShipEmbed,
-  buildLocationsEmbed,
-  buildCommoditiesEmbed
-} = require('../tradeEmbeds');
 
-const {
-  buildShipSelectMenu
-} = require('../tradeComponents');
+const { buildPriceEmbed } = require('../tradeEmbeds');
+
 
 const { safeReply } = require('./shared');
 
@@ -37,30 +14,31 @@ const { safeReply } = require('./shared');
 // /trade find
 async function handleTradeFind(interaction) {
     try {
-      const fromLocation = interaction.options.getString('from');
-      const toLocation = interaction.options.getString('to');
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] handleTradeFind → fromLocation=${fromLocation}, toLocation=${toLocation}`);
-  
-      const sellOptions = await getSellOptionsAtLocation(fromLocation);
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Found ${sellOptions.length} sellOptions from ${fromLocation}`);
-  
-      const filtered = sellOptions.filter(o =>
-        o.terminal && (o.terminal.name === toLocation || o.terminal.city_name === toLocation)
-      );
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Filtered down to ${filtered.length} options matching toLocation`);
-  
-      if (!filtered.length) {
-        console.warn(`[TRADE HANDLERS] No trades found from ${fromLocation} to ${toLocation}`);
-        await safeReply(interaction, `❌ No trades found from **${fromLocation}** to **${toLocation}**.`);
-        return;
-      }
-  
-      const profitOptions = calculateProfitOptions(filtered, 66, 100000);
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Calculated ${profitOptions.length} profits`);
-  
-      const embed = buildBestTradesEmbed(`${fromLocation} → ${toLocation}`, profitOptions);
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for trade find`);
-      await safeReply(interaction, { embeds: [embed] });
+  const commodity = interaction.options.getString('commodity');
+  const type = interaction.options.getString('type');
+  const near = interaction.options.getString('near');
+  if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] handleTradeFind → commodity=${commodity}, type=${type}, near=${near}`);
+
+  const records = await getCommodityTradeOptions(commodity);
+  const filtered = records.filter(r => {
+    const price = type === 'buy' ? r.price_buy : r.price_sell;
+    if (!price || price <= 0) return false;
+    if (!near) return true;
+    const t = r.terminal;
+    return t && (t.name === near || t.city_name === near || t.planet_name === near);
+  });
+
+  if (!filtered.length) {
+    console.warn(`[TRADE HANDLERS] No ${type} options found for ${commodity}`);
+    await safeReply(interaction, `❌ No ${type} locations found for **${commodity}**${near ? ` near **${near}**` : ''}.`);
+    return;
+  }
+
+  filtered.sort((a, b) => type === 'buy' ? a.price_buy - b.price_buy : b.price_sell - a.price_sell);
+
+  const embed = buildPriceEmbed(commodity, near, filtered);
+  if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for trade find`);
+  await safeReply(interaction, { embeds: [embed] });
   
     } catch (err) {
       console.error(`[TRADE HANDLERS] handleTradeFind error:`, err);

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -179,6 +179,27 @@ function buildCommoditiesEmbed(commodities) {
   }
 }
 
+function buildCommodityPricesEmbed(location, records) {
+  try {
+    if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommodityPricesEmbed → location=${location}`);
+    const fields = records.slice(0, 10).map(rec => ({
+      name: rec.commodity_name ?? 'UNKNOWN_COMMODITY',
+      value: `Buy: **${rec.price_buy ?? 'N/A'}** | Sell: **${rec.price_sell ?? 'N/A'}**`,
+      inline: false
+    }));
+
+    const embed = new EmbedBuilder()
+      .setTitle(`📦 Commodity prices at ${location}`)
+      .addFields(fields)
+      .setFooter({ text: 'Prices from database.' });
+
+    return embed;
+  } catch (err) {
+    console.error(`[TRADE EMBEDS] buildCommodityPricesEmbed encountered an error:`, err);
+    return new EmbedBuilder().setTitle('❌ Failed to build commodity prices embed.');
+  }
+}
+
 module.exports = {
   buildBestTradesEmbed,
   buildRouteEmbed,
@@ -186,5 +207,6 @@ module.exports = {
   buildPriceEmbed,
   buildShipEmbed,
   buildLocationsEmbed,
-  buildCommoditiesEmbed
+  buildCommoditiesEmbed,
+  buildCommodityPricesEmbed
 };


### PR DESCRIPTION
## Summary
- expose queries for commodity names and prices
- implement `/trade commodities` to show prices at a location
- update `/trade find` to search buy/sell locations for a commodity
- expand `/trade circuit` options to better match design
- support new handlers and embed builders
- update unit tests

## Testing
- `npm test`