### PR TITLE
Add tests for additional commands

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -77,6 +77,13 @@ const PermissionFlagsBits = {
   ManageRoles: 0x00010000
 };
 
+const PermissionsBitField = {
+  Flags: { SendMessages: 0x00000000 },
+  resolve: (bits) => bits
+};
+
+const ComponentType = { StringSelect: 'StringSelect' };
+
 const MessageFlags = {
   Ephemeral: 1 << 6,
 };
@@ -223,5 +230,7 @@ module.exports = {
   SlashCommandBuilder,
   SlashCommandSubcommandBuilder: SlashCommandBuilder,
   EmbedBuilder,
-  PermissionFlagsBits
+  PermissionFlagsBits,
+  PermissionsBitField,
+  ComponentType
 };

--- a/__tests__/commands/fun/highcard.test.js
+++ b/__tests__/commands/fun/highcard.test.js
@@ -1,0 +1,91 @@
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+let highcard;
+
+const makeGuild = (hasTester = false) => {
+  const challengerMember = {
+    displayName: 'Challenger',
+    roles: { cache: { has: jest.fn(() => hasTester) } },
+  };
+  const opponentMember = {
+    displayName: 'Opponent',
+    roles: { cache: { has: jest.fn() } },
+  };
+  return {
+    members: { fetch: jest.fn(id => (id === 'challenger' ? challengerMember : opponentMember)) },
+    roles: { cache: { find: jest.fn(fn => (fn({ name: 'Fleet Admiral' }) ? { id: 'fa' } : undefined)) } },
+  };
+};
+
+const makeChallengeInteraction = (self = false, hasTester = false) => ({
+  user: { id: 'challenger' },
+  options: { getSubcommand: jest.fn(() => 'challenge'), getUser: jest.fn(() => ({ id: self ? 'challenger' : 'opponent' })) },
+  guild: makeGuild(hasTester),
+  reply: jest.fn(),
+  followUp: jest.fn(),
+});
+
+const makeAcceptInteraction = (userId = 'opponent') => ({
+  user: { id: userId, tag: 'Opp#1' },
+  options: { getSubcommand: jest.fn(() => 'accept') },
+  guild: makeGuild(),
+  client: { users: { fetch: jest.fn(() => ({ id: 'challenger' })) } },
+  reply: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.resetModules();
+  highcard = require('../../../commands/fun/highcard');
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test('rejects self challenge without role', async () => {
+  const interaction = makeChallengeInteraction(true);
+  await highcard.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('challenge yourself'),
+    flags: MessageFlags.Ephemeral,
+  });
+});
+
+test('challenge then accept resolves duel', async () => {
+  const challenge = makeChallengeInteraction();
+  await highcard.execute(challenge);
+  expect(challenge.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('has challenged') }));
+
+  const accept = makeAcceptInteraction();
+  jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0);
+  await highcard.execute(accept);
+  Math.random.mockRestore();
+
+  expect(accept.reply).toHaveBeenCalled();
+  const text = accept.reply.mock.calls[0][0].content;
+  expect(text).toContain('High Card Duel Result');
+});
+
+test('accept with no challenge', async () => {
+  const accept = makeAcceptInteraction();
+  await highcard.execute(accept);
+  expect(accept.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('no pending challenges'),
+    flags: MessageFlags.Ephemeral,
+  });
+});
+
+test('rejects challenge when opponent already challenged', async () => {
+  const first = makeChallengeInteraction();
+  await highcard.execute(first);
+
+  const second = makeChallengeInteraction();
+  await highcard.execute(second);
+  expect(second.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('already has a pending challenge'),
+    flags: MessageFlags.Ephemeral,
+  });
+});
+

--- a/__tests__/commands/fun/roll.test.js
+++ b/__tests__/commands/fun/roll.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../utils/parseDice');
+
+const parseDice = require('../../../utils/parseDice');
+const roll = require('../../../commands/fun/roll');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('sends embed with dice result', async () => {
+  parseDice.mockReturnValue({ total: 7, rolls: ['3', '4'] });
+
+  const interaction = {
+    options: { getString: jest.fn(key => (key === 'formula' ? '2d4' : 'test')) },
+    reply: jest.fn(),
+  };
+  await roll.execute(interaction);
+
+  expect(parseDice).toHaveBeenCalledWith('2d4');
+  expect(interaction.reply).toHaveBeenCalled();
+  const embed = interaction.reply.mock.calls[0][0].embeds[0].toJSON();
+  expect(embed.title).toContain('Dice Roll');
+  expect(embed.fields[1].value).toBe('**7**');
+});
+
+test('handles invalid formula error', async () => {
+  parseDice.mockImplementation(() => { throw new Error('bad'); });
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const interaction = { options: { getString: jest.fn(() => 'bad') }, reply: jest.fn() };
+
+  await roll.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('Invalid dice formula'),
+    flags: MessageFlags.Ephemeral,
+  });
+  errSpy.mockRestore();
+});
+

