### PR TITLE
Fix trade commodities pagination

### DIFF
--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -71,7 +71,6 @@ const {
       expect(result.data.fields[0].name).toBe('T1');
       const value = result.data.fields[0].value;
       expect(value.startsWith('```')).toBe(true);
-      expect(value).toContain('Commodity');
       expect(value).toContain('Agricium');
       expect(result.data.footer.text).toContain('Page 1 of 1');
     });
@@ -95,7 +94,7 @@ const {
       const result = buildCommoditiesEmbed('Area18', data, 0, 1);
       const value = result.data.fields[0].value;
       expect(value).toContain('…');
-      const row = value.split('\n')[2];
+      const row = value.split('\n')[1];
       const namePart = row.split('|')[0].trim();
       expect(namePart.length).toBeLessThanOrEqual(22);
     });

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -20,6 +20,7 @@ const { safeReply } = require('./shared');
 // =======================================
 // /trade commodities
 const PAGE_SIZE = 5;
+const COMMODITIES_PER_FIELD = 20;
 
 function chunkArray(arr, size) {
   const chunks = [];
@@ -53,7 +54,14 @@ async function handleTradeCommodities(interaction, { location, page = 0 } = {}) 
         sellPrice: r.price_sell
       });
     }
-    const terminals = Object.entries(terminalsMap).map(([terminal, commodities]) => ({ terminal, commodities }));
+    const terminals = [];
+    for (const [terminal, commodities] of Object.entries(terminalsMap)) {
+      const parts = chunkArray(commodities, COMMODITIES_PER_FIELD);
+      parts.forEach((list, idx) => {
+        const name = parts.length > 1 ? `${terminal} (${idx + 1}/${parts.length})` : terminal;
+        terminals.push({ terminal: name, commodities: list });
+      });
+    }
 
     const chunks = chunkArray(terminals, PAGE_SIZE);
     const pageData = chunks[page] || [];

--- a/utils/trade/tradeEmbeds.js
+++ b/utils/trade/tradeEmbeds.js
@@ -170,7 +170,6 @@ function buildCommoditiesEmbed(location, terminals, page = 0, totalPages = 1) {
     if (DEBUG_EMBED) console.log(`[TRADE EMBEDS] buildCommoditiesEmbed → location=${location}, page=${page}, total=${totalPages}`, terminals);
 
     const fields = terminals.slice(0, 25).map(t => {
-      const header = `${'Commodity'.padEnd(NAME_WIDTH, ' ')} |      Buy |     Sell`;
       const lines = t.commodities
         .map(c => {
           const buy = c.buyPrice ?? 'N/A';
@@ -184,7 +183,7 @@ function buildCommoditiesEmbed(location, terminals, page = 0, totalPages = 1) {
         })
         .join('\n');
 
-      let content = `${header}\n${lines}`.trim();
+      let content = lines.trim();
       const maxContentLength = 1017; // account for wrapping backticks
       if (content.length > maxContentLength) {
         content = `${content.slice(0, maxContentLength - 3)}...`;


### PR DESCRIPTION
## Summary
- remove column header in `/trade commodities`
- support pagination for long commodity lists
- adapt embed rendering to handle pagination without header
- update tests

## Testing
- `npm test`