### PR TITLE
Fix trade commodities pagination reply

### DIFF
--- a/__tests__/commands/tools/trade/commodities.test.js
+++ b/__tests__/commands/tools/trade/commodities.test.js
@@ -15,4 +15,16 @@ describe('/trade commodities subcommand', () => {
     await command.execute(interaction);
     expect(handleTradeCommodities).toHaveBeenCalledWith(interaction);
   });
+
+  test('button interaction defers update and calls handler with page', async () => {
+    const btn = {
+      customId: 'trade_commodities_page::Area18::2',
+      deferUpdate: jest.fn().mockResolvedValue(),
+    };
+
+    await command.button(btn);
+
+    expect(btn.deferUpdate).toHaveBeenCalled();
+    expect(handleTradeCommodities).toHaveBeenCalledWith(btn, { location: 'Area18', page: 2 });
+  });
 });

--- a/commands/tools/trade/commodities.js
+++ b/commands/tools/trade/commodities.js
@@ -20,6 +20,8 @@ module.exports = {
     const [, location, pageStr] = interaction.customId.split('::');
     const page = parseInt(pageStr, 10) || 0;
 
+    await interaction.deferUpdate();
+
     await handleTradeCommodities(interaction, { location, page });
   }
 };


### PR DESCRIPTION
## Summary
- ensure `/trade commodities` updates the existing ephemeral message
- test button handler to verify interaction deferral

## Testing
- `npm test`