### PR TITLE
Add tests for remaining modules

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -164,6 +164,9 @@ const SlashCommandBuilder = jest.fn(() => {
     setDefaultMemberPermissions() {
       return this;
     },
+    setDMPermission() {
+      return this;
+    },
   };
   return builder;
 });

--- a/__tests__/botactions/ambient/ambientEngine.test.js
+++ b/__tests__/botactions/ambient/ambientEngine.test.js
@@ -1,0 +1,49 @@
+const { startAmbientEngine, trackChannelActivity } = require('../../../botactions/ambient/ambientEngine');
+const { AmbientChannel, AmbientSetting, AmbientMessage } = require('../../../config/database');
+
+jest.useFakeTimers();
+
+jest.mock('../../../config/database', () => ({
+  AmbientChannel: { findAll: jest.fn() },
+  AmbientSetting: { findOne: jest.fn() },
+  AmbientMessage: { findAll: jest.fn() }
+}));
+
+describe('ambientEngine', () => {
+  let client;
+  let channel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    channel = { isTextBased: () => true, name: 'general', send: jest.fn() };
+    client = { channels: { cache: new Map([['1', channel]]) } };
+    AmbientChannel.findAll.mockResolvedValue([{ channelId: '1' }]);
+    AmbientSetting.findOne.mockResolvedValue({ minMessagesSinceLast: 1, freshWindowMs: 120000 });
+    AmbientMessage.findAll.mockResolvedValue([{ content: 'hi' }]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('sends ambient message when channel active', async () => {
+    await startAmbientEngine(client);
+    trackChannelActivity({ author: { bot: false }, channel: { id: '1' } });
+
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    expect(channel.send).toHaveBeenCalledWith('hi');
+  });
+
+  test('ignores activity from disallowed channel', async () => {
+    AmbientChannel.findAll.mockResolvedValue([]); // no allowed channels
+    await startAmbientEngine(client);
+    trackChannelActivity({ author: { bot: false }, channel: { id: '1' } });
+
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    expect(channel.send).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/commandHandling/process_messages.test.js
+++ b/__tests__/botactions/commandHandling/process_messages.test.js
@@ -1,0 +1,43 @@
+jest.mock('../../../messages.json', () => ({
+  words: {
+    hello: { action: 'respond', response: 'hi there' },
+    bad: { action: 'delete', response: 'nope' }
+  },
+  regex: {}
+}), { virtual: true });
+
+const { process_messages } = require('../../../botactions/commandHandling/process_messages');
+
+describe('process_messages', () => {
+  let message;
+  beforeEach(() => {
+    message = {
+      content: 'hello friend',
+      author: { bot: false, username: 'u' },
+      channel: { name: 'gen', send: jest.fn() },
+      client: { channels: { cache: new Map([['1', { send: jest.fn(), isText: () => true, isTextBased: () => true, type: 0 }]]) } },
+      delete: jest.fn(),
+    };
+  });
+
+  test('responds when word action is respond', () => {
+    process_messages(message, true, '1');
+    expect(message.channel.send).toHaveBeenCalledWith('hi there');
+    expect(message.delete).not.toHaveBeenCalled();
+  });
+
+  test('deletes message when action is delete', () => {
+    message.content = 'bad word';
+    process_messages(message, true, '1');
+    const responseChannel = message.client.channels.cache.get('1');
+    expect(responseChannel.send).toHaveBeenCalled();
+    expect(message.delete).toHaveBeenCalled();
+  });
+
+  test('ignores bot messages', () => {
+    message.author.bot = true;
+    const result = process_messages(message, true, '1');
+    expect(result).toBe(false);
+    expect(message.channel.send).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/eventHandling/openaiHandler.test.js
+++ b/__tests__/botactions/eventHandling/openaiHandler.test.js
@@ -1,0 +1,35 @@
+jest.mock('../../../botactions/eventHandling/messageEvents/messageEvents/openaiHandler', () => jest.fn(), { virtual: true });
+jest.mock('../../../botactions/eventHandling/messageEvents/messageEvents/filterHandler', () => jest.fn(), { virtual: true });
+jest.mock('../../../botactions/eventHandling/messageEvents/messageEvents/logHandler', () => jest.fn(), { virtual: true });
+
+const handleOpenAI = require('../../../botactions/eventHandling/messageEvents/messageEvents/openaiHandler');
+const handleFiltering = require('../../../botactions/eventHandling/messageEvents/messageEvents/filterHandler');
+const logMessage = require('../../../botactions/eventHandling/messageEvents/messageEvents/logHandler');
+
+const { handleMessageCreate } = require('../../../botactions/eventHandling/messageEvents/openaiHandler');
+
+describe('openaiHandler handleMessageCreate', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('ignores bots and messages outside guild', async () => {
+    const message = { guild: null, author: { bot: false }, mentions: { has: jest.fn() } };
+    await handleMessageCreate(message, {});
+    expect(handleOpenAI).not.toHaveBeenCalled();
+    expect(logMessage).not.toHaveBeenCalled();
+  });
+
+  test('invokes handleOpenAI when bot mentioned', async () => {
+    const client = { user: {} };
+    const message = { guild: { id: '1' }, author: { bot: false }, mentions: { has: jest.fn(() => true) } };
+    await handleMessageCreate(message, client);
+    expect(handleOpenAI).toHaveBeenCalledWith(message, client);
+  });
+
+  test('logs and filters when not mentioned', async () => {
+    const client = { user: {} };
+    const message = { guild: { id: '1' }, author: { bot: false }, mentions: { has: jest.fn(() => false) } };
+    await handleMessageCreate(message, client);
+    expect(logMessage).toHaveBeenCalledWith(message, '1');
+    expect(handleFiltering).toHaveBeenCalledWith(message, client);
+  });
+});

--- a/__tests__/commands/admin/addsnapchannel.test.js
+++ b/__tests__/commands/admin/addsnapchannel.test.js
@@ -1,0 +1,41 @@
+const { execute } = require('../../../commands/admin/addsnapchannel');
+const { addSnapChannel } = require('../../../botactions/channelManagement/snapChannels');
+const { MessageFlags } = require('discord.js');
+
+jest.mock('../../../botactions/channelManagement/snapChannels', () => ({
+  addSnapChannel: jest.fn()
+}));
+
+describe('/addsnapchannel command', () => {
+  const makeInteraction = (roles = []) => ({
+    member: { roles: { cache: { map: fn => roles.map(r => fn({ name: r })) } } },
+    options: {
+      getChannel: jest.fn(() => ({ id: 'c1', name: 'chan' })),
+      getInteger: jest.fn(() => 7)
+    },
+    guild: { id: 'g1' },
+    reply: jest.fn()
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('rejects when user lacks role', async () => {
+    const interaction = makeInteraction(['Member']);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('permission'),
+      flags: MessageFlags.Ephemeral
+    });
+    expect(addSnapChannel).not.toHaveBeenCalled();
+  });
+
+  test('adds channel for authorized user', async () => {
+    const interaction = makeInteraction(['Admiral']);
+    await execute(interaction);
+    expect(addSnapChannel).toHaveBeenCalledWith('c1', 7, 'g1');
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Snap channel chan added'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+});

--- a/__tests__/commands/admin/lookupuser.test.js
+++ b/__tests__/commands/admin/lookupuser.test.js
@@ -1,0 +1,49 @@
+const { execute } = require('../../../commands/admin/lookupuser');
+const { MessageFlags } = require('discord.js');
+
+describe('/lookupuser command', () => {
+  const createInteraction = (guildFetchFn, userFetchFn) => ({
+    options: { getString: jest.fn(() => '123') },
+    guild: { members: { fetch: guildFetchFn } },
+    client: { users: { fetch: userFetchFn } },
+    reply: jest.fn()
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('replies with member info if found in guild', async () => {
+    const interaction = createInteraction(
+      jest.fn().mockResolvedValue({ displayName: 'Bob', user: { tag: 'Bob#1' } }),
+      jest.fn()
+    );
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Bob'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('falls back to global user lookup', async () => {
+    const interaction = createInteraction(
+      jest.fn().mockRejectedValue(new Error('nope')),
+      jest.fn().mockResolvedValue({ id: '123', tag: 'X#1' })
+    );
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('X#1'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('handles failure of both lookups', async () => {
+    const interaction = createInteraction(
+      jest.fn().mockRejectedValue(new Error('nope')),
+      jest.fn().mockRejectedValue(new Error('fail'))
+    );
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining("Couldn't fetch"),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+});

--- a/__tests__/commands/admin/syncapidata.test.js
+++ b/__tests__/commands/admin/syncapidata.test.js
@@ -1,0 +1,36 @@
+jest.mock('../../../botactions/userManagement/permissions', () => ({ isAdmin: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncApiData', () => ({ runFullApiSync: jest.fn() }));
+
+const { isAdmin } = require('../../../botactions/userManagement/permissions');
+const { runFullApiSync } = require('../../../utils/apiSync/syncApiData');
+const { execute } = require('../../../commands/admin/syncapidata');
+const { MessageFlags } = require('discord.js');
+
+describe('/syncapidata command', () => {
+  const makeInteraction = () => ({
+    deferReply: jest.fn(),
+    reply: jest.fn(),
+    member: {},
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('blocks non-admin users', async () => {
+    isAdmin.mockReturnValue(false);
+    const interaction = makeInteraction();
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('permission'),
+      flags: MessageFlags.Ephemeral
+    });
+    expect(runFullApiSync).not.toHaveBeenCalled();
+  });
+
+  test('runs full API sync for admins', async () => {
+    isAdmin.mockReturnValue(true);
+    const interaction = makeInteraction();
+    await execute(interaction);
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(runFullApiSync).toHaveBeenCalledWith(interaction);
+  });
+});

--- a/__tests__/models/voiceLog.test.js
+++ b/__tests__/models/voiceLog.test.js
@@ -1,0 +1,15 @@
+const defineVoiceLog = require('../../models/voiceLog');
+
+describe('VoiceLog model', () => {
+  test('defines fields and options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineVoiceLog(sequelize);
+    const [name, attrs] = define.mock.calls[0];
+    expect(name).toBe('VoiceLog');
+    expect(attrs).toHaveProperty('user_id');
+    expect(attrs).toHaveProperty('event_type');
+    expect(attrs).toHaveProperty('server_id');
+    expect(model).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- improve `discord.js` mock to support setDMPermission
- add tests for ambient engine tracking and posting
- cover message filtering logic
- test additional admin commands
- test OpenAI message handler
- add model coverage for VoiceLog

## Testing
- `npm test -- --coverage`