### PR TITLE
Fix safeReply for string payloads

### DIFF
--- a/__tests__/utils/trade/handlers/shared.test.js
+++ b/__tests__/utils/trade/handlers/shared.test.js
@@ -46,6 +46,13 @@ describe('safeReply', () => {
     expect(interaction.reply).not.toHaveBeenCalled();
   });
 
+  test('accepts string payloads and wraps with content', async () => {
+    const interaction = createInteraction();
+    await safeReply(interaction, 'hello');
+
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'hello', flags: MessageFlags.Ephemeral });
+  });
+
   test('errors are caught and logged without throwing', async () => {
     const interaction = createInteraction();
     interaction.reply.mockImplementation(() => { throw new Error('boom'); });

--- a/utils/trade/handlers/shared.js
+++ b/utils/trade/handlers/shared.js
@@ -8,6 +8,10 @@ async function safeReply(interaction, payload = {}) {
     return;
   }
 
+  if (typeof payload === 'string') {
+    payload = { content: payload };
+  }
+
   // Always enforce ephemeral visibility
   payload.flags = MessageFlags.Ephemeral;
 


### PR DESCRIPTION
## Notes
- Extend `safeReply` to wrap string payloads and always apply ephemeral flags.
- Added unit test covering string payload behavior.

## Testing
- `npm test`