### PR TITLE
Fix commodity name formatting in embed

### DIFF
--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -88,6 +88,17 @@ const {
       expect(value.length).toBeLessThanOrEqual(1024);
       expect(value.endsWith('...```')).toBe(true);
     });
+
+    test('buildCommoditiesEmbed truncates long commodity names', () => {
+      const longName = 'Supercalifragilisticexpialidocious Commodity';
+      const data = [{ terminal: 'T1', commodities: [{ name: longName, buyPrice: 1, sellPrice: 2 }] }];
+      const result = buildCommoditiesEmbed('Area18', data, 0, 1);
+      const value = result.data.fields[0].value;
+      expect(value).toContain('…');
+      const row = value.split('\n')[2];
+      const namePart = row.split('|')[0].trim();
+      expect(namePart.length).toBeLessThanOrEqual(22);
+    });
     
     test('buildLocationsEmbed uses planet_name fallback', () => {
       const result = buildLocationsEmbed([{ name: 'Terminal A', planet_name: 'MicroTech' }]);

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -163,17 +163,23 @@ function buildLocationsEmbed(terminals) {
   }
 }
 
+const NAME_WIDTH = 22; // width of the commodity column
+
 function buildCommoditiesEmbed(location, terminals, page = 0, totalPages = 1) {
   try {
     if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}, page=${page}, total=${totalPages}`, terminals);
 
     const fields = terminals.slice(0, 25).map(t => {
-      const header = 'Commodity           |      Buy |     Sell';
+      const header = `${'Commodity'.padEnd(NAME_WIDTH, ' ')} |      Buy |     Sell`;
       const lines = t.commodities
         .map(c => {
           const buy = c.buyPrice ?? 'N/A';
           const sell = c.sellPrice ?? 'N/A';
-          const name = String(c.name).padEnd(18, ' ');
+          let name = String(c.name);
+          if (name.length > NAME_WIDTH) {
+            name = name.slice(0, NAME_WIDTH - 1) + '…';
+          }
+          name = name.padEnd(NAME_WIDTH, ' ');
           return `${name} | ${String(buy).padStart(7, ' ')} | ${String(sell).padStart(7, ' ')}`;
         })
         .join('\n');


### PR DESCRIPTION
## Summary
- handle long commodity names when building trade embeds
- test commodity name truncation behavior

## Testing
- `npm test`