### PR TITLE
Fix Lavalink load failures

### DIFF
--- a/__tests__/services/lavalink.test.js
+++ b/__tests__/services/lavalink.test.js
@@ -84,6 +84,20 @@ describe('lavalink service config fallback', () => {
 
     jest.dontMock('node-fetch');
   });
+
+  test('throws when loadType is LOAD_FAILED', async () => {
+    global.fetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ loadType: 'LOAD_FAILED' }) });
+    lavalink = require('../../services/lavalink');
+    await expect(lavalink.loadTrack('bad'))
+      .rejects.toThrow('Failed to load track');
+  });
+
+  test('throws when loadType is NO_MATCHES', async () => {
+    global.fetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ loadType: 'NO_MATCHES' }) });
+    lavalink = require('../../services/lavalink');
+    await expect(lavalink.loadTrack('bad'))
+      .rejects.toThrow('Failed to load track');
+  });
 });
 
 describe('lavalink local spawning', () => {

--- a/services/lavalink.js
+++ b/services/lavalink.js
@@ -99,7 +99,12 @@ async function loadTrack(query) {
     throw new Error('Failed to load track');
   }
   debugLog('Lavalink loadTrack status:', res.status);
-  return res.json();
+  const data = await res.json();
+  if (data.loadType === 'LOAD_FAILED' || data.loadType === 'NO_MATCHES') {
+    console.error('⚠️ Lavalink returned loadType', data.loadType);
+    throw new Error('Failed to load track');
+  }
+  return data;
 }
 
 async function play(guildId, track) {


### PR DESCRIPTION
## Summary
- check Lavalink `loadType` after fetching tracks
- treat `LOAD_FAILED` or `NO_MATCHES` as errors
- add unit tests for the new failure cases

## Testing
- `npm test`