### PR TITLE
Add unit tests for UEX models and fetchUexData

### DIFF
--- a/__tests__/models/generalModels.test.js
+++ b/__tests__/models/generalModels.test.js
@@ -1,0 +1,67 @@
+const defineUsageLog = require('../../models/usageLog');
+const defineVehicle = require('../../models/vehicle');
+const defineVehicleDetail = require('../../models/vehicleDetail');
+const defineVerificationCode = require('../../models/verificationCode');
+const defineVerifiedUser = require('../../models/verifiedUser');
+
+describe('Misc model definitions', () => {
+  test('UsageLog model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineUsageLog(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UsageLog');
+    expect(attrs).toHaveProperty('user_id');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(model).toBe(modelObj);
+  });
+
+  test('Vehicle model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineVehicle(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('Vehicle');
+    expect(attrs).toHaveProperty('uuid');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(model).toBe(modelObj);
+  });
+
+  test('VehicleDetail model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineVehicleDetail(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('VehicleDetail');
+    expect(attrs).toHaveProperty('uuid');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(model).toBe(modelObj);
+  });
+
+  test('VerificationCode model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineVerificationCode(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('VerificationCode');
+    expect(attrs).toHaveProperty('discordUserId');
+    expect(opts.tableName).toBe('verification_codes');
+    expect(model).toBe(modelObj);
+  });
+
+  test('VerifiedUser model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineVerifiedUser(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('VerifiedUser');
+    expect(attrs).toHaveProperty('discordUserId');
+    expect(opts.tableName).toBe('verified_users');
+    expect(model).toBe(modelObj);
+  });
+});

--- a/__tests__/models/uexModels.test.js
+++ b/__tests__/models/uexModels.test.js
@@ -1,0 +1,112 @@
+const defineFuelPrice = require('../../models/uexFuelPrice');
+const defineItemPrice = require('../../models/uexItemPrice');
+const definePoi = require('../../models/uexPoi');
+const defineTerminal = require('../../models/uexTerminal');
+const defineVehicle = require('../../models/uexVehicle');
+const definePurchasePrice = require('../../models/uexVehiclePurchasePrice');
+const defineRentalPrice = require('../../models/uexVehicleRentalPrice');
+
+describe('UEX related model definitions', () => {
+  test('UexFuelPrice model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineFuelPrice(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexFuelPrice');
+    expect(attrs).toHaveProperty('price_buy');
+    expect(opts.tableName).toBe('UexFuelPrices');
+    expect(opts.timestamps).toBe(false);
+    expect(model).toBe(modelObj);
+  });
+
+  test('UexItemPrice model definition and association', () => {
+    const modelObj = { belongsTo: jest.fn() };
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineItemPrice(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexItemPrice');
+    expect(attrs).toHaveProperty('id_item');
+    expect(opts.tableName).toBe('UexItemPrices');
+    expect(model).toBe(modelObj);
+    expect(typeof model.associate).toBe('function');
+
+    const terminalModel = {};
+    model.associate({ UexTerminal: terminalModel });
+    expect(model.belongsTo).toHaveBeenCalledWith(terminalModel, {
+      foreignKey: 'id_terminal',
+      as: 'terminal'
+    });
+  });
+
+  test('UexPoi model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = definePoi(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexPoi');
+    expect(attrs).toHaveProperty('name');
+    expect(opts.tableName).toBe('UexPois');
+    expect(typeof model.associate).toBe('function');
+  });
+
+  test('UexTerminal model definition and association', () => {
+    const modelObj = { belongsTo: jest.fn() };
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineTerminal(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexTerminal');
+    expect(attrs).toHaveProperty('id');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(model).toBe(modelObj);
+    model.associate({ UexPoi: 'poiModel' });
+    expect(model.belongsTo).toHaveBeenCalledWith('poiModel', {
+      foreignKey: 'id_poi',
+      as: 'poi'
+    });
+  });
+
+  test('UexVehicle model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineVehicle(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexVehicle');
+    expect(attrs).toHaveProperty('uuid');
+    expect(opts.tableName).toBe('UexVehicles');
+    expect(model).toBe(modelObj);
+  });
+
+  test('UexVehiclePurchasePrice model definition and association', () => {
+    const modelObj = { belongsTo: jest.fn() };
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = definePurchasePrice(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexVehiclePurchasePrice');
+    expect(attrs).toHaveProperty('price_buy');
+    expect(opts.tableName).toBe('UexVehiclePurchasePrices');
+    expect(model).toBe(modelObj);
+    model.associate({ UexTerminal: 'terminalModel' });
+    expect(model.belongsTo).toHaveBeenCalledWith('terminalModel', {
+      foreignKey: 'id_terminal',
+      as: 'terminal'
+    });
+  });
+
+  test('UexVehicleRentalPrice model definition', () => {
+    const modelObj = {};
+    const define = jest.fn(() => modelObj);
+    const sequelize = { define };
+    const model = defineRentalPrice(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+    expect(name).toBe('UexVehicleRentalPrice');
+    expect(attrs).toHaveProperty('price_rent');
+    expect(opts.tableName).toBe('UexVehicleRentalPrices');
+    expect(model).toBe(modelObj);
+  });
+});

--- a/__tests__/utils/fetchUexData.test.js
+++ b/__tests__/utils/fetchUexData.test.js
@@ -1,0 +1,51 @@
+const { fetchUexData } = require('../../utils/fetchUexData');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch');
+
+describe('fetchUexData', () => {
+  let errorSpy;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.UEX_API_TOKEN = 'token';
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  test('returns json when request succeeds', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true })
+    });
+
+    const data = await fetchUexData('vehicles');
+
+    expect(fetch).toHaveBeenCalledWith('https://api.uexcorp.space/2.0/vehicles', {
+      headers: { Authorization: 'Bearer token', Accept: 'application/json' }
+    });
+    expect(data).toEqual({ success: true });
+  });
+
+  test('logs and returns empty object on http failure', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const data = await fetchUexData('missing');
+
+    expect(data).toEqual({});
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[UEX FETCH ERROR] Failed to fetch https://api.uexcorp.space/2.0/missing: 404 Not Found'
+    );
+  });
+
+  test('logs and returns empty object on network error', async () => {
+    fetch.mockRejectedValue(new Error('bad'));
+
+    const data = await fetchUexData('bad');
+
+    expect(data).toEqual({});
+    expect(errorSpy).toHaveBeenCalledWith('[UEX FETCH ERROR] bad');
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for several Sequelize model definitions
- add test coverage for fetchUexData utility

## Testing
- `npm test`