### PR TITLE
Fix Lavalink startup wait and config port

### DIFF
--- a/config/lavalink.json
+++ b/config/lavalink.json
@@ -1,5 +1,5 @@
 {
   "host": "localhost",
-  "port": 2333,
+  "port": 8080,
   "password": "youshallnotpass"
 }

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -45,7 +45,7 @@ function spawnLavalink() {
   return lavalinkProcess;
 }
 
-async function waitForLavalink(retries = 5, delayMs = 1000) {
+async function waitForLavalink(retries = 15, delayMs = 2000) {
   let lastError;
   for (let i = 0; i < retries; i++) {
     const url = buildUrl('/version');


### PR DESCRIPTION
## Summary
- update Lavalink default port in `config/lavalink.json`
- extend the retry logic in `waitForLavalink`

## Testing
- `npm test`