### PR TITLE
Add coinflip tests and update coverage plan

### DIFF
--- a/TEST_COVERAGE_TODO.md
+++ b/TEST_COVERAGE_TODO.md
@@ -2,15 +2,17 @@
 
 This document summarises tasks required to raise Jest coverage to **100%** across all modules.
 
+## Progress as of 2025-05-29
+Current overall coverage around 96% line coverage. Tests now exist for ambientEngine, utilityFunctions, admin commands, process_messages, openaiHandler and many trade handlers. Remaining gaps include fun commands, several tool commands, and most models.
+
 ## 1. Create Test Modules for Untested Files
-- Add a Jest test file for every JavaScript module currently lacking tests. Examples include:
-  - `botactions/ambient/ambientEngine.js`
-  - `botactions/utilityFunctions.js` ✅ (helpers like `formatTime` and async fetch utilities)
-  - Admin commands such as `addsnapchannel.js`, `lookupuser.js`, and `syncapidata.js`
-  - Fun commands like `coinflip.js`, `highcard.js`, and `roll.js`
-  - Tool commands (`help.js`, `shipdetails.js`, `uexvehicle.js`)
-  - All model definitions under `models/`
-  - Additional botaction handlers (e.g. `process_messages.js`, `openaiHandler.js`)
+- [x] `botactions/ambient/ambientEngine.js`
+- [x] `botactions/utilityFunctions.js` (helpers like `formatTime` and async fetch utilities)
+- [x] Admin commands such as `addsnapchannel.js`, `lookupuser.js`, and `syncapidata.js`
+- [ ] Fun commands like `coinflip.js`, `highcard.js`, and `roll.js`
+- [ ] Tool commands (`help.js`, `shipdetails.js`, `uexvehicle.js`)
+- [ ] All model definitions under `models/`
+- [x] Additional botaction handlers (e.g. `process_messages.js`, `openaiHandler.js`)
 
 ## 2. Expand Tests for Partially Covered Modules
 - Increase branch and line coverage for modules already tested but below 100% such as:

--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -161,6 +161,38 @@ const SlashCommandBuilder = jest.fn(() => {
       this.options.push(option);
       return this;
     },
+    addSubcommand(fn) {
+      const sub = { type: 'subcommand', name: undefined, description: undefined, options: [] };
+      const subBuilder = {
+        setName(name) { sub.name = name; return this; },
+        setDescription(desc) { sub.description = desc; return this; },
+        addUserOption(userFn) {
+          const opt = { type: 'user', name: undefined, description: undefined, required: false };
+          userFn({
+            setName(n) { opt.name = n; return this; },
+            setDescription(d) { opt.description = d; return this; },
+            setRequired(r) { opt.required = r; return this; },
+            addChoices: jest.fn()
+          });
+          sub.options.push(opt);
+          return this;
+        },
+        addStringOption(strFn) {
+          const opt = { type: 'string', name: undefined, description: undefined, required: false };
+          strFn({
+            setName(n) { opt.name = n; return this; },
+            setDescription(d) { opt.description = d; return this; },
+            setRequired(r) { opt.required = r; return this; },
+            addChoices: jest.fn()
+          });
+          sub.options.push(opt);
+          return this;
+        }
+      };
+      fn(subBuilder);
+      this.options.push(sub);
+      return this;
+    },
     addRoleOption(fn) {
       const option = { type: 'role', name: undefined, description: undefined, required: false };
       fn({

--- a/__tests__/commands/fun/coinflip.test.js
+++ b/__tests__/commands/fun/coinflip.test.js
@@ -1,0 +1,106 @@
+const coinflip = require('../../../commands/fun/coinflip');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+jest.useFakeTimers();
+
+const makeGuild = (hasTesterRole = false) => {
+  const challengerMember = {
+    displayName: 'Challenger',
+    roles: { cache: { has: jest.fn(() => hasTesterRole) } },
+  };
+  const opponentMember = {
+    displayName: 'Opponent',
+    roles: { cache: { has: jest.fn() } },
+  };
+  return {
+    members: {
+      fetch: jest.fn(id => (id === 'challenger' ? challengerMember : opponentMember)),
+    },
+    roles: {
+      cache: {
+        find: jest.fn(fn => (fn({ name: 'Fleet Admiral' }) ? { id: 'fa', name: 'Fleet Admiral' } : undefined)),
+      },
+    },
+  };
+};
+
+const makeChallengeInteraction = ({ self = false, hasTesterRole = false } = {}) => {
+  const user = { id: 'challenger' };
+  const opponent = { id: self ? 'challenger' : 'opponent' };
+  return {
+    user,
+    options: {
+      getSubcommand: jest.fn(() => 'challenge'),
+      getUser: jest.fn(() => opponent),
+    },
+    guild: makeGuild(hasTesterRole),
+    reply: jest.fn(),
+  };
+};
+
+const makeCallInteraction = (choice) => {
+  return {
+    user: { id: 'opponent' },
+    options: {
+      getSubcommand: jest.fn(() => 'call'),
+      getString: jest.fn(() => choice),
+    },
+    guild: makeGuild(),
+    client: { users: { fetch: jest.fn(() => ({ id: 'challenger' })) } },
+    reply: jest.fn(),
+  };
+};
+
+describe('/coinflip command', () => {
+  let originalRandom;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalRandom = Math.random;
+    Math.random = jest.fn(() => 0); // always heads
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    jest.useRealTimers();
+  });
+
+  test('rejects self challenge without role', async () => {
+    const interaction = makeChallengeInteraction({ self: true });
+    await coinflip.execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('challenge yourself'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  test('handles challenge and call flow', async () => {
+    const challenge = makeChallengeInteraction();
+    await coinflip.execute(challenge);
+    expect(challenge.reply).toHaveBeenCalledWith(expect.stringContaining('has challenged'));
+
+    const call = makeCallInteraction('heads');
+    await coinflip.execute(call);
+    expect(call.reply.mock.calls[0][0].embeds[0].toJSON().description).toContain('wins the toss');
+
+    // second call after challenge resolved
+    call.reply.mockClear();
+    await coinflip.execute(call);
+    expect(call.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('no pending coin flip'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  test('challenge expires after timeout', async () => {
+    const challenge = makeChallengeInteraction();
+    await coinflip.execute(challenge);
+    jest.advanceTimersByTime(2 * 60 * 1000);
+
+    const call = makeCallInteraction('heads');
+    await coinflip.execute(call);
+    expect(call.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('no pending coin flip'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+});

--- a/__tests__/models/galactapediaEntry.test.js
+++ b/__tests__/models/galactapediaEntry.test.js
@@ -1,0 +1,16 @@
+const defineModel = require('../../models/galactapediaEntry');
+
+describe('GalactapediaEntry model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('GalactapediaEntry');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs).toHaveProperty('title');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- document coverage progress in TEST_COVERAGE_TODO.md
- extend SlashCommandBuilder mock with `addSubcommand`
- add tests for the `/coinflip` command
- add model test for `galactapediaEntry`

## Testing
- `npm test -- --coverage`