### PR TITLE
Implement location-based commodity prices

### DIFF
--- a/__tests__/commands/tools/trade/commodities.test.js
+++ b/__tests__/commands/tools/trade/commodities.test.js
@@ -11,7 +11,7 @@ describe('/trade commodities subcommand', () => {
   beforeEach(() => jest.clearAllMocks());
 
   test('delegates to handleTradeCommodities', async () => {
-    const interaction = new MockInteraction({});
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
     await command.execute(interaction);
     expect(handleTradeCommodities).toHaveBeenCalledWith(interaction);
   });

--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -1,7 +1,7 @@
 const { MockInteraction } = require('../../../../__mocks__/discord.js');
 
 jest.mock('../../../../utils/trade/tradeQueries', () => ({
-  getAllShipNames: jest.fn(),
+  getSellOptionsAtLocation: jest.fn(),
 }));
 
 jest.mock('../../../../utils/trade/tradeEmbeds', () => ({
@@ -13,7 +13,7 @@ jest.mock('../../../../utils/trade/handlers/shared', () => ({
 }));
 
 const { handleTradeCommodities } = require('../../../../utils/trade/handlers/commodities');
-const { getAllShipNames } = require('../../../../utils/trade/tradeQueries');
+const { getSellOptionsAtLocation } = require('../../../../utils/trade/tradeQueries');
 const { buildCommoditiesEmbed } = require('../../../../utils/trade/tradeEmbeds');
 const { safeReply } = require('../../../../utils/trade/handlers/shared');
 
@@ -29,22 +29,22 @@ describe('handleTradeCommodities', () => {
   });
 
   test('sends commodities embed', async () => {
-    const interaction = new MockInteraction({});
-    getAllShipNames.mockResolvedValue(['A', 'B']);
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+    getSellOptionsAtLocation.mockResolvedValue([{ commodity_name: 'A', price_buy: 1, price_sell: 2 }]);
     buildCommoditiesEmbed.mockReturnValue({ title: 'embed' });
 
     await handleTradeCommodities(interaction);
 
-    expect(buildCommoditiesEmbed).toHaveBeenCalledWith(['A', 'B']);
+    expect(buildCommoditiesEmbed).toHaveBeenCalled();
     expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
   });
 
   test('warns when no commodities', async () => {
-    const interaction = new MockInteraction({});
-    getAllShipNames.mockResolvedValue([]);
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+    getSellOptionsAtLocation.mockResolvedValue([]);
 
     await handleTradeCommodities(interaction);
-    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No known commodities'));
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No commodity data'));
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -62,11 +62,14 @@ const {
       expect(result.data.fields[0].name).toContain('Terminal A');
     });
   
-    test('buildCommoditiesEmbed returns embed listing commodities', () => {
-      const result = buildCommoditiesEmbed(['Agricium', 'Laranite']);
-      expect(result.data.title).toContain('commodities');
-      expect(result.data.description).toContain('Agricium');
-      expect(result.data.description).toContain('Laranite');
+    test('buildCommoditiesEmbed returns embed with price info', () => {
+      const data = [
+        { name: 'Agricium', buyPrice: 1, sellPrice: 2, averagePrice: 1.5, margin: 1 }
+      ];
+      const result = buildCommoditiesEmbed('Area18', data);
+      expect(result.data.title).toContain('Area18');
+      expect(result.data.fields[0].name).toBe('Agricium');
+      expect(result.data.fields[0].value).toContain('Buy:');
     });
     
     test('buildLocationsEmbed uses planet_name fallback', () => {

--- a/commands/tools/trade/commodities.js
+++ b/commands/tools/trade/commodities.js
@@ -4,7 +4,11 @@ const { handleTradeCommodities } = require('../../../utils/trade/tradeHandlers')
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('commodities')
-    .setDescription('List known commodities'),
+    .setDescription('List commodity prices at a location')
+    .addStringOption(opt =>
+      opt.setName('location')
+        .setDescription('Location to check')
+        .setRequired(true)),
 
   async execute(interaction) {
     await handleTradeCommodities(interaction);

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -2,14 +2,7 @@
 const DEBUG_TRADE = false;
 
 const {
-  getSellOptionsAtLocation,
-  getBuyOptionsAtLocation,
-  getCommodityTradeOptions,
-  getVehicleByName,
-  getAllShipNames,
-  getReturnOptions,
-  getTerminalsAtLocation,
-  getSellPricesForCommodityElsewhere
+  getSellOptionsAtLocation
 } = require('../tradeQueries');
 
 const {
@@ -36,26 +29,36 @@ const { safeReply } = require('./shared');
 // =======================================
 // /trade commodities
 async function handleTradeCommodities(interaction) {
-    try {
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] handleTradeCommodities triggered`);
-      const commodities = await getAllShipNames();
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Found ${commodities.length} commodities`);
-  
-      if (!commodities.length) {
-        console.warn(`[TRADE HANDLERS] No commodities found`);
-        await safeReply(interaction, `❌ No known commodities.`);
-        return;
-      }
-  
-      const embed = buildCommoditiesEmbed(commodities);
-      if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for commodities`);
-      await safeReply(interaction, { embeds: [embed] });
-  
-    } catch (err) {
-      console.error(`[TRADE HANDLERS] handleTradeCommodities error:`, err);
-      if (!interaction.replied) await safeReply(interaction, `⚠️ An error occurred processing your request.`);
+  try {
+    const location = interaction.options.getString('location');
+    if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] handleTradeCommodities → location=${location}`);
+
+    const records = await getSellOptionsAtLocation(location);
+    if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Found ${records.length} price records`);
+
+    if (!records.length) {
+      console.warn(`[TRADE HANDLERS] No commodity prices found at ${location}`);
+      await safeReply(interaction, `❌ No commodity data found for **${location}**.`);
+      return;
     }
+
+    const commodities = records.map(r => ({
+      name: r.commodity_name,
+      buyPrice: r.price_buy,
+      sellPrice: r.price_sell,
+      averagePrice: Math.round(((r.price_buy ?? 0) + (r.price_sell ?? 0)) / 2) || null,
+      margin: r.price_sell != null && r.price_buy != null ? r.price_sell - r.price_buy : null
+    }));
+
+    const embed = buildCommoditiesEmbed(location, commodities);
+    if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for commodities`);
+    await safeReply(interaction, { embeds: [embed] });
+
+  } catch (err) {
+    console.error(`[TRADE HANDLERS] handleTradeCommodities error:`, err);
+    if (!interaction.replied) await safeReply(interaction, `⚠️ An error occurred processing your request.`);
   }
+}
 
   module.exports = {
     handleTradeCommodities

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -163,14 +163,25 @@ function buildLocationsEmbed(terminals) {
   }
 }
 
-function buildCommoditiesEmbed(commodities) {
+function buildCommoditiesEmbed(location, commodities) {
   try {
-    if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → commodities:`, commodities);
+    if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}`, commodities);
+
+    const fields = commodities.slice(0, 25).map(c => ({
+      name: c.name,
+      value: [
+        `Buy: **${c.buyPrice ?? 'N/A'}**`,
+        `Sell: **${c.sellPrice ?? 'N/A'}**`,
+        `Avg: **${c.averagePrice ?? 'N/A'}**`,
+        c.margin != null ? `Profit: **${c.margin}**` : null
+      ].filter(Boolean).join(' | '),
+      inline: false
+    }));
 
     const embed = new EmbedBuilder()
-      .setTitle(`📦 Known commodities`)
-      .setDescription(commodities.join(', '))
-      .setFooter({ text: 'Commodity list from database.' });
+      .setTitle(`📦 Commodity prices at ${location}`)
+      .addFields(fields)
+      .setFooter({ text: 'Prices from latest available data.' });
 
     return embed;
   } catch (err) {


### PR DESCRIPTION
## Summary
- update `/trade commodities` subcommand to require a location
- fetch commodity pricing for the chosen location
- render detailed price info using `buildCommoditiesEmbed`
- adjust unit tests for new behaviour

## Testing
- `npm test`