### PR TITLE
feat(trade): improve commodities embed

### DIFF
--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -30,12 +30,14 @@ describe('handleTradeCommodities', () => {
 
   test('sends commodities embed', async () => {
     const interaction = new MockInteraction({ options: { location: 'Area18' } });
-    getSellOptionsAtLocation.mockResolvedValue([{ commodity_name: 'A', price_buy: 1, price_sell: 2 }]);
+    getSellOptionsAtLocation.mockResolvedValue([
+      { commodity_name: 'A', price_buy: 1, price_sell: 2, terminal: { name: 'T1' } }
+    ]);
     buildCommoditiesEmbed.mockReturnValue({ title: 'embed' });
 
     await handleTradeCommodities(interaction);
 
-    expect(buildCommoditiesEmbed).toHaveBeenCalled();
+    expect(buildCommoditiesEmbed).toHaveBeenCalledWith('Area18', expect.any(Array));
     expect(safeReply).toHaveBeenCalledWith(interaction, { embeds: [{ title: 'embed' }] });
   });
 

--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -62,14 +62,16 @@ const {
       expect(result.data.fields[0].name).toContain('Terminal A');
     });
   
-    test('buildCommoditiesEmbed returns embed with price info', () => {
+    test('buildCommoditiesEmbed returns embed grouped by terminal', () => {
       const data = [
-        { name: 'Agricium', buyPrice: 1, sellPrice: 2, averagePrice: 1.5, margin: 1 }
+        { terminal: 'T1', commodities: [{ name: 'Agricium', buyPrice: 1, sellPrice: 2 }] }
       ];
       const result = buildCommoditiesEmbed('Area18', data);
       expect(result.data.title).toContain('Area18');
-      expect(result.data.fields[0].name).toBe('Agricium');
+      expect(result.data.fields[0].name).toBe('T1');
+      expect(result.data.fields[0].value).toContain('Agricium');
       expect(result.data.fields[0].value).toContain('Buy:');
+      expect(result.data.fields[0].value).not.toContain('Avg');
     });
     
     test('buildLocationsEmbed uses planet_name fallback', () => {

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -42,15 +42,19 @@ async function handleTradeCommodities(interaction) {
       return;
     }
 
-    const commodities = records.map(r => ({
-      name: r.commodity_name,
-      buyPrice: r.price_buy,
-      sellPrice: r.price_sell,
-      averagePrice: Math.round(((r.price_buy ?? 0) + (r.price_sell ?? 0)) / 2) || null,
-      margin: r.price_sell != null && r.price_buy != null ? r.price_sell - r.price_buy : null
-    }));
+    const terminalsMap = {};
+    for (const r of records) {
+      const terminalName = r.terminal?.nickname || r.terminal?.name || 'UNKNOWN_TERMINAL';
+      if (!terminalsMap[terminalName]) terminalsMap[terminalName] = [];
+      terminalsMap[terminalName].push({
+        name: r.commodity_name,
+        buyPrice: r.price_buy,
+        sellPrice: r.price_sell
+      });
+    }
+    const terminals = Object.entries(terminalsMap).map(([terminal, commodities]) => ({ terminal, commodities }));
 
-    const embed = buildCommoditiesEmbed(location, commodities);
+    const embed = buildCommoditiesEmbed(location, terminals);
     if (DEBUG_TRADE) console.log(`[TRADE HANDLERS] Built embed for commodities`);
     await safeReply(interaction, { embeds: [embed] });
 

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -163,20 +163,18 @@ function buildLocationsEmbed(terminals) {
   }
 }
 
-function buildCommoditiesEmbed(location, commodities) {
+function buildCommoditiesEmbed(location, terminals) {
   try {
-    if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}`, commodities);
+    if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}`, terminals);
 
-    const fields = commodities.slice(0, 25).map(c => ({
-      name: c.name,
-      value: [
-        `Buy: **${c.buyPrice ?? 'N/A'}**`,
-        `Sell: **${c.sellPrice ?? 'N/A'}**`,
-        `Avg: **${c.averagePrice ?? 'N/A'}**`,
-        c.margin != null ? `Profit: **${c.margin}**` : null
-      ].filter(Boolean).join(' | '),
-      inline: false
-    }));
+    const fields = terminals.slice(0, 25).map(t => {
+      const lines = t.commodities.map(c => `${c.name} - Buy: **${c.buyPrice ?? 'N/A'}** | Sell: **${c.sellPrice ?? 'N/A'}**`).join('\n');
+      return {
+        name: t.terminal,
+        value: lines || 'No commodities found',
+        inline: false
+      };
+    });
 
     const embed = new EmbedBuilder()
       .setTitle(`📦 Commodity prices at ${location}`)


### PR DESCRIPTION
## Summary
- rework `/trade commodities` handler to group data by terminal
- remove profit/average info from commodities embed
- show commodity name, buy price, and sell price grouped per terminal
- update tests for new embed format

## Testing
- `npm test`