### PR TITLE
Suppress console errors in tests

### DIFF
--- a/__tests__/bot.test.js
+++ b/__tests__/bot.test.js
@@ -38,6 +38,7 @@ const originalConsoleWarn = console.warn;
 
 let bot;
 let pendingLogs;
+let errorSpy;
 
 describe('bot.js core utilities', () => {
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('bot.js core utilities', () => {
     console.log = originalConsoleLog;
     console.error = originalConsoleError;
     console.warn = originalConsoleWarn;
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     bot = require('../bot');
     pendingLogs = require('../jobs/logState').pendingLogs;
     pendingLogs.length = 0;
@@ -54,6 +56,7 @@ describe('bot.js core utilities', () => {
     console.log = originalConsoleLog;
     console.error = originalConsoleError;
     console.warn = originalConsoleWarn;
+    errorSpy.mockRestore();
   });
 
   test('console.log forwards to pending logs', () => {

--- a/__tests__/commands/admin/manual-verify.test.js
+++ b/__tests__/commands/admin/manual-verify.test.js
@@ -30,8 +30,19 @@ const createInteraction = (hasPerm = true) => {
   };
 };
 
+
+let errorSpy;
+let warnSpy;
+
 beforeEach(() => {
   jest.clearAllMocks();
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  warnSpy.mockRestore();
 });
 
 describe('/manual-verify command', () => {
@@ -90,6 +101,7 @@ describe('/manual-verify command', () => {
       content: expect.stringContaining('Failed to manually verify'),
       flags: MessageFlags.Ephemeral
     }));
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it('updates nickname even when org tag is unknown', async () => {

--- a/__tests__/utils/rsiScrapeOrgMembers.test.js
+++ b/__tests__/utils/rsiScrapeOrgMembers.test.js
@@ -5,7 +5,16 @@ jest.mock('node-fetch');
 const rsiScrapeOrgMembers = require('../../utils/rsiScrapeOrgMembers');
 
 describe('rsiScrapeOrgMembers', () => {
-  afterEach(() => jest.clearAllMocks());
+  let errorSpy;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    errorSpy.mockRestore();
+  });
 
   test('collects members across pages', async () => {
     const page1 = `
@@ -31,5 +40,6 @@ describe('rsiScrapeOrgMembers', () => {
   test('throws on http error', async () => {
     fetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'err' });
     await expect(rsiScrapeOrgMembers('PFC')).rejects.toThrow('Failed to fetch page 1');
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/trade/handlers/find.test.js
+++ b/__tests__/utils/trade/handlers/find.test.js
@@ -24,13 +24,16 @@ const { safeReply } = require('../../../../utils/trade/handlers/shared');
 
 describe('handleTradeFind', () => {
   let warnSpy;
+  let errorSpy;
   beforeEach(() => {
     jest.clearAllMocks();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   test('returns trades embed when results found', async () => {
@@ -60,5 +63,6 @@ describe('handleTradeFind', () => {
     getSellOptionsAtLocation.mockRejectedValue(new Error('fail'));
     await handleTradeFind(interaction);
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/trade/handlers/ship.test.js
+++ b/__tests__/utils/trade/handlers/ship.test.js
@@ -19,13 +19,16 @@ const { safeReply } = require('../../../../utils/trade/handlers/shared');
 
 describe('handleTradeShip', () => {
   let warnSpy;
+  let errorSpy;
   beforeEach(() => {
     jest.clearAllMocks();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
     warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   test('sends ship embed', async () => {
@@ -53,5 +56,6 @@ describe('handleTradeShip', () => {
     getVehicleByName.mockRejectedValue(new Error('db'));
     await handleTradeShip(interaction);
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/trade/tradeQueries.test.js
+++ b/__tests__/utils/trade/tradeQueries.test.js
@@ -28,8 +28,18 @@ const {
 } = tradeQueries;
 
 describe('tradeQueries', () => {
+  let errorSpy;
+  let warnSpy;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   test('getCommodityTradeOptions returns DB results', async () => {
@@ -116,12 +126,10 @@ describe('tradeQueries', () => {
   });
 
   test('getVehicleByName warns when no match found', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     UexVehicle.findAll.mockResolvedValue([]);
     const res = await getVehicleByName('Unknown');
     expect(res).toEqual([]);
     expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   test('getAllShipNames returns empty array on error', async () => {
@@ -262,14 +270,12 @@ describe('tradeQueries', () => {
 
   test('getReturnOptions logs error on DB failure', async () => {
     const error = new Error('db fail');
-    jest.spyOn(console, 'error').mockImplementation(() => {});
     UexCommodityPrice.findAll.mockRejectedValue(error);
     const res = await getReturnOptions('LocA', 'LocB');
     expect(res).toEqual([]);
-    expect(console.error).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       '[TRADE QUERIES] getReturnOptions encountered an error:',
       error
     );
-    console.error.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- silence noisy error logs in tests
- assert error logging in related test cases

## Testing
- `npm test -- --detectOpenHandles`