### PR TITLE
Fix trade commodities pagination

### DIFF
--- a/__tests__/utils/trade/handlers/commodities.test.js
+++ b/__tests__/utils/trade/handlers/commodities.test.js
@@ -63,7 +63,7 @@ describe('handleTradeCommodities', () => {
 
     await handleTradeCommodities(interaction);
 
-    expect(buildCommoditiesEmbed).toHaveBeenCalledWith('Lorville', expect.any(Array), 0, 7);
+    expect(buildCommoditiesEmbed).toHaveBeenCalledWith('Lorville', expect.any(Array), 0, 20);
 
     const prev = ButtonBuilder.mock.instances[0];
     const next = ButtonBuilder.mock.instances[1];

--- a/commands/tools/trade.js
+++ b/commands/tools/trade.js
@@ -78,5 +78,34 @@ module.exports = {
         flags: MessageFlags.Ephemeral
       });
     }
+  },
+
+  async button(interaction, client) {
+    const customId = interaction.customId;
+    const [prefix] = customId.split('::');
+
+    if (!prefix.startsWith('trade_')) return;
+
+    const subcommand = prefix.slice('trade_'.length).split('_')[0];
+
+    try {
+      const subcommandModule = require(`./trade/${subcommand}`);
+
+      if (subcommandModule && typeof subcommandModule.button === 'function') {
+        await subcommandModule.button(interaction, client);
+      } else {
+        console.warn(`[TRADE] No button handler function found in "${subcommand}".`);
+        await safeReply(interaction, {
+          content: `❌ No handler for button in "${subcommand}".`,
+          flags: MessageFlags.Ephemeral
+        });
+      }
+    } catch (err) {
+      console.error(`❌ Failed to handle button for subcommand "${subcommand}":`, err);
+      await safeReply(interaction, {
+        content: `❌ Error loading button handler for "${subcommand}".`,
+        flags: MessageFlags.Ephemeral
+      });
+    }
   }
 };

--- a/utils/trade/handlers/commodities.js
+++ b/utils/trade/handlers/commodities.js
@@ -19,7 +19,7 @@ const { safeReply } = require('./shared');
 
 // =======================================
 // /trade commodities
-const PAGE_SIZE = 3;
+const PAGE_SIZE = 1;
 const COMMODITIES_PER_FIELD = 20;
 
 function chunkArray(arr, size) {


### PR DESCRIPTION
## Summary
- handle trade subcommand buttons in the main trade command
- show one commodities page per embed
- update commodities tests for the new page count

## Testing
- `npm test`