### PR TITLE
Improve scheduler.js coverage

### DIFF
--- a/__tests__/jobs/scheduler.test.js
+++ b/__tests__/jobs/scheduler.test.js
@@ -36,5 +36,51 @@ describe('scheduleDailyApiSync', () => {
     expect(runFullApiSync).toHaveBeenCalledTimes(1);
     expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 24 * 60 * 60 * 1000);
   });
+
+  test('schedules API sync later the same day when future time', async () => {
+    const baseTime = new Date('2023-01-01T03:00:00.000Z');
+    jest.useFakeTimers();
+    jest.setSystemTime(baseTime);
+    jest.spyOn(global, 'setTimeout');
+    jest.spyOn(global, 'setInterval');
+
+    scheduleDailyApiSync(4, 0);
+
+    const now = new Date(baseTime);
+    const next = new Date(baseTime);
+    next.setUTCHours(4, 0, 0, 0);
+    if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+    const expectedDelay = next - now;
+
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), expectedDelay);
+
+    await jest.advanceTimersByTimeAsync(expectedDelay);
+    await Promise.resolve();
+
+    expect(runFullApiSync).toHaveBeenCalledTimes(1);
+    expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 24 * 60 * 60 * 1000);
+  });
+
+  test('logs an error when runFullApiSync fails', async () => {
+    const baseTime = new Date('2023-01-01T03:59:30.000Z');
+    jest.useFakeTimers();
+    jest.setSystemTime(baseTime);
+    runFullApiSync.mockRejectedValueOnce(new Error('fail'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    scheduleDailyApiSync(); // uses defaults of 4:00
+
+    const now = new Date(baseTime);
+    const next = new Date(baseTime);
+    next.setUTCHours(4, 0, 0, 0);
+    if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+    const expectedDelay = next - now;
+
+    await jest.advanceTimersByTimeAsync(expectedDelay);
+    await Promise.resolve();
+
+    expect(runFullApiSync).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('❌ API sync failed:', expect.any(Error));
+  });
 });
 


### PR DESCRIPTION
## Summary
- expand scheduler job tests to cover additional branches

## Testing
- `npm test -- --coverage`