### PR TITLE
Fix Lavalink v4 path

### DIFF
--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -25,7 +25,7 @@ describe('lavalink service config fallback', () => {
     await lavalink.loadTrack('song');
 
     expect(global.fetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/loadtracks?identifier=song`,
+      `http://${config.host}:${config.port}/v4/loadtracks?identifier=song`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
   });
@@ -39,7 +39,7 @@ describe('lavalink service config fallback', () => {
     await lavalink.loadTrack('track');
 
     expect(global.fetch).toHaveBeenCalledWith(
-      'http://envhost:9999/loadtracks?identifier=track',
+      'http://envhost:9999/v4/loadtracks?identifier=track',
       expect.objectContaining({ headers: { Authorization: 'secret' } })
     );
   });
@@ -78,7 +78,7 @@ describe('lavalink service config fallback', () => {
     await lavalink.loadTrack('song');
 
     expect(nodeFetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/loadtracks?identifier=song`,
+      `http://${config.host}:${config.port}/v4/loadtracks?identifier=song`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
 
@@ -116,7 +116,7 @@ describe('lavalink local spawning', () => {
       expect.objectContaining({ cwd: expect.stringContaining('lavalink'), detached: true })
     );
     expect(global.fetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/version`,
+      `http://${config.host}:${config.port}/v4/version`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
   });
@@ -136,7 +136,7 @@ describe('waitForLavalink', () => {
     const { waitForLavalink } = require('../../services/lavalink');
     await expect(waitForLavalink(1, 0)).resolves.toBeUndefined();
     expect(global.fetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/version`,
+      `http://${config.host}:${config.port}/v4/version`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
   });

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -14,6 +14,7 @@ try {
 const host = process.env.LAVALINK_HOST || config.host;
 const port = process.env.LAVALINK_PORT || config.port;
 const password = process.env.LAVALINK_PASSWORD || config.password;
+const apiPrefix = process.env.LAVALINK_API_PREFIX || '/v4';
 
 let lavalinkProcess;
 
@@ -78,7 +79,7 @@ if (process.env.SPAWN_LOCAL_LAVALINK === 'true') {
 }
 
 function buildUrl(path) {
-  return `http://${host}:${port}${path}`;
+  return `http://${host}:${port}${apiPrefix}${path}`;
 }
 
 async function loadTrack(query) {


### PR DESCRIPTION
## Notes
- use `/v4` path prefix when calling Lavalink REST
- update lavalink tests to match v4 routes

## Testing
- `npm test`