### PR TITLE
Improve test branch coverage

### DIFF
--- a/__tests__/botactions/orgTagSync/syncCooldownTracker.test.js
+++ b/__tests__/botactions/orgTagSync/syncCooldownTracker.test.js
@@ -29,4 +29,10 @@ describe('Manual Sync Cooldown Logic', () => {
     markManualSyncRun(0);
     expect(canRunManualSync(30 * 60 * 1000)).toBe(false); // Not enough time
   });
+
+  test('uses default timestamps when args omitted', () => {
+    expect(canRunManualSync()).toBe(true);
+    markManualSyncRun();
+    expect(typeof canRunManualSync()).toBe('boolean');
+  });
 });

--- a/__tests__/utils/parseDice.test.js
+++ b/__tests__/utils/parseDice.test.js
@@ -18,4 +18,18 @@ describe('parseDice', () => {
     expect(() => parseDice('101d6')).toThrow('Too many dice or sides');
     expect(() => parseDice('1d1001')).toThrow('Too many dice or sides');
   });
+
+  test('supports keep highest modifier', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.2).mockReturnValueOnce(0.6);
+    const result = parseDice('2d6kh1');
+    expect(result.rolls.filter(r => r.includes('**'))).toHaveLength(1);
+    Math.random.mockRestore();
+  });
+
+  test('handles numeric modifier', () => {
+    jest.spyOn(Math, 'random').mockReturnValueOnce(0.5);
+    const result = parseDice('1d6-1');
+    expect(typeof result.total).toBe('number');
+    Math.random.mockRestore();
+  });
 });

--- a/__tests__/utils/trade/handlers/find.test.js
+++ b/__tests__/utils/trade/handlers/find.test.js
@@ -54,4 +54,11 @@ describe('handleTradeFind', () => {
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No trades found'));
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  test('handles query errors gracefully', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getSellOptionsAtLocation.mockRejectedValue(new Error('fail'));
+    await handleTradeFind(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
+  });
 });

--- a/__tests__/utils/trade/handlers/ship.test.js
+++ b/__tests__/utils/trade/handlers/ship.test.js
@@ -47,4 +47,11 @@ describe('handleTradeShip', () => {
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('not found'));
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  test('handles lookup errors gracefully', async () => {
+    const interaction = new MockInteraction({ options: { name: 'Cutlass' } });
+    getVehicleByName.mockRejectedValue(new Error('db'));
+    await handleTradeShip(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
+  });
 });

--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -75,6 +75,12 @@ const {
       expect(result.data.footer.text).toContain('Page 1 of 1');
     });
 
+    test('buildCommoditiesEmbed uses default paging', () => {
+      const data = [{ terminal: 'T1', commodities: [] }];
+      const embed = buildCommoditiesEmbed('Area18', data);
+      expect(embed.data.footer.text).toContain('Page 1');
+    });
+
     test('buildCommoditiesEmbed truncates long field values', () => {
       const longList = Array.from({ length: 300 }, (_, i) => ({
         name: `Item${i}`,


### PR DESCRIPTION
## Summary
- extend cooldown tracker tests for default param path
- add error path checks for trade find and ship handlers
- cover additional modifiers in parseDice tests
- verify default paging in tradeEmbeds

## Testing
- `npm test`
- `npm test -- --coverage`