### PR TITLE
fix lavalink connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 ### Added
 - Initial music bot framework with Lavalink integration.
 - `/play` and `/queue` commands with basic queue management.
+- Graceful error handling when Lavalink is unreachable.

--- a/__tests__/commands/music/play.test.js
+++ b/__tests__/commands/music/play.test.js
@@ -18,4 +18,16 @@ describe('play command', () => {
     expect(audioManager.enqueue).toHaveBeenCalledWith('g1', 'test');
     expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Queued') }));
   });
+
+  test('handles enqueue failure', async () => {
+    const interaction = new MockInteraction({ options: { query: 'fail' }, guild: { id: 'g1' } });
+    jest.spyOn(interaction, 'deferReply');
+    jest.spyOn(interaction, 'editReply');
+    audioManager.enqueue.mockRejectedValue(new Error('bad'));
+
+    await play.execute(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining('❌'));
+  });
 });

--- a/__tests__/services/audioManager.test.js
+++ b/__tests__/services/audioManager.test.js
@@ -31,4 +31,11 @@ describe('audioManager', () => {
     expect(lavalink.stop).toHaveBeenCalledWith('guild');
     expect(audio.getQueue('guild')).toHaveLength(0);
   });
+
+  test('enqueue propagates errors', async () => {
+    lavalink.loadTrack.mockRejectedValue(new Error('fail'));
+    await expect(audio.enqueue('guild', 'bad')).rejects.toThrow('Failed to load track');
+    expect(audio.getQueue('guild')).toHaveLength(0);
+    expect(lavalink.play).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -42,4 +42,10 @@ describe('lavalink service config fallback', () => {
       expect.objectContaining({ headers: { Authorization: 'secret' } })
     );
   });
+
+  test('throws error when fetch fails', async () => {
+    global.fetch.mockRejectedValue(new Error('connect error'));
+    lavalink = require('../../services/lavalink');
+    await expect(lavalink.loadTrack('bad')).rejects.toThrow('Lavalink connection failed');
+  });
 });

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -15,7 +15,11 @@ module.exports = {
   async execute(interaction) {
     const query = interaction.options.getString('query');
     await interaction.deferReply({});
-    await audioManager.enqueue(interaction.guild.id, query);
-    await interaction.editReply({ content: `Queued: ${query}` });
+    try {
+      await audioManager.enqueue(interaction.guild.id, query);
+      await interaction.editReply({ content: `Queued: ${query}` });
+    } catch (err) {
+      await interaction.editReply(`❌ Failed to play track: ${err.message}`);
+    }
   }
 };

--- a/services/audioManager.js
+++ b/services/audioManager.js
@@ -11,7 +11,13 @@ function getQueue(guildId) {
 }
 
 async function enqueue(guildId, query) {
-  const data = await lavalink.loadTrack(query);
+  let data;
+  try {
+    data = await lavalink.loadTrack(query);
+  } catch (err) {
+    console.error('❌ Failed to load track:', err);
+    throw new Error('Failed to load track');
+  }
   const track = data.tracks ? data.tracks[0] : data;
   const queue = queues.get(guildId) || [];
   queue.push(track);

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -15,9 +15,14 @@ function buildUrl(path) {
 }
 
 async function loadTrack(query) {
-  const res = await fetch(buildUrl(`/loadtracks?identifier=${encodeURIComponent(query)}`), {
-    headers: { Authorization: password }
-  });
+  let res;
+  try {
+    res = await fetch(buildUrl(`/loadtracks?identifier=${encodeURIComponent(query)}`), {
+      headers: { Authorization: password }
+    });
+  } catch (err) {
+    throw new Error('Lavalink connection failed');
+  }
   if (!res.ok) throw new Error('Failed to load track');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- handle Lavalink connection failures gracefully
- propagate load errors through the audio manager
- report errors in the `/play` command
- add tests for Lavalink fetch failures and enqueue errors
- document change in CHANGELOG

## Testing
- `npm test`