--- a/__tests__/commands/tools/galactapedia.test.js
+++ b/__tests__/commands/tools/galactapedia.test.js
@@ -1,0 +1,53 @@
+jest.mock('../../../utils/verifyGuard');
+jest.mock('../../../config/database', () => ({
+  GalactapediaEntry: { findOne: jest.fn(), findAll: jest.fn(), findByPk: jest.fn() },
+  GalactapediaDetail: { findByPk: jest.fn(), upsert: jest.fn() },
+  GalactapediaCategory: { destroy: jest.fn(), upsert: jest.fn() },
+  GalactapediaTag: { destroy: jest.fn(), upsert: jest.fn() },
+  GalactapediaProperty: { destroy: jest.fn(), create: jest.fn() },
+  GalactapediaRelatedArticle: { destroy: jest.fn(), upsert: jest.fn() },
+}));
+jest.mock('../../../utils/fetchSCData');
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const { fetchSCDataByUrl } = require('../../../utils/fetchSCData');
+const command = require('../../../commands/tools/galactapedia');
+
+const makeInteraction = () => ({
+  options: { getString: jest.fn(() => 'foo') },
+  user: { id: '1' },
+  guild: {},
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  reply: jest.fn(),
+  channel: { awaitMessageComponent: jest.fn() },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('rejects unverified users', async () => {
+  isUserVerified.mockResolvedValue(false);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('verify'),
+    flags: expect.any(Number),
+  });
+});
+
+test('displays existing entry detail', async () => {
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  db.GalactapediaEntry.findOne.mockResolvedValue({ id: 1, title: 'Test', rsi_url: 'url' });
+  db.GalactapediaDetail.findByPk.mockResolvedValue({ content: 'desc' });
+
+  await command.execute(i);
+
+  expect(i.deferReply).toHaveBeenCalled();
+  const embed = i.editReply.mock.calls[0][0].embeds[0];
+  expect(embed.title).toBe('Test');
+});
+

--- a/__tests__/commands/tools/help.test.js
+++ b/__tests__/commands/tools/help.test.js
@@ -1,0 +1,32 @@
+const help = require('../../../commands/tools/help');
+const { ActionRowBuilder, StringSelectMenuBuilder, PermissionsBitField, MessageFlags } = require('../../../__mocks__/discord.js');
+
+const makeInteraction = () => {
+  const permissions = { has: jest.fn(() => true) };
+  return {
+    member: { permissions },
+    deferReply: jest.fn(),
+    followUp: jest.fn().mockResolvedValue({ createMessageComponentCollector: jest.fn(() => ({ on: jest.fn() })) }),
+  };
+};
+
+test('builds help menu from commands', async () => {
+  const interaction = makeInteraction();
+
+  const commands = new Map();
+  commands.set('a', { data: { name: 'a', default_member_permissions: PermissionsBitField.Flags.SendMessages }, help: 'desc', category: 'Fun' });
+  commands.set('b', { data: { name: 'b' }, help: 'other', category: 'Misc' });
+
+  const client = { commands };
+  await help.execute(interaction, client);
+
+  expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+  expect(interaction.followUp).toHaveBeenCalled();
+});
+
+test('option ignores unrelated custom id', async () => {
+  const spy = jest.fn();
+  await help.option({ customId: 'other', reply: spy });
+  expect(spy).not.toHaveBeenCalled();
+});
+

--- a/__tests__/commands/tools/org.test.js
+++ b/__tests__/commands/tools/org.test.js
@@ -1,0 +1,28 @@
+jest.mock('node-fetch');
+jest.mock('../../../config.json', () => ({ botPermsReq: 0 }), { virtual: true });
+
+const fetch = require('node-fetch');
+const command = require('../../../commands/tools/org');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+const makeInteraction = () => ({
+  options: { _hoistedOptions: [{ value: 'pfc' }] },
+  reply: jest.fn(),
+});
+
+afterEach(() => jest.clearAllMocks());
+
+test('replies with org info when found', async () => {
+  fetch.mockResolvedValue({ text: jest.fn().mockResolvedValue(JSON.stringify({ data: { name: 'PFC', url: 'u', headline: { plaintext: 'bio' }, logo: 'l', members: 1, recruiting: true } })) });
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({ flags: MessageFlags.Ephemeral }));
+});
+
+test('handles org not found', async () => {
+  fetch.mockResolvedValue({ text: jest.fn().mockResolvedValue(JSON.stringify({ message: 'not found' })) });
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith({ content: 'not found', flags: MessageFlags.Ephemeral });
+});
+

