### PR TITLE
Fix lavalink spawn test path

### DIFF
--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -88,7 +88,11 @@ describe('lavalink local spawning', () => {
     require('../../services/lavalink');
     expect(spawnMock).toHaveBeenCalledWith(
       'java',
-      ['-Xmx512M', '-jar', expect.stringContaining('lavalink/Lavalink.jar')],
+      [
+        '-Xmx512M',
+        '-jar',
+        expect.stringContaining(path.join('lavalink', 'Lavalink.jar')),
+      ],
       expect.objectContaining({ cwd: expect.stringContaining('lavalink'), detached: true })
     );
   });


### PR DESCRIPTION
## Summary
- adjust lavalink spawn test to use `path.join`

## Testing
- `npm test`