### PR TITLE
feat: allow bot to spawn local Lavalink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - `/play` and `/queue` commands with basic queue management.
 - Graceful error handling when Lavalink is unreachable.
 - Lavalink service now falls back to `node-fetch` when `fetch` is not available.
+- Optional local Lavalink spawning with `SPAWN_LOCAL_LAVALINK` env var.


### PR DESCRIPTION
## Summary
- spawn optional local Lavalink when `SPAWN_LOCAL_LAVALINK` is set
- export `spawnLavalink` function from `services/lavalink.js`
- add test coverage for Lavalink spawning
- document the new environment variable in CHANGELOG
- add placeholder `lavalink` folder

## Testing
- `npm test`