### PR TITLE
Fix music search and Spotify token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@
 - Lavalink service now falls back to `node-fetch` when `fetch` is not available.
 - Optional local Lavalink spawning with `SPAWN_LOCAL_LAVALINK` env var.
 - Startup now verifies Lavalink becomes reachable and logs readiness.
+- Fallback YouTube search for text queries in `/play`.
+- Spotify service now refreshes tokens on 401 responses.

--- a/__tests__/services/audioManager.test.js
+++ b/__tests__/services/audioManager.test.js
@@ -19,7 +19,8 @@ describe('audioManager', () => {
 
   test('enqueue loads and plays when queue empty', async () => {
     await audio.enqueue('guild', 'query');
-    expect(lavalink.loadTrack).toHaveBeenCalledWith('query');
+    expect(youtube.search).toHaveBeenCalledWith('query');
+    expect(lavalink.loadTrack).toHaveBeenCalledWith('yturl');
     expect(lavalink.play).toHaveBeenCalledWith('guild', 't1');
     expect(audio.getQueue('guild')).toHaveLength(1);
   });
@@ -43,6 +44,7 @@ describe('audioManager', () => {
     lavalink.loadTrack.mockRejectedValue(new Error('fail'));
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     await expect(audio.enqueue('guild', 'bad')).rejects.toThrow('Failed to load track');
+    expect(youtube.search).toHaveBeenCalledWith('bad');
     expect(audio.getQueue('guild')).toHaveLength(0);
     expect(lavalink.play).not.toHaveBeenCalled();
     expect(errSpy).toHaveBeenCalledWith('❌ Failed to load track:', 'fail');
@@ -75,5 +77,11 @@ describe('audioManager', () => {
     expect(youtube.search).toHaveBeenCalledWith('Solo Artist');
     expect(lavalink.loadTrack).toHaveBeenCalledWith('yt');
     expect(lavalink.play).toHaveBeenCalledWith('id', 't1');
+  });
+
+  test('uses query directly when URL provided', async () => {
+    await audio.enqueue('id', 'https://youtube.com/watch?v=123');
+    expect(youtube.search).not.toHaveBeenCalled();
+    expect(lavalink.loadTrack).toHaveBeenCalledWith('https://youtube.com/watch?v=123');
   });
 });

--- a/__tests__/services/spotify.test.js
+++ b/__tests__/services/spotify.test.js
@@ -1,0 +1,42 @@
+const spotifyPath = '../../services/spotify';
+
+describe('spotify service', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('retries auth when unauthorized', async () => {
+    const mockJson = jest.fn().mockResolvedValue({ items: [] });
+    global.fetch = jest
+      .fn()
+      // initial token fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 't1' }) })
+      // first playlist request unauthorized
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      // refresh token
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 't2' }) })
+      // successful playlist request
+      .mockResolvedValueOnce({ ok: true, json: mockJson });
+    const spotify = require(spotifyPath);
+    spotify._resetAuth();
+    await spotify.getPlaylistTracks('id');
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  test('returns data on success', async () => {
+    const data = { items: [1] };
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 't1' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => data });
+    const spotify = require(spotifyPath);
+    spotify._resetAuth();
+    const res = await spotify.getPlaylistTracks('id');
+    expect(res).toEqual(data);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/audioManager.js
+++ b/services/audioManager.js
@@ -32,6 +32,15 @@ async function enqueue(guildId, query) {
   queues.set(guildId, queue);
 }
 
+function isUrl(str) {
+  try {
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function resolveQuery(query) {
   if (query.includes('open.spotify.com/')) {
     try {
@@ -54,6 +63,14 @@ async function resolveQuery(query) {
       }
     } catch (err) {
       console.error('❌ Failed to process Spotify query:', err.message);
+      throw new Error('Failed to load track');
+    }
+  }
+  if (!isUrl(query)) {
+    try {
+      return [await youtube.search(query)];
+    } catch (err) {
+      console.error('❌ Failed to search YouTube:', err.message);
       throw new Error('Failed to load track');
     }
   }

--- a/services/spotify.js
+++ b/services/spotify.js
@@ -16,29 +16,31 @@ async function auth() {
   return token;
 }
 
+async function fetchSpotify(url) {
+  let tk = await auth();
+  let res = await fetch(url, { headers: { Authorization: `Bearer ${tk}` } });
+  if (!res.ok && res.status === 401) {
+    token = null;
+    tk = await auth();
+    res = await fetch(url, { headers: { Authorization: `Bearer ${tk}` } });
+  }
+  return res;
+}
+
 async function searchTrack(query) {
-  const tk = await auth();
-  const res = await fetch(`https://api.spotify.com/v1/search?type=track&limit=1&q=${encodeURIComponent(query)}`, {
-    headers: { Authorization: `Bearer ${tk}` }
-  });
+  const res = await fetchSpotify(`https://api.spotify.com/v1/search?type=track&limit=1&q=${encodeURIComponent(query)}`);
   if (!res.ok) throw new Error('Spotify search failed');
   return res.json();
 }
 
 async function getPlaylistTracks(id) {
-  const tk = await auth();
-  const res = await fetch(`https://api.spotify.com/v1/playlists/${id}/tracks`, {
-    headers: { Authorization: `Bearer ${tk}` }
-  });
+  const res = await fetchSpotify(`https://api.spotify.com/v1/playlists/${id}/tracks`);
   if (!res.ok) throw new Error('Spotify playlist fetch failed');
   return res.json();
 }
 
 async function getTrack(id) {
-  const tk = await auth();
-  const res = await fetch(`https://api.spotify.com/v1/tracks/${id}`, {
-    headers: { Authorization: `Bearer ${tk}` }
-  });
+  const res = await fetchSpotify(`https://api.spotify.com/v1/tracks/${id}`);
   if (!res.ok) throw new Error('Spotify track fetch failed');
   return res.json();
 }


### PR DESCRIPTION
## Summary
- fall back to YouTube search for plain `/play` queries
- refresh Spotify access token on 401 and add tests
- adjust audioManager tests
- add Spotify service tests
- update changelog

## Testing
- `npm test`