### PR TITLE
Capture console errors during scheduled events tests

### DIFF
--- a/__tests__/botactions/scheduledEventsHandler.test.js
+++ b/__tests__/botactions/scheduledEventsHandler.test.js
@@ -177,7 +177,10 @@ jest.mock('../../config/database', () => ({
 
       it('throws when fetch fails', async () => {
         mockGuild.scheduledEvents.fetch.mockRejectedValue(new Error('fail'));
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         await expect(getAllScheduledEventsFromClient(mockClient)).rejects.toThrow('There was an error fetching the events.');
+        expect(consoleSpy).toHaveBeenCalled();
+        consoleSpy.mockRestore();
       });
     });
 


### PR DESCRIPTION
## Summary
- intercept console.error when scheduled events fetch fails

## Testing
- `npm test`