### PR TITLE
Improve trade command tests

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -141,6 +141,16 @@ const SlashCommandBuilder = jest.fn(() => {
       this.options.push(option);
       return this;
     },
+    addIntegerOption(fn) {
+      const option = { type: 'integer', name: undefined, description: undefined, required: false };
+      fn({
+        setName(name) { option.name = name; return this; },
+        setDescription(desc) { option.description = desc; return this; },
+        setRequired(req) { option.required = req; return this; },
+      });
+      this.options.push(option);
+      return this;
+    },
     addUserOption(fn) {
       const option = { type: 'user', name: undefined, description: undefined, required: false };
       fn({
@@ -179,6 +189,7 @@ module.exports = {
   StringSelectMenuBuilder,
   ButtonStyle,
   SlashCommandBuilder,
+  SlashCommandSubcommandBuilder: SlashCommandBuilder,
   EmbedBuilder,
   PermissionFlagsBits
 };

--- a/__tests__/commands/tools/trade/circuit.test.js
+++ b/__tests__/commands/tools/trade/circuit.test.js
@@ -15,4 +15,14 @@ describe('/trade circuit subcommand', () => {
     await command.execute(interaction);
     expect(handleTradeBestCircuit).toHaveBeenCalledWith(interaction);
   });
+
+  test('defines command data with options', () => {
+    const data = command.data();
+    const optionNames = data.options.map(o => o.name);
+    expect(data.name).toBe('circuit');
+    expect(optionNames).toEqual(['from', 'with', 'cash']);
+    const cashOpt = data.options.find(o => o.name === 'cash');
+    expect(cashOpt.type).toBe('integer');
+    expect(data.options.find(o => o.name === 'from').required).toBe(true);
+  });
 });

--- a/__tests__/commands/tools/trade/commodities.test.js
+++ b/__tests__/commands/tools/trade/commodities.test.js
@@ -16,6 +16,13 @@ describe('/trade commodities subcommand', () => {
     expect(handleTradeCommodities).toHaveBeenCalledWith(interaction);
   });
 
+  test('defines command data with location option', () => {
+    const data = command.data();
+    expect(data.name).toBe('commodities');
+    expect(data.options).toHaveLength(1);
+    expect(data.options[0]).toEqual(expect.objectContaining({ name: 'location', required: true }));
+  });
+
   test('button interaction defers update and calls handler with page', async () => {
     const btn = {
       customId: 'trade_commodities_page::Area18::2',
@@ -26,5 +33,12 @@ describe('/trade commodities subcommand', () => {
 
     expect(btn.deferUpdate).toHaveBeenCalled();
     expect(handleTradeCommodities).toHaveBeenCalledWith(btn, { location: 'Area18', page: 2 });
+  });
+
+  test('ignores unrelated button customId', async () => {
+    const btn = { customId: 'other', deferUpdate: jest.fn() };
+    await command.button(btn);
+    expect(btn.deferUpdate).not.toHaveBeenCalled();
+    expect(handleTradeCommodities).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/commands/tools/trade/find.test.js
+++ b/__tests__/commands/tools/trade/find.test.js
@@ -15,4 +15,12 @@ describe('/trade find subcommand', () => {
     await command.execute(interaction);
     expect(handleTradeFind).toHaveBeenCalledWith(interaction);
   });
+
+  test('defines command data with from/to options', () => {
+    const data = command.data();
+    const names = data.options.map(o => o.name);
+    expect(data.name).toBe('find');
+    expect(names).toEqual(['from', 'to']);
+    data.options.forEach(opt => expect(opt.required).toBe(true));
+  });
 });

--- a/__tests__/commands/tools/trade/price.test.js
+++ b/__tests__/commands/tools/trade/price.test.js
@@ -15,4 +15,13 @@ describe('/trade price subcommand', () => {
     await command.execute(interaction);
     expect(handleTradePrice).toHaveBeenCalledWith(interaction);
   });
+
+  test('defines command data with commodity/location options', () => {
+    const data = command.data();
+    expect(data.name).toBe('price');
+    const commodity = data.options.find(o => o.name === 'commodity');
+    const location = data.options.find(o => o.name === 'location');
+    expect(commodity.required).toBe(true);
+    expect(location.required).toBe(false);
+  });
 });

--- a/__tests__/commands/tools/trade/route.test.js
+++ b/__tests__/commands/tools/trade/route.test.js
@@ -15,4 +15,11 @@ describe('/trade route subcommand', () => {
     await command.execute(interaction, {});
     expect(handleTradeRoute).toHaveBeenCalledWith(interaction, {}, { from: 'A', to: 'B' });
   });
+
+  test('defines command data with required options', () => {
+    const data = command.data();
+    const names = data.options.map(o => o.name);
+    expect(names).toEqual(['from', 'to']);
+    data.options.forEach(opt => expect(opt.required).toBe(true));
+  });
 });


### PR DESCRIPTION
## Notes
- Added SlashCommandSubcommandBuilder alias and integer option support in the Discord mock so subcommand builders can be constructed in tests.
- Expanded tests for trade command modules to verify command definitions and negative paths.

## Summary
- stub `addIntegerOption` and `SlashCommandSubcommandBuilder` in `__mocks__/discord.js`
- extend `/trade` command tests to check builder options and button handling

## Testing
- `npm test`