### PR TITLE
Add admin command tests

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -118,6 +118,10 @@ const ButtonStyle = {
   Secondary: 2,
 };
 
+const AttachmentBuilder = jest.fn(function(path) {
+  this.path = path;
+});
+
 const SlashCommandBuilder = jest.fn(() => {
   const builder = {
     name: undefined,
@@ -223,5 +227,6 @@ module.exports = {
   SlashCommandBuilder,
   SlashCommandSubcommandBuilder: SlashCommandBuilder,
   EmbedBuilder,
+  AttachmentBuilder,
   PermissionFlagsBits
 };

--- a/__tests__/commands/admin/listsnapchannels.test.js
+++ b/__tests__/commands/admin/listsnapchannels.test.js
@@ -1,0 +1,61 @@
+const { execute } = require('../../../commands/admin/listsnapchannels');
+const { listSnapChannels } = require('../../../botactions/channelManagement/snapChannels');
+const { MessageFlags } = require('discord.js');
+
+jest.mock('../../../botactions/channelManagement/snapChannels', () => ({
+  listSnapChannels: jest.fn()
+}));
+
+const makeInteraction = (roles = []) => {
+  const guild = {
+    id: 'guild1',
+    name: 'Test Guild',
+    channels: { cache: new Map([['c1', { name: 'chan1' }]]) }
+  };
+  return {
+    member: { roles: { cache: { map: fn => roles.map(r => fn({ name: r })) } } },
+    guild,
+    reply: jest.fn()
+  };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('/listsnapchannels command', () => {
+  test('rejects users without required role', async () => {
+    const interaction = makeInteraction(['User']);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('permission'),
+      flags: MessageFlags.Ephemeral
+    });
+    expect(listSnapChannels).not.toHaveBeenCalled();
+  });
+
+  test('lists channels for authorized user', async () => {
+    const interaction = makeInteraction(['Admiral']);
+    listSnapChannels.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 3 }]);
+    await execute(interaction);
+    expect(listSnapChannels).toHaveBeenCalledWith({ where: { serverId: 'guild1' } });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('chan1'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('handles errors gracefully', async () => {
+    const interaction = makeInteraction(['Fleet Admiral']);
+    const err = new Error('fail');
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    listSnapChannels.mockRejectedValue(err);
+
+    await execute(interaction);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('error'),
+      flags: MessageFlags.Ephemeral
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/listtags.test.js
+++ b/__tests__/commands/admin/listtags.test.js
@@ -1,0 +1,46 @@
+jest.mock('../../../config/database', () => require('../../../__mocks__/config/database'));
+const { execute } = require('../../../commands/admin/listtags');
+const { OrgTag } = require('../../../config/database');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({
+  deferReply: jest.fn(),
+  editReply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('/listtags command', () => {
+  test('replies when no tags defined', async () => {
+    const interaction = makeInteraction();
+    OrgTag.findAll.mockResolvedValue([]);
+
+    await execute(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.editReply).toHaveBeenCalledWith('❌ No organization tags are currently defined.');
+  });
+
+  test('lists tags when present', async () => {
+    const interaction = makeInteraction();
+    OrgTag.findAll.mockResolvedValue([{ tag: 'PFC', rsiOrgId: 'PFCS' }]);
+
+    await execute(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('PFCS')
+    });
+  });
+
+  test('handles fetch errors', async () => {
+    const interaction = makeInteraction();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    OrgTag.findAll.mockRejectedValue(new Error('fail'));
+
+    await execute(interaction);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith('❌ Something went wrong while fetching org tags.');
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/orgstatus.test.js
+++ b/__tests__/commands/admin/orgstatus.test.js
@@ -1,0 +1,41 @@
+jest.mock('../../../config/database', () => require('../../../__mocks__/config/database'));
+jest.mock('../../../utils/rsiScrapeOrgMembers');
+jest.mock('../../../utils/getGuildMembersWithRoles');
+
+const { execute } = require('../../../commands/admin/orgstatus');
+const { VerifiedUser } = require('../../../config/database');
+const rsiScrapeOrgMembers = require('../../../utils/rsiScrapeOrgMembers');
+const getGuildMembersWithRoles = require('../../../utils/getGuildMembersWithRoles');
+
+const makeInteraction = () => ({
+  guild: { memberCount: 5 },
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  guildId: 'guild1',
+  guild: {
+    id: 'guild1',
+    memberCount: 5
+  }
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/orgstatus report', () => {
+  test('generates report embed', async () => {
+    const interaction = makeInteraction();
+    rsiScrapeOrgMembers.mockResolvedValue({ members: [{ handle: 'A' }], redactedCount: 1 });
+    VerifiedUser.findAll.mockResolvedValue([
+      { rsiOrgId: 'PFCS', rsiHandle: 'A', discordUserId: 'd1' },
+      { rsiOrgId: 'OTHER', rsiHandle: 'B', discordUserId: 'd2' }
+    ]);
+    getGuildMembersWithRoles.mockResolvedValue([{ id: 'd1' }]);
+
+    await execute(interaction);
+
+    expect(rsiScrapeOrgMembers).toHaveBeenCalled();
+    expect(getGuildMembersWithRoles).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({ embeds: [expect.any(Object)] });
+  });
+});

--- a/__tests__/commands/admin/removesnapchannel.test.js
+++ b/__tests__/commands/admin/removesnapchannel.test.js
@@ -1,0 +1,54 @@
+const { execute } = require('../../../commands/admin/removesnapchannel');
+const { removeSnapChannel } = require('../../../botactions/channelManagement/snapChannels');
+const { MessageFlags } = require('discord.js');
+
+jest.mock('../../../botactions/channelManagement/snapChannels', () => ({
+  removeSnapChannel: jest.fn()
+}));
+
+const makeInteraction = (roles = []) => ({
+  member: { roles: { cache: { map: fn => roles.map(r => fn({ name: r })) } } },
+  options: { getChannel: jest.fn(() => ({ id: 'c1', name: 'chan' })) },
+  guild: {},
+  reply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('/removesnapchannel command', () => {
+  test('rejects users without role', async () => {
+    const interaction = makeInteraction(['User']);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('permission'),
+      flags: MessageFlags.Ephemeral
+    });
+    expect(removeSnapChannel).not.toHaveBeenCalled();
+  });
+
+  test('removes channel when authorized', async () => {
+    const interaction = makeInteraction(['Admiral']);
+    await execute(interaction);
+    expect(removeSnapChannel).toHaveBeenCalledWith('c1');
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('removed'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('handles errors gracefully', async () => {
+    const interaction = makeInteraction(['Fleet Admiral']);
+    const err = new Error('fail');
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    removeSnapChannel.mockRejectedValue(err);
+
+    await execute(interaction);
+
+    expect(spy).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('error'),
+      flags: MessageFlags.Ephemeral
+    });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/runTests.test.js
+++ b/__tests__/commands/admin/runTests.test.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+const { AttachmentBuilder, MessageFlags } = require('discord.js');
+const path = require('path');
+
+jest.mock('child_process', () => ({ exec: jest.fn() }));
+jest.mock('fs');
+
+const { execute } = require('../../../commands/admin/runTests');
+
+const makeInteraction = () => ({
+  deferReply: jest.fn(),
+  editReply: jest.fn()
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/runtests command', () => {
+  test('runs tests and uploads file', async () => {
+    const interaction = makeInteraction();
+    exec.mockImplementation((cmd, opts, cb) => cb(null, 'out', ''));
+    fs.writeFileSync.mockReturnValue();
+    fs.unlink.mockImplementation((p, cb) => cb(null));
+
+    await execute(interaction);
+
+    expect(exec).toHaveBeenCalledWith('npm run test', expect.any(Object), expect.any(Function));
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Test run complete'),
+      files: expect.any(Array),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+
+  test('handles file errors gracefully', async () => {
+    const interaction = makeInteraction();
+    exec.mockImplementation((cmd, opts, cb) => cb(null, 'out', ''));
+    fs.writeFileSync.mockImplementation(() => { throw new Error('fail'); });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await execute(interaction);
+
+    expect(spy).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({ content: '❌ Test ran but failed to upload output.', flags: MessageFlags.Ephemeral });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/schedule.test.js
+++ b/__tests__/commands/admin/schedule.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../botactions/scheduling/scheduleHandler', () => ({
+  saveAnnouncementToDatabase: jest.fn()
+}));
+
+const { pendingChannelSelection } = require('../../../utils/pendingSelections');
+const { saveAnnouncementToDatabase } = require('../../../botactions/scheduling/scheduleHandler');
+const { execute, option } = require('../../../commands/admin/schedule');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({
+  showModal: jest.fn(),
+  values: ['channel1'],
+  guild: { id: 'guild1' },
+  reply: jest.fn(),
+  user: { id: 'user1' }
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const k of Object.keys(pendingChannelSelection)) delete pendingChannelSelection[k];
+});
+
+
+describe('/schedule option handler', () => {
+  test('rejects when no pending announcement', async () => {
+    const interaction = makeInteraction();
+    await option(interaction, {});
+    expect(interaction.reply).toHaveBeenCalledWith({ content: expect.stringContaining('No pending'), flags: MessageFlags.Ephemeral });
+  });
+
+  test('saves announcement and clears pending', async () => {
+    const interaction = makeInteraction();
+    pendingChannelSelection['user1'] = { title: 't', description: 'd', author: 'a', time: 'now' };
+    interaction.user = { id: 'user1' };
+    await option(interaction, {});
+    expect(saveAnnouncementToDatabase).toHaveBeenCalledWith('channel1', 'guild1', expect.any(Object), 'now', {});
+    expect(pendingChannelSelection['user1']).toBeUndefined();
+    expect(interaction.reply).toHaveBeenCalledWith({ content: expect.stringContaining('successfully'), flags: MessageFlags.Ephemeral });
+  });
+});

--- a/__tests__/commands/admin/scrapeProfile.test.js
+++ b/__tests__/commands/admin/scrapeProfile.test.js
@@ -1,0 +1,35 @@
+jest.mock('../../../utils/rsiProfileScraper');
+const { fetchRsiProfileInfo } = require('../../../utils/rsiProfileScraper');
+const { execute } = require('../../../commands/admin/scrapeProfile');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({
+  options: { getString: jest.fn(() => 'Handle') },
+  reply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('/scrape-profile command', () => {
+  test('replies with profile embed', async () => {
+    const interaction = makeInteraction();
+    fetchRsiProfileInfo.mockResolvedValue({ handle: 'Handle', bio: 'b', enlisted: 'e', avatar: 'a', orgRank: 'r', orgName: 'n', orgId: 'id' });
+
+    await execute(interaction);
+
+    expect(fetchRsiProfileInfo).toHaveBeenCalledWith('Handle');
+    expect(interaction.reply).toHaveBeenCalledWith({ embeds: [expect.any(Object)], flags: MessageFlags.Ephemeral });
+  });
+
+  test('handles errors', async () => {
+    const interaction = makeInteraction();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    fetchRsiProfileInfo.mockRejectedValue(new Error('fail'));
+
+    await execute(interaction);
+
+    expect(spy).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Failed to fetch profile'), flags: MessageFlags.Ephemeral }));
+    spy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/setorgtag.test.js
+++ b/__tests__/commands/admin/setorgtag.test.js
@@ -1,0 +1,43 @@
+jest.mock('../../../config/database', () => require('../../../__mocks__/config/database'));
+const { OrgTag } = require('../../../config/database');
+const { execute } = require('../../../commands/admin/setorgtag');
+const { MessageFlags, PermissionFlagsBits } = require('discord.js');
+
+const makeInteraction = (isAdmin = true) => ({
+  member: { permissions: { has: jest.fn(() => isAdmin) } },
+  options: {
+    getString: jest.fn(name => (name === 'rsi_org_id' ? 'pfcs' : 'pfc'))
+  },
+  reply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+beforeAll(() => { OrgTag.upsert = jest.fn(); });
+
+describe('/set-org-tag command', () => {
+  test('blocks non-admin users', async () => {
+    const interaction = makeInteraction(false);
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: expect.any(String), flags: MessageFlags.Ephemeral });
+    expect(OrgTag.upsert).not.toHaveBeenCalled();
+  });
+
+  test('saves org tag with uppercase values', async () => {
+    const interaction = makeInteraction(true);
+    await execute(interaction);
+    expect(OrgTag.upsert).toHaveBeenCalledWith({ rsiOrgId: 'PFCS', tag: 'PFC' });
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('PFCS'), flags: MessageFlags.Ephemeral }));
+  });
+
+  test('handles errors gracefully', async () => {
+    const interaction = makeInteraction(true);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    OrgTag.upsert.mockRejectedValue(new Error('fail'));
+
+    await execute(interaction);
+
+    expect(spy).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Something went wrong'), flags: MessageFlags.Ephemeral }));
+    spy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/syncOrgRanks.test.js
+++ b/__tests__/commands/admin/syncOrgRanks.test.js
@@ -1,0 +1,34 @@
+jest.mock('../../../config/database', () => require('../../../__mocks__/config/database'));
+jest.mock('../../../utils/rsiProfileScraper');
+
+const { execute } = require('../../../commands/admin/syncOrgRanks');
+const { VerifiedUser } = require('../../../config/database');
+const { fetchRsiProfileInfo } = require('../../../utils/rsiProfileScraper');
+
+const makeInteraction = () => ({
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  guild: {
+    members: {
+      fetch: jest.fn(() => Promise.resolve({
+        roles: { cache: { map: fn => ['captain'].map(n => fn({ name: n })) } },
+        user: { tag: 'user#1' }
+      }))
+    }
+  }
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('/sync-org-ranks command', () => {
+  test('reports mismatches', async () => {
+    const interaction = makeInteraction();
+    VerifiedUser.findAll.mockResolvedValue([{ rsiHandle: 'foo', discordUserId: 'id1', rsiOrgId: 'PFCS' }]);
+    fetchRsiProfileInfo.mockResolvedValue({ orgId: 'PFCS', orgRank: 'Admiral' });
+
+    await execute(interaction);
+
+    expect(fetchRsiProfileInfo).toHaveBeenCalledWith('foo');
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.any(String));
+  });
+});

--- a/__tests__/commands/admin/updateaccolade.test.js
+++ b/__tests__/commands/admin/updateaccolade.test.js
@@ -1,0 +1,49 @@
+jest.mock('../../../config/database', () => ({
+  Accolade: {
+    findOne: jest.fn()
+  }
+}));
+jest.mock('../../../utils/accoladeEmbedBuilder');
+const { execute } = require('../../../commands/admin/updateaccolade');
+const { Accolade } = require('../../../config/database');
+const { buildAccoladeEmbed } = require('../../../utils/accoladeEmbedBuilder');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = (emoji = '<:medal:1>', desc = 'desc') => {
+  const guild = {
+    channels: { fetch: jest.fn(() => ({ type: 0, messages: { fetch: jest.fn(() => Promise.resolve({ edit: jest.fn() })) }, send: jest.fn(() => ({ id: 'mid' })) })) },
+    members: { fetch: jest.fn(() => Promise.resolve()), cache: { filter: jest.fn(() => ({ map: fn => [] })) } }
+  };
+  return {
+    options: {
+      getRole: jest.fn(() => ({ id: 'r1', name: 'Role' })),
+      getString: jest.fn(name => (name === 'emoji' ? emoji : desc))
+    },
+    guild,
+    reply: jest.fn()
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('/updateaccolade command', () => {
+  test('rejects invalid emoji', async () => {
+    const interaction = makeInteraction('invalid');
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('valid emoji'), flags: MessageFlags.Ephemeral }));
+  });
+
+  test('updates accolade and message', async () => {
+    const interaction = makeInteraction();
+    Accolade.findOne.mockResolvedValue({ role_id: 'r1', name: 'Test', save: jest.fn(), channel_id: 'c1', message_id: 'm1', emoji: '', description: '' });
+    buildAccoladeEmbed.mockReturnValue('embed');
+
+    await execute(interaction);
+
+    expect(Accolade.findOne).toHaveBeenCalledWith({ where: { role_id: 'r1' } });
+    expect(buildAccoladeEmbed).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({ content: expect.stringContaining('updated'), flags: MessageFlags.Ephemeral });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for various admin commands
- extend discord.js mock to support AttachmentBuilder

## Testing
- `npm test`