### PR TITLE
Improve coverage for API sync helpers

### DIFF
--- a/__tests__/utils/apiSync/galactapediaDetail.test.js
+++ b/__tests__/utils/apiSync/galactapediaDetail.test.js
@@ -11,7 +11,16 @@ const db = require('../../../config/database');
 const { syncGalactapediaDetail } = require('../../../utils/apiSync/galactapediaDetail');
 
 describe('syncGalactapediaDetail', () => {
-  beforeEach(() => jest.clearAllMocks());
+  let errorSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
 
   test('saves details and related data', async () => {
     fetchSCDataByUrl.mockResolvedValue({ data: { id: 1, translations: { en_EN: 'text' }, tags: [], properties: [], related_articles: [] } });
@@ -20,6 +29,42 @@ describe('syncGalactapediaDetail', () => {
     expect(fetchSCDataByUrl).toHaveBeenCalledWith('url');
     expect(db.GalactapediaDetail.upsert).toHaveBeenCalled();
     expect(res).toBe(true);
+  });
+
+  test('saves tags, properties, and related articles', async () => {
+    fetchSCDataByUrl.mockResolvedValue({
+      data: {
+        id: 2,
+        created_at: '2020-01-01',
+        translations: { en_EN: 'detail' },
+        tags: [{ id: 10, name: 'Tag' }],
+        properties: [{ name: 'Key', value: 'Val' }],
+        related_articles: [{ id: 9, title: 'Rel', url: '/rel', api_url: 'relUrl' }]
+      }
+    });
+
+    const res = await syncGalactapediaDetail({ api_url: 'url2', id: 2 });
+
+    expect(db.GalactapediaTag.destroy).toHaveBeenCalledWith({ where: { article_id: 2 } });
+    expect(db.GalactapediaTag.bulkCreate).toHaveBeenCalledWith([
+      { article_id: 2, tag_id: 10, tag_name: 'Tag' }
+    ]);
+    expect(db.GalactapediaProperty.destroy).toHaveBeenCalledWith({ where: { article_id: 2 } });
+    expect(db.GalactapediaProperty.bulkCreate).toHaveBeenCalledWith([
+      { article_id: 2, name: 'Key', value: 'Val' }
+    ]);
+    expect(db.GalactapediaRelatedArticle.destroy).toHaveBeenCalledWith({ where: { article_id: 2 } });
+    expect(db.GalactapediaRelatedArticle.bulkCreate).toHaveBeenCalledWith([
+      { article_id: 2, related_id: 9, title: 'Rel', url: '/rel', api_url: 'relUrl' }
+    ]);
+    expect(res).toBe(true);
+  });
+
+  test('handles fetch failure gracefully', async () => {
+    fetchSCDataByUrl.mockRejectedValue(new Error('fail'));
+    const res = await syncGalactapediaDetail({ api_url: 'bad', id: 3 });
+    expect(res).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   test('returns false when no detail content', async () => {


### PR DESCRIPTION
## Summary
- expand galactapedia detail sync tests
- cover interaction updates in API sync runner

## Testing
- `npm test -- --coverage`