### PR TITLE
fix: fallback to lavalink config

### DIFF
--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const config = require('../../config/lavalink.json');
+
+describe('lavalink service config fallback', () => {
+  const originalEnv = { ...process.env };
+  let lavalink;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    delete global.fetch;
+  });
+
+  test('uses config file when env vars missing', async () => {
+    delete process.env.LAVALINK_HOST;
+    delete process.env.LAVALINK_PORT;
+    delete process.env.LAVALINK_PASSWORD;
+
+    lavalink = require('../../services/lavalink');
+    await lavalink.loadTrack('song');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `http://${config.host}:${config.port}/loadtracks?identifier=song`,
+      expect.objectContaining({ headers: { Authorization: config.password } })
+    );
+  });
+
+  test('uses environment variables when provided', async () => {
+    process.env.LAVALINK_HOST = 'envhost';
+    process.env.LAVALINK_PORT = '9999';
+    process.env.LAVALINK_PASSWORD = 'secret';
+
+    lavalink = require('../../services/lavalink');
+    await lavalink.loadTrack('track');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://envhost:9999/loadtracks?identifier=track',
+      expect.objectContaining({ headers: { Authorization: 'secret' } })
+    );
+  });
+});

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -1,6 +1,14 @@
-const host = process.env.LAVALINK_HOST;
-const port = process.env.LAVALINK_PORT;
-const password = process.env.LAVALINK_PASSWORD;
+const path = require('path');
+let config = {};
+try {
+  config = require(path.join(__dirname, '..', 'config', 'lavalink.json'));
+} catch {
+  // ignore if config file missing; env vars may still be set
+}
+
+const host = process.env.LAVALINK_HOST || config.host;
+const port = process.env.LAVALINK_PORT || config.port;
+const password = process.env.LAVALINK_PASSWORD || config.password;
 
 function buildUrl(path) {
   return `http://${host}:${port}${path}`;


### PR DESCRIPTION
## Summary
- read lavalink server info from `config/lavalink.json` if env vars are missing
- add unit tests for lavalink service covering env var and config scenarios

## Testing
- `npm test`