### PR TITLE
Increase branch coverage

### DIFF
--- a/__tests__/utils/apiSync/syncUexCategories.test.js
+++ b/__tests__/utils/apiSync/syncUexCategories.test.js
@@ -29,6 +29,23 @@ describe('syncUexCategories', () => {
     expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
   });
 
+  test('skips invalid entries', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 0 }, { id: 2, name: 'Two' }] });
+    UexCategory.upsert.mockResolvedValue([{}, false]);
+
+    const res = await syncUexCategories();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 1, skipped: 1, total: 2 });
+  });
+
+  test('logs and rethrows on upsert error', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 3, name: 'Boom' }] });
+    UexCategory.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncUexCategories()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   test('throws on invalid data', async () => {
     fetchUexData.mockResolvedValue({});
     await expect(syncUexCategories()).rejects.toThrow('Expected an array of categories');

--- a/__tests__/utils/apiSync/syncUexFuelPrices.test.js
+++ b/__tests__/utils/apiSync/syncUexFuelPrices.test.js
@@ -29,6 +29,23 @@ describe('syncUexFuelPrices', () => {
     expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
   });
 
+  test('skips invalid entries', async () => {
+    fetchUexData.mockResolvedValue({ data: [{}, { id: 2, commodity_name: 'Fuel' }] });
+    UexFuelPrice.upsert.mockResolvedValue([{}, false]);
+
+    const res = await syncUexFuelPrices();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 1, skipped: 1, total: 2 });
+  });
+
+  test('logs and rethrows on upsert error', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 3, commodity_name: 'f' }] });
+    UexFuelPrice.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncUexFuelPrices()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   test('throws on invalid data', async () => {
     fetchUexData.mockResolvedValue({});
     await expect(syncUexFuelPrices()).rejects.toThrow('Expected an array of fuel price entries');

--- a/__tests__/utils/apiSync/syncUexVehiclePurchasePrices.test.js
+++ b/__tests__/utils/apiSync/syncUexVehiclePurchasePrices.test.js
@@ -29,6 +29,23 @@ describe('syncUexVehiclePurchasePrices', () => {
     expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
   });
 
+  test('skips invalid entries', async () => {
+    fetchUexData.mockResolvedValue({ data: [{}, { id: 2, vehicle_name: 'ok', id_vehicle: 2, id_terminal: 1 }] });
+    UexVehiclePurchasePrice.upsert.mockResolvedValue([{}, false]);
+
+    const res = await syncUexVehiclePurchasePrices();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 1, skipped: 1, total: 2 });
+  });
+
+  test('logs and rethrows on upsert error', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 3, vehicle_name: 'x', id_vehicle: 3, id_terminal: 1 }] });
+    UexVehiclePurchasePrice.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncUexVehiclePurchasePrices()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   test('throws on invalid data', async () => {
     fetchUexData.mockResolvedValue({});
     await expect(syncUexVehiclePurchasePrices()).rejects.toThrow('Expected an array of vehicle purchase price entries');

--- a/__tests__/utils/apiSync/syncUexVehicles.test.js
+++ b/__tests__/utils/apiSync/syncUexVehicles.test.js
@@ -29,6 +29,23 @@ describe('syncUexVehicles', () => {
     expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
   });
 
+  test('skips invalid entries', async () => {
+    fetchUexData.mockResolvedValue({ data: [{}, { id: 2, name: 'ok' }] });
+    UexVehicle.upsert.mockResolvedValue([{}, false]);
+
+    const res = await syncUexVehicles();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 1, skipped: 1, total: 2 });
+  });
+
+  test('logs and rethrows on upsert failure', async () => {
+    fetchUexData.mockResolvedValue({ data: [{ id: 3, name: 'b' }] });
+    UexVehicle.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncUexVehicles()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   test('throws on invalid data', async () => {
     fetchUexData.mockResolvedValue({});
     await expect(syncUexVehicles()).rejects.toThrow('Expected an array of vehicles');

--- a/__tests__/utils/apiSync/vehicles.test.js
+++ b/__tests__/utils/apiSync/vehicles.test.js
@@ -29,6 +29,23 @@ describe('syncVehicles', () => {
     expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
   });
 
+  test('skips entries without uuid', async () => {
+    fetchSCData.mockResolvedValue([{ uuid: '', name: 'x' }, { uuid: 'u2', name: 'y' }]);
+    Vehicle.upsert.mockResolvedValue([{}, false]);
+
+    const res = await syncVehicles();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 1, skipped: 1, total: 2 });
+  });
+
+  test('logs and rethrows when upsert fails', async () => {
+    fetchSCData.mockResolvedValue([{ uuid: 'u3', name: 'z' }]);
+    Vehicle.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncVehicles()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
   test('throws on invalid data', async () => {
     fetchSCData.mockResolvedValue(null);
     await expect(syncVehicles()).rejects.toThrow('Expected an array of vehicles');

--- a/__tests__/utils/trade/handlers/best.test.js
+++ b/__tests__/utils/trade/handlers/best.test.js
@@ -13,7 +13,7 @@ jest.mock('../../../../utils/trade/tradeEmbeds');
 jest.mock('../../../../utils/trade/handlers/shared');
 
 // 🔧 Import handler after mocks are active
-const { handleTradeBest } = require('../../../../utils/trade/handlers/best');
+const { handleTradeBest, handleTradeBestCore } = require('../../../../utils/trade/handlers/best');
 
 const {
   getVehicleByName,
@@ -138,6 +138,14 @@ describe('handleTradeBest', () => {
       components: [{ type: 1, components: [] }],
       flags: MessageFlags.Ephemeral
     });
+  });
+
+  test('returns error when multiple ships but no userId', async () => {
+    getVehicleByName.mockResolvedValue([{ name: 'A' }, { name: 'B' }]);
+
+    const result = await handleTradeBestCore({ fromLocation: 'A', shipQuery: 'X', cash: 0 });
+
+    expect(result).toEqual({ error: '❌ Multiple ships matched, and no userId provided for caching.' });
   });
 
   test('clears TradeStateCache if a single ship is selected', async () => {

--- a/__tests__/utils/trade/handlers/find.test.js
+++ b/__tests__/utils/trade/handlers/find.test.js
@@ -58,6 +58,15 @@ describe('handleTradeFind', () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
+  test('warns when no terminal matches to location', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getSellOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'C' }, price_buy: 10, scu_buy: 1 }]);
+    calculateProfitOptions.mockReturnValue([]);
+
+    await handleTradeFind(interaction);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
   test('handles query errors gracefully', async () => {
     const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
     getSellOptionsAtLocation.mockRejectedValue(new Error('fail'));

--- a/__tests__/utils/trade/handlers/locations.test.js
+++ b/__tests__/utils/trade/handlers/locations.test.js
@@ -47,4 +47,19 @@ describe('handleTradeLocations', () => {
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('No known terminals'));
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  test('handles lookup errors gracefully', async () => {
+    const interaction = new MockInteraction({});
+    getTerminalsAtLocation.mockRejectedValue(new Error('fail'));
+    await handleTradeLocations(interaction);
+    expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
+  });
+
+  test('does not reply twice on error if already replied', async () => {
+    const interaction = new MockInteraction({});
+    interaction.replied = true;
+    getTerminalsAtLocation.mockRejectedValue(new Error('boom'));
+    await handleTradeLocations(interaction);
+    expect(safeReply).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/utils/trade/handlers/route.test.js
+++ b/__tests__/utils/trade/handlers/route.test.js
@@ -63,4 +63,15 @@ describe('handleTradeRoute', () => {
       flags: MessageFlags.Ephemeral,
     });
   });
+
+  test('returns error when route not profitable', async () => {
+    const interaction = new MockInteraction({ options: { from: 'A', to: 'B' } });
+    getBuyOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'A' }, commodity_name: 'X', price_buy: 1, scu_buy: 1 }]);
+    getSellOptionsAtLocation.mockResolvedValue([{ terminal: { name: 'B' }, commodity_name: 'X', price_sell: 0 }]);
+    resolveBestMatchingTerminal.mockReturnValueOnce({ name: 'A' }).mockReturnValueOnce({ name: 'B' });
+    calculateProfitOptions.mockReturnValue([]);
+
+    await handleTradeRoute(interaction, {}, { from: 'A', to: 'B' });
+    expect(safeReply).toHaveBeenCalledWith(interaction, { content: expect.stringContaining('No profitable trades'), flags: MessageFlags.Ephemeral });
+  });
 });

--- a/__tests__/utils/trade/handlers/ship.test.js
+++ b/__tests__/utils/trade/handlers/ship.test.js
@@ -58,4 +58,12 @@ describe('handleTradeShip', () => {
     expect(safeReply).toHaveBeenCalledWith(interaction, expect.stringContaining('error'));
     expect(errorSpy).toHaveBeenCalled();
   });
+
+  test('does not reply again if already replied on error', async () => {
+    const interaction = new MockInteraction({ options: { name: 'Cutlass' } });
+    interaction.replied = true;
+    getVehicleByName.mockRejectedValue(new Error('x'));
+    await handleTradeShip(interaction);
+    expect(safeReply).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/utils/trade/tradeEmbeds.test.js
+++ b/__tests__/utils/trade/tradeEmbeds.test.js
@@ -17,6 +17,14 @@ const {
       expect(result.data.title).toContain('Port Olisar');
       expect(result.data.fields).toHaveLength(1);
     });
+
+    test('buildBestTradesEmbed supports shipName and null values', () => {
+      const opts = [{ commodity: 'Agricium', fromTerminal: 'T1', toTerminal: 'T2', profitPerSCU: 1, returnOnInvestment: 1, cargoUsed: null, totalProfit: null }];
+      const result = buildBestTradesEmbed('Area18', opts, 'Ship');
+      expect(result.data.title).toContain('using Ship');
+      expect(result.data.fields[0].value).toContain('No ship selected');
+      expect(result.data.fields[0].value).toContain('Total: *N/A*');
+    });
   
     test('buildRouteEmbed returns an embed with sell options', () => {
       const result = buildRouteEmbed('Agricium', 'Port Olisar', [
@@ -24,6 +32,12 @@ const {
       ]);
       expect(result.data.title).toContain('Agricium');
       expect(result.data.fields[0].name).toContain('Terminal B');
+    });
+
+    test('buildRouteEmbed handles missing fields', () => {
+      const res = buildRouteEmbed('C', 'Loc', [{ }]);
+      expect(res.data.fields[0].name).toContain('UNKNOWN_TERMINAL');
+      expect(res.data.fields[0].value).toContain('N/A');
     });
   
     test('buildCircuitEmbed returns embed with outbound + return fields', () => {
@@ -42,6 +56,12 @@ const {
       expect(result.data.fields).toHaveLength(2);
       expect(result.data.fields[1].value).toContain('No profitable return');
     });
+
+    test('buildCircuitEmbed falls back when fields missing', () => {
+      const outbound = {};
+      const res = buildCircuitEmbed(outbound, null, 'X');
+      expect(res.data.fields[0].name).toContain('UNKNOWN_COMMODITY');
+    });
   
     test('buildPriceEmbed returns embed with price data', () => {
       const result = buildPriceEmbed('Agricium', 'Port Olisar', [
@@ -50,16 +70,38 @@ const {
       expect(result.data.title).toContain('Agricium');
       expect(result.data.fields[0].value).toContain('Buy:');
     });
+
+    test('buildPriceEmbed handles null location and prices', () => {
+      const res = buildPriceEmbed('Commodity', null, [{ }]);
+      expect(res.data.title).toContain('Commodity');
+      expect(res.data.fields[0].value).toContain('N/A');
+    });
   
     test('buildShipEmbed returns embed with ship info', () => {
       const result = buildShipEmbed({ name: 'Freelancer', scu: 66, is_cargo: true });
       expect(result.data.title).toContain('Freelancer');
       expect(result.data.description).toContain('Cargo Capacity');
     });
+
+    test('buildShipEmbed handles non-cargo ship', () => {
+      const res = buildShipEmbed({ name: 'X', scu: 0, is_cargo: false });
+      expect(res.data.description).toContain('Non-cargo');
+    });
+
+    test('buildShipEmbed uses fallbacks for missing fields', () => {
+      const res = buildShipEmbed({});
+      expect(res.data.title).toContain('UNKNOWN_NAME');
+      expect(res.data.description).toContain('N/A');
+    });
   
     test('buildLocationsEmbed returns embed with location names', () => {
       const result = buildLocationsEmbed([{ name: 'Terminal A', city_name: 'Lorville' }]);
       expect(result.data.fields[0].name).toContain('Terminal A');
+    });
+
+    test('buildCommoditiesEmbed shows no commodities message', () => {
+      const res = buildCommoditiesEmbed('Loc', [{ terminal: 'T', commodities: [] }], 0, 1);
+      expect(res.data.fields[0].value).toBe('```\n```');
     });
   
     test('buildCommoditiesEmbed returns embed grouped by terminal', () => {
@@ -92,6 +134,12 @@ const {
       const value = result.data.fields[0].value;
       expect(value.length).toBeLessThanOrEqual(1024);
       expect(value.endsWith('...```')).toBe(true);
+    });
+
+    test('buildCommoditiesEmbed handles missing prices', () => {
+      const data = [{ terminal: 'T1', commodities: [{ name: 'X' }] }];
+      const res = buildCommoditiesEmbed('L', data, 0, 1);
+      expect(res.data.fields[0].value).toContain('N/A');
     });
 
     test('buildCommoditiesEmbed truncates long commodity names', () => {


### PR DESCRIPTION
## Notes
- Added missing branch tests across API sync and trade handler modules
- Expanded trade embed unit tests to exercise additional branches
- Added error handling cases for locations and price handlers
- Coverage for modules below 80% now exceeds target

## Testing
- `npm test`