### PR TITLE
fix: correct Lavalink version endpoint

### DIFF
--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -116,7 +116,7 @@ describe('lavalink local spawning', () => {
       expect.objectContaining({ cwd: expect.stringContaining('lavalink'), detached: true })
     );
     expect(global.fetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/v4/version`,
+      `http://${config.host}:${config.port}/version`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
   });
@@ -136,7 +136,7 @@ describe('waitForLavalink', () => {
     const { waitForLavalink } = require('../../services/lavalink');
     await expect(waitForLavalink(1, 0)).resolves.toBeUndefined();
     expect(global.fetch).toHaveBeenCalledWith(
-      `http://${config.host}:${config.port}/v4/version`,
+      `http://${config.host}:${config.port}/version`,
       expect.objectContaining({ headers: { Authorization: config.password } })
     );
   });

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -50,7 +50,7 @@ function spawnLavalink() {
 async function waitForLavalink(retries = 15, delayMs = 2000) {
   let lastError;
   for (let i = 0; i < retries; i++) {
-    const url = buildUrl('/version');
+    const url = buildUrl('/version', true);
     try {
       const res = await fetchFn(url, {
         headers: { Authorization: password }
@@ -78,8 +78,8 @@ if (process.env.SPAWN_LOCAL_LAVALINK === 'true') {
   waitForLavalink().catch(() => {});
 }
 
-function buildUrl(path) {
-  return `http://${host}:${port}${apiPrefix}${path}`;
+function buildUrl(path, noPrefix = false) {
+  return `http://${host}:${port}${noPrefix ? '' : apiPrefix}${path}`;
 }
 
 async function loadTrack(query) {


### PR DESCRIPTION
## Summary
- adjust Lavalink wait routine to call `/version` without the API prefix
- update tests accordingly

## Testing
- `npm test`