### PR TITLE
Fix Lavalink YouTube search URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Spotify service now refreshes tokens on 401 responses.
 ### Fixed
 - Music bot now joins the user's voice channel before queuing tracks.
+- YouTube search returns stable video URLs for Lavalink metadata.

--- a/__tests__/services/youtube.test.js
+++ b/__tests__/services/youtube.test.js
@@ -1,0 +1,30 @@
+const path = '../../services/youtube';
+
+describe('youtube service', () => {
+  let execFile;
+  beforeEach(() => {
+    jest.resetModules();
+    execFile = jest.fn();
+    jest.doMock('child_process', () => ({ execFile }));
+  });
+
+  afterEach(() => {
+    jest.dontMock('child_process');
+  });
+
+  test('returns webpage url from yt-dlp output', async () => {
+    const json = JSON.stringify({ webpage_url: 'https://yt/watch?v=1', url: 'https://cdn.example/v=1' });
+    execFile.mockImplementation((cmd, args, cb) => cb(null, json));
+    const youtube = require(path);
+    const res = await youtube.search('test');
+    expect(execFile).toHaveBeenCalledWith(expect.any(String), ['-j', 'ytsearch1:test'], expect.any(Function));
+    expect(res).toBe('https://yt/watch?v=1');
+  });
+
+  test('rejects on exec error', async () => {
+    const err = new Error('fail');
+    execFile.mockImplementation((cmd, args, cb) => cb(err));
+    const youtube = require(path);
+    await expect(youtube.search('bad')).rejects.toThrow(err);
+  });
+});

--- a/services/youtube.js
+++ b/services/youtube.js
@@ -12,8 +12,9 @@ function search(query) {
       }
       try {
         const info = JSON.parse(stdout.trim());
-        debugLog('yt-dlp returned url:', info.url);
-        resolve(info.url); // direct URL
+        const pageUrl = info.webpage_url || info.url;
+        debugLog('yt-dlp returned url:', pageUrl);
+        resolve(pageUrl); // use stable webpage URL
       } catch (e) {
         debugLog('Failed to parse yt-dlp output');
         reject(e);


### PR DESCRIPTION
## Summary
- resolve yt-dlp results to webpage URLs
- test youtube service output and error path
- document fix in CHANGELOG

## Testing
- `npm test`