--- a/__tests__/commands/tools/shipdetails.test.js
+++ b/__tests__/commands/tools/shipdetails.test.js
@@ -1,0 +1,46 @@
+jest.mock('../../../utils/verifyGuard');
+jest.mock('../../../config/database', () => ({
+  Vehicle: { findOne: jest.fn(), findAll: jest.fn(), findByPk: jest.fn() },
+  VehicleDetail: { findByPk: jest.fn(), upsert: jest.fn() },
+}));
+jest.mock('../../../utils/fetchSCData');
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const command = require('../../../commands/tools/shipdetails');
+
+const makeInteraction = () => ({
+  options: { getString: jest.fn(() => 'ship') },
+  user: { id: '1' },
+  guild: {},
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  reply: jest.fn(),
+  channel: { awaitMessageComponent: jest.fn() },
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+test('rejects unverified user', async () => {
+  isUserVerified.mockResolvedValue(false);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('verify'),
+    flags: expect.any(Number),
+  });
+});
+
+test('shows vehicle detail when found', async () => {
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  db.Vehicle.findOne.mockResolvedValue({ uuid: '1', updated_at: new Date(), name: 'Ship' });
+  db.VehicleDetail.findByPk.mockResolvedValue({ uuid: '1', name: 'Ship', updated_at: new Date() });
+
+  await command.execute(i);
+
+  expect(i.deferReply).toHaveBeenCalled();
+  const embed = i.editReply.mock.calls[0][0].embeds[0];
+  expect(embed.title).toContain('Ship');
+});
+

--- a/__tests__/commands/tools/trade.test.js
+++ b/__tests__/commands/tools/trade.test.js
@@ -1,0 +1,38 @@
+jest.mock('../../../utils/trade/tradeHandlers', () => ({ safeReply: jest.fn() }));
+
+const { safeReply } = require('../../../utils/trade/tradeHandlers');
+
+jest.mock('../../../commands/tools/trade/best', () => ({ execute: jest.fn(), option: jest.fn(), button: jest.fn(), data: jest.fn(() => ({ name: 'best' })) }));
+const bestPath = require.resolve('../../../commands/tools/trade/best');
+
+const trade = require('../../../commands/tools/trade');
+
+afterEach(() => jest.clearAllMocks());
+
+test('executes subcommand module', async () => {
+  const interaction = { options: { getSubcommand: jest.fn(() => 'best') } };
+  const mod = require(bestPath);
+  await trade.execute(interaction, {});
+  expect(mod.execute).toHaveBeenCalledWith(interaction, {});
+});
+
+test('handles missing subcommand module', async () => {
+  const interaction = { options: { getSubcommand: jest.fn(() => 'missing') } };
+  await trade.execute(interaction, {});
+  expect(safeReply).toHaveBeenCalled();
+});
+
+test('option routes to subcommand handler', async () => {
+  const interaction = { customId: 'trade::best::x', deferUpdate: jest.fn() };
+  const mod = require(bestPath);
+  await trade.option(interaction, {});
+  expect(mod.option).toHaveBeenCalledWith(interaction, {});
+});
+
+test('button routes to subcommand handler', async () => {
+  const interaction = { customId: 'trade_best_select::whatever', deferUpdate: jest.fn() };
+  const mod = require(bestPath);
+  await trade.button(interaction, {});
+  expect(mod.button).toHaveBeenCalledWith(interaction, {});
+});
+

