### PR TITLE
fix: reduce lavalink error stack

### DIFF
--- a/__tests__/services/audioManager.test.js
+++ b/__tests__/services/audioManager.test.js
@@ -34,8 +34,11 @@ describe('audioManager', () => {
 
   test('enqueue propagates errors', async () => {
     lavalink.loadTrack.mockRejectedValue(new Error('fail'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     await expect(audio.enqueue('guild', 'bad')).rejects.toThrow('Failed to load track');
     expect(audio.getQueue('guild')).toHaveLength(0);
     expect(lavalink.play).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith('❌ Failed to load track:', 'fail');
+    errSpy.mockRestore();
   });
 });

--- a/services/audioManager.js
+++ b/services/audioManager.js
@@ -15,7 +15,7 @@ async function enqueue(guildId, query) {
   try {
     data = await lavalink.loadTrack(query);
   } catch (err) {
-    console.error('❌ Failed to load track:', err);
+    console.error('❌ Failed to load track:', err.message);
     throw new Error('Failed to load track');
   }
   const track = data.tracks ? data.tracks[0] : data;


### PR DESCRIPTION
## Summary
- reduce lavalink error stack logging
- test console.error output for enqueue failures

## Testing
- `npm test`