### PR TITLE
fix commodities embed length

### DIFF
--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -74,6 +74,19 @@ const {
       expect(result.data.fields[0].value).not.toContain('Avg');
       expect(result.data.footer.text).toContain('Page 1 of 1');
     });
+
+    test('buildCommoditiesEmbed truncates long field values', () => {
+      const longList = Array.from({ length: 300 }, (_, i) => ({
+        name: `Item${i}`,
+        buyPrice: i,
+        sellPrice: i + 1
+      }));
+      const data = [{ terminal: 'T1', commodities: longList }];
+      const result = buildCommoditiesEmbed('Area18', data, 0, 1);
+      const value = result.data.fields[0].value;
+      expect(value.length).toBeLessThanOrEqual(1024);
+      expect(value.endsWith('...')).toBe(true);
+    });
     
     test('buildLocationsEmbed uses planet_name fallback', () => {
       const result = buildLocationsEmbed([{ name: 'Terminal A', planet_name: 'MicroTech' }]);

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -168,7 +168,16 @@ function buildCommoditiesEmbed(location, terminals, page = 0, totalPages = 1) {
     if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}, page=${page}, total=${totalPages}`, terminals);
 
     const fields = terminals.slice(0, 25).map(t => {
-      const lines = t.commodities.map(c => `${c.name} - Buy: **${c.buyPrice ?? 'N/A'}** | Sell: **${c.sellPrice ?? 'N/A'}**`).join('\n');
+      let lines = t.commodities
+        .map(c => `${c.name} - Buy: **${c.buyPrice ?? 'N/A'}** | Sell: **${c.sellPrice ?? 'N/A'}**`)
+        .join('\n');
+
+      // Discord embed field values are limited to 1024 characters.
+      // Trim and add ellipsis when this limit would be exceeded.
+      if (lines.length > 1024) {
+        lines = `${lines.slice(0, 1021)}...`;
+      }
+
       return {
         name: t.terminal,
         value: lines || 'No commodities found',


### PR DESCRIPTION
## Summary
- ensure commodity fields don't exceed Discord's 1024 char limit
- add test verifying long commodity lists are truncated

## Testing
- `npm test`