--- a/__tests__/commands/tools/trade/best.test.js
+++ b/__tests__/commands/tools/trade/best.test.js
@@ -1,0 +1,47 @@
+jest.mock('../../../../utils/trade/tradeHandlers', () => ({
+  handleTradeBest: jest.fn(),
+  handleTradeBestCore: jest.fn(() => ({ embed: {} })),
+}));
+jest.mock('../../../../utils/trade/handlers/shared');
+jest.mock('../../../../config/database', () => ({ UexVehicle: { findByPk: jest.fn() } }));
+
+const { handleTradeBest, handleTradeBestCore } = require('../../../../utils/trade/tradeHandlers');
+const shared = require('../../../../utils/trade/handlers/shared');
+const { UexVehicle } = require('../../../../config/database');
+const command = require('../../../../commands/tools/trade/best');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('execute caches state and calls handler', async () => {
+  const interaction = {
+    user: { id: '1', tag: 't' },
+    options: {
+      getString: jest.fn(key => (key === 'from' ? 'A' : 'B')),
+      getInteger: jest.fn(() => null),
+    },
+  };
+
+  await command.execute(interaction, {});
+  expect(shared.TradeStateCache.set).toHaveBeenCalledWith('1', { fromLocation: 'A', shipQuery: 'B', cash: null });
+  expect(handleTradeBest).toHaveBeenCalledWith(interaction, {}, { fromLocation: 'A', shipQuery: 'B', cash: null });
+});
+
+test('option processes ship selection', async () => {
+  const interaction = {
+    customId: 'trade::best::select_ship',
+    values: ['1'],
+    user: { id: '1', tag: 't' },
+    deferUpdate: jest.fn(),
+  };
+  shared.TradeStateCache.get.mockReturnValue({ fromLocation: 'A', shipQuery: 'B', cash: null });
+  UexVehicle.findByPk.mockResolvedValue({ id: '1' });
+
+  await command.option(interaction, {});
+
+  expect(UexVehicle.findByPk).toHaveBeenCalledWith('1', { raw: true });
+  expect(handleTradeBestCore).toHaveBeenCalled();
+  expect(shared.safeReply).toHaveBeenCalled();
+});
+

--- a/__tests__/commands/tools/uexfinditem.test.js
+++ b/__tests__/commands/tools/uexfinditem.test.js
@@ -1,0 +1,39 @@
+jest.mock('../../../utils/verifyGuard');
+jest.mock('../../../config/database', () => ({
+  UexItemPrice: { findAll: jest.fn() },
+  UexCommodityPrice: { findAll: jest.fn() },
+  UexVehiclePurchasePrice: { findAll: jest.fn() },
+  UexTerminal: { findAll: jest.fn() },
+}));
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const command = require('../../../commands/tools/uexfinditem');
+
+const makeInteraction = () => ({
+  options: { getString: jest.fn(() => 'med') },
+  user: { id: '1' },
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  reply: jest.fn(),
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+test('rejects when user not verified', async () => {
+  isUserVerified.mockResolvedValue(false);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
+});
+
+test('responds with no matches', async () => {
+  isUserVerified.mockResolvedValue(true);
+  db.UexItemPrice.findAll.mockResolvedValue([]);
+  db.UexCommodityPrice.findAll.mockResolvedValue([]);
+  db.UexVehiclePurchasePrice.findAll.mockResolvedValue([]);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.editReply).toHaveBeenCalledWith('No matches found. Try refining your search.');
+});
+

--- a/__tests__/commands/tools/uexinventory.test.js
+++ b/__tests__/commands/tools/uexinventory.test.js
@@ -1,0 +1,38 @@
+jest.mock('../../../utils/verifyGuard');
+jest.mock('../../../config/database', () => ({
+  UexTerminal: { findAll: jest.fn(), findByPk: jest.fn() },
+  UexItemPrice: { findAll: jest.fn() },
+  UexCommodityPrice: { findAll: jest.fn() },
+  UexFuelPrice: { findAll: jest.fn() },
+  UexVehiclePurchasePrice: { findAll: jest.fn() },
+  UexVehicleRentalPrice: { findAll: jest.fn() },
+}));
+
+const { isUserVerified } = require('../../../utils/verifyGuard');
+const db = require('../../../config/database');
+const command = require('../../../commands/tools/uexinventory');
+
+const makeInteraction = () => ({
+  options: { getString: jest.fn(() => 'Area18') },
+  user: { id: '1' },
+  reply: jest.fn(),
+  update: jest.fn(),
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+test('rejects when user not verified', async () => {
+  isUserVerified.mockResolvedValue(false);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({ flags: expect.any(Number) }));
+});
+
+test('no terminals found', async () => {
+  isUserVerified.mockResolvedValue(true);
+  db.UexTerminal.findAll.mockResolvedValue([]);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No terminals found') }));
+});
+


### PR DESCRIPTION
## Summary
- extend Discord mock with PermissionsBitField and ComponentType
- add unit tests for highcard, roll, galactapedia, help and org commands
- add tests for shipdetails, trade command and best subcommand
- cover uexfinditem and uexinventory commands

## Testing
- `npm test`