### PR TITLE
test: silence noisy console output

### DIFF
--- a/__tests__/botactions/ambient/ambientEngine.test.js
+++ b/__tests__/botactions/ambient/ambientEngine.test.js
@@ -71,6 +71,7 @@ describe('ambientEngine', () => {
 
   test('handles empty ambient message list', async () => {
     AmbientMessage.findAll.mockResolvedValue([]);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     await startAmbientEngine(client);
     trackChannelActivity({ author: { bot: false }, channel: { id: '1' } });
 
@@ -78,6 +79,8 @@ describe('ambientEngine', () => {
     await Promise.resolve();
 
     expect(channel.send).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith('⚠️ No ambient messages available in DB.');
+    warnSpy.mockRestore();
   });
 
   test('logs error when loading allowed channels fails', async () => {

--- a/__tests__/botactions/orgTagSync/syncOrgTags.test.js
+++ b/__tests__/botactions/orgTagSync/syncOrgTags.test.js
@@ -199,6 +199,7 @@ describe('syncOrgTags', () => {
   });
 
   it('continues when profile not found and member fetch fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     mockGuild.members.fetch = jest.fn().mockRejectedValue(new Error('fetch failed'));
 
     VerifiedUser.findAll.mockResolvedValue([
@@ -215,5 +216,9 @@ describe('syncOrgTags', () => {
       where: { discordUserId: 'user1' }
     });
     expect(mockMember.setNickname).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('RSI profile not found for VerifiedUser')
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/__tests__/botactions/scheduling/scheduleHandler.test.js
+++ b/__tests__/botactions/scheduling/scheduleHandler.test.js
@@ -49,8 +49,11 @@ describe('scheduleHandler', () => {
 
   test('getScheduledAnnouncements returns empty array on error', async () => {
     db.ScheduledAnnouncement.findAll.mockRejectedValue(new Error('fail'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const res = await getScheduledAnnouncements();
     expect(res).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   test('deleteScheduledAnnouncement deletes record', async () => {

--- a/__tests__/commands/admin/addsnapchannel.test.js
+++ b/__tests__/commands/admin/addsnapchannel.test.js
@@ -52,11 +52,14 @@ describe('/addsnapchannel command', () => {
 
   test('replies with error message on failure', async () => {
     const interaction = makeInteraction(['Admiral']);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     addSnapChannel.mockRejectedValueOnce(new Error('oops'));
     await execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith({
       content: expect.stringContaining('error'),
       flags: MessageFlags.Ephemeral
     });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/__tests__/commands/admin/lookupuser.test.js
+++ b/__tests__/commands/admin/lookupuser.test.js
@@ -9,7 +9,18 @@ describe('/lookupuser command', () => {
     reply: jest.fn()
   });
 
-  beforeEach(() => jest.clearAllMocks());
+  let warnSpy;
+  let errorSpy;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
 
   test('replies with member info if found in guild', async () => {
     const interaction = createInteraction(

--- a/__tests__/utils/fetchHelpers.test.js
+++ b/__tests__/utils/fetchHelpers.test.js
@@ -5,8 +5,14 @@ const fetch = require('node-fetch');
 jest.mock('node-fetch');
 
 describe('fetch helpers', () => {
+  let errorSpy;
   beforeEach(() => {
     jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
   describe('fetchSCData', () => {


### PR DESCRIPTION
## Summary
- spy on `console.error` in `/addsnapchannel` failure test
- capture errors for scheduleHandler DB failure path
- mock console errors for fetch helper tests
- spy on console for `/lookupuser` tests
- expect ambient warning when no messages exist
- capture warning in syncOrgTags member fetch failure

## Testing
- `npm test`