### PR TITLE
feat(lavalink): add readiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Graceful error handling when Lavalink is unreachable.
 - Lavalink service now falls back to `node-fetch` when `fetch` is not available.
 - Optional local Lavalink spawning with `SPAWN_LOCAL_LAVALINK` env var.
+- Startup now verifies Lavalink becomes reachable and logs readiness.


### PR DESCRIPTION
## Summary
- log Lavalink startup
- add `waitForLavalink` to verify connection via `/version`
- test readiness function and update spawn tests
- document startup verification in changelog

## Testing
- `npm test`