### PR TITLE
Fix commodities pagination

### DIFF
--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -63,7 +63,7 @@ describe('handleTradeCommodities', () => {
 
     await handleTradeCommodities(interaction);
 
-    expect(buildCommoditiesEmbed).toHaveBeenCalledWith('Lorville', expect.any(Array), 0, 4);
+    expect(buildCommoditiesEmbed).toHaveBeenCalledWith('Lorville', expect.any(Array), 0, 7);
 
     const prev = ButtonBuilder.mock.instances[0];
     const next = ButtonBuilder.mock.instances[1];

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -19,7 +19,7 @@ const { safeReply } = require('./shared');
 
 // =======================================
 // /trade commodities
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 3;
 const COMMODITIES_PER_FIELD = 20;
 
 function chunkArray(arr, size) {


### PR DESCRIPTION
## Notes
- Adjust commodities paging to show fewer fields per page
- Update unit tests for new page count

## Summary
- paginate commodity listings with `PAGE_SIZE=3`
- expect seven pages in commodities handler test

## Testing
- `npm test`