### PR TITLE
Add tests for tools commands and models

### DIFF
--- a/__tests__/commands/tools/uexterminals.test.js
+++ b/__tests__/commands/tools/uexterminals.test.js
@@ -1,0 +1,68 @@
+const { MockInteraction, MessageFlags } = require('../../../__mocks__/discord.js');
+
+jest.mock('../../../utils/verifyGuard', () => ({ isUserVerified: jest.fn() }));
+jest.mock('../../../config/database', () => ({
+  UexTerminal: { findAll: jest.fn() }
+}));
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const command = require('../../../commands/tools/uexterminals');
+
+describe('/uexterminals command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects when user not verified', async () => {
+    isUserVerified.mockResolvedValue(false);
+    const interaction = new MockInteraction({ options: { location: 'Area18' } });
+
+    await command.execute(interaction);
+
+    expect(interaction.replyContent).toMatch('verify');
+    expect(interaction.replyFlags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test('replies when no terminals found', async () => {
+    isUserVerified.mockResolvedValue(true);
+    db.UexTerminal.findAll.mockResolvedValue([]);
+    const interaction = new MockInteraction({ options: { location: 'Nowhere' } });
+
+    await command.execute(interaction);
+
+    expect(interaction.replyContent).toMatch('No terminals');
+    expect(interaction.replyFlags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test('returns embed table when results found', async () => {
+    isUserVerified.mockResolvedValue(true);
+    db.UexTerminal.findAll.mockResolvedValue([
+      { code:'A1', name:'Term1', space_station_name:'Port' }
+    ]);
+    const interaction = new MockInteraction({ options: { location: 'Port' } });
+    interaction.reply = jest.fn();
+
+    await command.execute(interaction);
+
+    const reply = interaction.reply.mock.calls[0][0];
+    expect(reply.embeds[0].data.title).toContain('Terminals in');
+    expect(reply.components).toHaveLength(2);
+  });
+
+  test('button updates page with ephemeral embed', async () => {
+    db.UexTerminal.findAll.mockResolvedValue([
+      { code:'A1', name:'T1', space_station_name:'Port' }
+    ]);
+    const update = jest.fn();
+    const btn = {
+      customId: 'uexterminals_page::Port::0::false',
+      update,
+      message: {},
+    };
+    await command.button(btn);
+    const embed = update.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toContain('Terminals in');
+    expect(update).toHaveBeenCalled();
+  });
+});

--- a/__tests__/commands/tools/uexvehicle.test.js
+++ b/__tests__/commands/tools/uexvehicle.test.js
@@ -1,0 +1,80 @@
+const { MockInteraction, MessageFlags, StringSelectMenuBuilder } = require('../../../__mocks__/discord.js');
+
+jest.mock('../../../utils/verifyGuard', () => ({ isUserVerified: jest.fn() }));
+jest.mock('../../../config/database', () => ({
+  UexVehicle: { findAll: jest.fn(), findByPk: jest.fn() },
+  UexVehiclePurchasePrice: { findAll: jest.fn() },
+  UexTerminal: {}
+}));
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const command = require('../../../commands/tools/uexvehicle');
+
+describe('/uexvehicle command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('rejects unverified users', async () => {
+    isUserVerified.mockResolvedValue(false);
+    const interaction = new MockInteraction({ options: { name: 'Aurora' } });
+
+    await command.execute(interaction);
+
+    expect(interaction.replyContent).toMatch('verify');
+    expect(interaction.replyFlags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test('replies when no vehicles found', async () => {
+    isUserVerified.mockResolvedValue(true);
+    db.UexVehicle.findAll.mockResolvedValue([]);
+    const interaction = new MockInteraction({ options: { name: 'Unknown' } });
+
+    await command.execute(interaction);
+
+    expect(interaction.replyContent).toMatch('No vehicles found');
+    expect(interaction.replyFlags).toBe(MessageFlags.Ephemeral);
+  });
+
+  test('returns embed when single match found', async () => {
+    isUserVerified.mockResolvedValue(true);
+    const vehicle = { id: 1, name: 'Aurora', length: 1, width: 1, height: 1 };
+    db.UexVehicle.findAll.mockResolvedValue([vehicle]);
+    const interaction = new MockInteraction({ options: { name: 'Aurora' } });
+    interaction.reply = jest.fn();
+
+    await command.execute(interaction);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toContain('Aurora');
+  });
+
+  test('shows select menu when multiple matches', async () => {
+    isUserVerified.mockResolvedValue(true);
+    db.UexVehicle.findAll.mockResolvedValue([{ id:1, name:'A' }, { id:2, name:'B' }]);
+    const interaction = new MockInteraction({ options: { name: 'A' } });
+    interaction.reply = jest.fn();
+
+    await command.execute(interaction);
+
+    const reply = interaction.reply.mock.calls[0][0];
+    expect(reply.components).toBeDefined();
+    expect(db.UexVehicle.findAll).toHaveBeenCalled();
+  });
+
+  test('option adds purchase locations or fallback', async () => {
+    const update = jest.fn();
+    db.UexVehicle.findByPk.mockResolvedValue({ id:5, name:'Ship', length:1,width:1,height:1 });
+    db.UexVehiclePurchasePrice.findAll.mockResolvedValue([{ price_buy: 100, terminal:{name:'Term'} }]);
+
+    await command.option({ values:['5'], update });
+
+    const embed = update.mock.calls[0][0].embeds[0];
+    expect(embed.data.fields).toEqual(
+      expect.arrayContaining([
+        { name:'Purchase Locations', value:'• Term — 100 aUEC' }
+      ])
+    );
+  });
+});

--- a/__tests__/commands/tools/usagestats.test.js
+++ b/__tests__/commands/tools/usagestats.test.js
@@ -1,0 +1,74 @@
+jest.mock('../../../config/database', () => ({
+  UsageLog: { findAll: jest.fn() },
+  VoiceLog: { findAll: jest.fn() }
+}));
+jest.mock('../../../utils/verifyGuard', () => ({ isUserVerified: jest.fn() }));
+jest.mock('../../../botactions/userManagement/permissions', () => ({ isAdmin: jest.fn() }));
+
+const { MessageFlags, EmbedBuilder } = require('discord.js');
+const db = require('../../../config/database');
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const { isAdmin } = require('../../../botactions/userManagement/permissions');
+const command = require('../../../commands/tools/usagestats');
+
+describe('/usagestats command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function makeInteraction(targetId = 'req') {
+    return {
+      options: { getUser: jest.fn(() => ({ id: targetId, username: 't' })) },
+      user: { id: 'req' },
+      member: {},
+      guildId: 'guild',
+      guild: { members: { fetch: jest.fn(() => Promise.resolve({ displayName: 'Tester' })) } },
+      deferReply: jest.fn(),
+      reply: jest.fn(),
+      editReply: jest.fn()
+    };
+  }
+
+  test('blocks non-admin querying others', async () => {
+    isUserVerified.mockResolvedValue(true);
+    isAdmin.mockResolvedValue(false);
+    const interaction = makeInteraction('other');
+
+    await command.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Only admins'), flags: MessageFlags.Ephemeral })
+    );
+  });
+
+  test('rejects unverified user', async () => {
+    isUserVerified.mockResolvedValue(false);
+    const interaction = makeInteraction();
+
+    await command.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('verify'), flags: MessageFlags.Ephemeral })
+    );
+  });
+
+  test('builds usage summary embed', async () => {
+    isUserVerified.mockResolvedValue(true);
+    isAdmin.mockResolvedValue(true);
+    db.UsageLog.findAll.mockResolvedValue([
+      { interaction_type:'message', channel_id:'1' },
+      { interaction_type:'command', command_name:'ping' }
+    ]);
+    db.VoiceLog.findAll.mockResolvedValue([
+      { channel_id:'1', duration:60 },
+      { channel_id:'1', duration:30 }
+    ]);
+    const interaction = makeInteraction('other');
+
+    await command.execute(interaction);
+
+    const embed = interaction.editReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toContain('Usage Summary');
+    expect(embed.data.fields.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/jest-config.test.js
+++ b/__tests__/jest-config.test.js
@@ -1,0 +1,20 @@
+const config = require('../jest.config');
+
+describe('jest configuration', () => {
+  test('has expected basic settings', () => {
+    expect(config.testEnvironment).toBe('node');
+    expect(config.roots).toContain('<rootDir>/__tests__');
+    expect(config.moduleNameMapper['^discord.js$']).toBe('<rootDir>/__mocks__/discord.js');
+    expect(config.collectCoverage).toBe(true);
+    expect(config.coverageDirectory).toBe('coverage');
+    expect(config.collectCoverageFrom).toEqual(
+      expect.arrayContaining([
+        'utils/**/*.{js,ts}',
+        'commands/**/*.{js,ts}',
+        'botactions/**/*.{js,ts}',
+        'jobs/**/*.{js,ts}',
+        'models/**/*.{js,ts}'
+      ])
+    );
+  });
+});

--- a/__tests__/models/accolade.test.js
+++ b/__tests__/models/accolade.test.js
@@ -1,0 +1,16 @@
+const defineModel = require('../../models/accolade');
+
+describe('Accolade model', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('Accolade');
+    expect(attrs).toHaveProperty('role_id');
+    expect(attrs).toHaveProperty('emoji');
+    expect(opts.tableName).toBe('Accolades');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/ambiEntMessage.test.js
+++ b/__tests__/models/ambiEntMessage.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/ambiEntMessage');
+
+describe('AmbientMessage model', () => {
+  test('defines fields and options correctly', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('AmbientMessage');
+    expect(attrs).toHaveProperty('content');
+    expect(attrs).toHaveProperty('tag');
+    expect(opts.tableName).toBe('ambient_messages');
+    expect(opts.timestamps).toBe(true);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/ambientChannel.test.js
+++ b/__tests__/models/ambientChannel.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/ambientChannel');
+
+describe('AmbientChannel model', () => {
+  test('defines fields and unique index', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('AmbientChannel');
+    expect(attrs).toHaveProperty('guildId');
+    expect(attrs).toHaveProperty('channelId');
+    expect(opts.tableName).toBe('ambient_channels');
+    expect(opts.indexes[0].unique).toBe(true);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/ambientSetting.test.js
+++ b/__tests__/models/ambientSetting.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/ambientSetting');
+
+describe('AmbientSetting model', () => {
+  test('defines fields and options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('AmbientSetting');
+    expect(attrs).toHaveProperty('guildId');
+    expect(attrs).toHaveProperty('minMessagesSinceLast');
+    expect(opts.tableName).toBe('ambient_settings');
+    expect(opts.timestamps).toBe(false);
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/eventsModel.test.js
+++ b/__tests__/models/eventsModel.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/eventsModel');
+
+describe('Event model', () => {
+  test('defines fields and table name', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('Event');
+    expect(attrs).toHaveProperty('event_id');
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('start_time');
+    expect(opts.tableName).toBe('Events');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/galactapediaCategory.test.js
+++ b/__tests__/models/galactapediaCategory.test.js
@@ -1,0 +1,17 @@
+const defineModel = require('../../models/galactapediaCategory');
+
+describe('GalactapediaCategory model', () => {
+  test('defines fields and charset options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('GalactapediaCategory');
+    expect(attrs).toHaveProperty('entry_id');
+    expect(attrs).toHaveProperty('category_id');
+    expect(opts.charset).toBe('utf8mb4');
+    expect(opts.collate).toBe('utf8mb4_unicode_ci');
+    expect(model).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- add test for jest config
- test tools commands `uexterminals`, `uexvehicle`, and `usagestats`
- add unit tests for several data models

## Testing
- `npm test`