### PR TITLE
Add tests for remaining model definitions

### DIFF
--- a/__tests__/models/galactapediaDetail.test.js
+++ b/__tests__/models/galactapediaDetail.test.js
@@ -1,0 +1,20 @@
+const defineModel = require('../../models/galactapediaDetail');
+
+describe('GalactapediaDetail model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('GalactapediaDetail');
+    expect(attrs).toHaveProperty('entry_id');
+    expect(attrs.entry_id.primaryKey).toBe(true);
+    expect(attrs).toHaveProperty('content');
+    expect(attrs).toHaveProperty('created_at');
+    expect(attrs).toHaveProperty('updated_at');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/galactapediaProperty.test.js
+++ b/__tests__/models/galactapediaProperty.test.js
@@ -1,0 +1,19 @@
+const defineModel = require('../../models/galactapediaProperty');
+
+describe('GalactapediaProperty model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('GalactapediaProperty');
+    expect(attrs).toHaveProperty('entry_id');
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('value');
+    expect(opts.indexes[0].fields).toEqual(['entry_id']);
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/galactapediaRelatedArticle.test.js
+++ b/__tests__/models/galactapediaRelatedArticle.test.js
@@ -1,0 +1,21 @@
+const defineModel = require('../../models/galactapediaRelatedArticle');
+
+describe('GalactapediaRelatedArticle model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('GalactapediaRelatedArticle');
+    expect(attrs).toHaveProperty('entry_id');
+    expect(attrs).toHaveProperty('related_id');
+    expect(attrs).toHaveProperty('title');
+    expect(attrs).toHaveProperty('url');
+    expect(attrs).toHaveProperty('api_url');
+    expect(opts.indexes[0].fields).toEqual(['entry_id']);
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/galactapediaTag.test.js
+++ b/__tests__/models/galactapediaTag.test.js
@@ -1,0 +1,19 @@
+const defineModel = require('../../models/galactapediaTag');
+
+describe('GalactapediaTag model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('GalactapediaTag');
+    expect(attrs).toHaveProperty('entry_id');
+    expect(attrs).toHaveProperty('tag_id');
+    expect(attrs).toHaveProperty('tag_name');
+    expect(opts.indexes[0].fields).toEqual(['entry_id']);
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/manufacturer.test.js
+++ b/__tests__/models/manufacturer.test.js
@@ -1,0 +1,19 @@
+const defineModel = require('../../models/manufacturer');
+
+describe('Manufacturer model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('Manufacturer');
+    expect(attrs).toHaveProperty('code');
+    expect(attrs.code.primaryKey).toBe(true);
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('link');
+    expect(opts.tableName).toBe('Manufacturers');
+    expect(opts.timestamps).toBe(false);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/orgTag.test.js
+++ b/__tests__/models/orgTag.test.js
@@ -1,0 +1,19 @@
+const defineModel = require('../../models/orgTag');
+
+describe('OrgTag model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('OrgTag');
+    expect(attrs).toHaveProperty('rsiOrgId');
+    expect(attrs.rsiOrgId.primaryKey).toBe(true);
+    expect(attrs).toHaveProperty('tag');
+    expect(opts.tableName).toBe('org_tags');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/scheduledAnnouncement.test.js
+++ b/__tests__/models/scheduledAnnouncement.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/scheduledAnnouncement');
+
+describe('ScheduledAnnouncement model definition', () => {
+  test('defines fields correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs] = define.mock.calls[0];
+
+    expect(name).toBe('ScheduledAnnouncement');
+    expect(attrs).toHaveProperty('channelId');
+    expect(attrs).toHaveProperty('guildId');
+    expect(attrs).toHaveProperty('embedData');
+    expect(attrs).toHaveProperty('time');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/snapChannels.test.js
+++ b/__tests__/models/snapChannels.test.js
@@ -1,0 +1,22 @@
+const defineModel = require('../../models/snapChannels');
+
+describe('SnapChannel model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('SnapChannel');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs.id.autoIncrement).toBe(true);
+    expect(attrs).toHaveProperty('channelId');
+    expect(attrs.channelId.unique).toBe(true);
+    expect(attrs).toHaveProperty('purgeTimeInDays');
+    expect(attrs).toHaveProperty('serverId');
+    expect(attrs).toHaveProperty('lastPurgeDate');
+    expect(opts.tableName).toBe('SnapChannels');
+    expect(opts.timestamps).toBe(true);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/uexCategory.test.js
+++ b/__tests__/models/uexCategory.test.js
@@ -1,0 +1,26 @@
+const defineModel = require('../../models/uexCategory');
+
+describe('UexCategory model definition', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('UexCategory');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs.id.primaryKey).toBe(true);
+    expect(attrs).toHaveProperty('type');
+    expect(attrs).toHaveProperty('section');
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('is_game_related');
+    expect(attrs).toHaveProperty('is_mining');
+    expect(attrs).toHaveProperty('date_added');
+    expect(attrs).toHaveProperty('date_modified');
+    expect(opts.tableName).toBe('UexCategories');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(opts.timestamps).toBe(false);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/uexCommodityPrice.test.js
+++ b/__tests__/models/uexCommodityPrice.test.js
@@ -1,0 +1,32 @@
+const defineModel = require('../../models/uexCommodityPrice');
+
+describe('UexCommodityPrice model definition', () => {
+  test('defines fields, options, and association correctly', () => {
+    const define = jest.fn(() => ({}));
+    const belongsTo = jest.fn();
+    const sequelize = { define };
+    const models = { UexTerminal: {} };
+
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('UexCommodityPrice');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs.id.primaryKey).toBe(true);
+    expect(attrs).toHaveProperty('id_commodity');
+    expect(attrs).toHaveProperty('id_terminal');
+    expect(opts.tableName).toBe('UexCommodityPrices');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(opts.timestamps).toBe(false);
+    expect(typeof model.associate).toBe('function');
+
+    // test association method
+    model.belongsTo = belongsTo; // in case define returned object, we patch
+    model.associate(models);
+    expect(belongsTo).toHaveBeenCalledWith(models.UexTerminal, {
+      foreignKey: 'id_terminal',
+      as: 'terminal'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- increase coverage for sequelize models by testing definitions
- check attributes, options, and associations

## Testing
- `npm test`