### PR TITLE
Add tests for botaction modules

### DIFF
--- a/__tests__/botactions/api/syncEndpoints.test.js
+++ b/__tests__/botactions/api/syncEndpoints.test.js
@@ -1,0 +1,93 @@
+const {
+  syncAllEndpoints,
+  syncManufacturers,
+  syncVehicles,
+  syncGalactapedia,
+  syncUexVehicles,
+  syncUexTerminals,
+  syncUexItemPrices,
+  syncUexCategories,
+  syncUexCommodityPrices,
+  syncUexFuelPrices,
+  syncUexVehiclePurchasePrices,
+  syncUexVehicleRentalPrices,
+  syncUexPois
+} = require('../../../botactions/api/syncEndpoints');
+
+jest.mock('../../../utils/apiSync/manufacturers', () => ({ syncManufacturers: jest.fn() }));
+jest.mock('../../../utils/apiSync/vehicles', () => ({ syncVehicles: jest.fn() }));
+jest.mock('../../../utils/apiSync/galactapedia', () => ({ syncGalactapedia: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexVehicles', () => ({ syncUexVehicles: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexTerminals', () => ({ syncUexTerminals: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexItemPrices', () => ({ syncUexItemPrices: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexCategories', () => ({ syncUexCategories: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexCommodityPrices', () => ({ syncUexCommodityPrices: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexFuelPrices', () => ({ syncUexFuelPrices: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexVehiclePurchasePrices', () => ({ syncUexVehiclePurchasePrices: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexVehicleRentalPrices', () => ({ syncUexVehicleRentalPrices: jest.fn() }));
+jest.mock('../../../utils/apiSync/syncUexPoi', () => ({ syncUexPois: jest.fn() }));
+
+const manufacturers = require('../../../utils/apiSync/manufacturers');
+const vehicles = require('../../../utils/apiSync/vehicles');
+const galactapedia = require('../../../utils/apiSync/galactapedia');
+const uexVehicles = require('../../../utils/apiSync/syncUexVehicles');
+const uexTerminals = require('../../../utils/apiSync/syncUexTerminals');
+const uexItemPrices = require('../../../utils/apiSync/syncUexItemPrices');
+const uexCategories = require('../../../utils/apiSync/syncUexCategories');
+const uexCommodityPrices = require('../../../utils/apiSync/syncUexCommodityPrices');
+const uexFuelPrices = require('../../../utils/apiSync/syncUexFuelPrices');
+const uexVehiclePurchasePrices = require('../../../utils/apiSync/syncUexVehiclePurchasePrices');
+const uexVehicleRentalPrices = require('../../../utils/apiSync/syncUexVehicleRentalPrices');
+const uexPois = require('../../../utils/apiSync/syncUexPoi');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('syncAllEndpoints', () => {
+  test('returns results from all sync functions in order', async () => {
+    const results = [];
+    const fns = [
+      uexTerminals.syncUexTerminals,
+      manufacturers.syncManufacturers,
+      vehicles.syncVehicles,
+      galactapedia.syncGalactapedia,
+      uexVehicles.syncUexVehicles,
+      uexItemPrices.syncUexItemPrices,
+      uexCategories.syncUexCategories,
+      uexCommodityPrices.syncUexCommodityPrices,
+      uexFuelPrices.syncUexFuelPrices,
+      uexVehiclePurchasePrices.syncUexVehiclePurchasePrices,
+      uexVehicleRentalPrices.syncUexVehicleRentalPrices,
+      uexPois.syncUexPois
+    ];
+    fns.forEach((fn, i) => fn.mockResolvedValue({ id: i }));
+
+    const res = await syncAllEndpoints();
+
+    expect(res).toEqual(fns.map((_, i) => ({ id: i })));
+    fns.forEach(fn => expect(fn).toHaveBeenCalled());
+  });
+
+  test('handles errors and continues processing', async () => {
+    uexTerminals.syncUexTerminals.mockRejectedValue(new Error('fail'));
+    manufacturers.syncManufacturers.mockResolvedValue('a');
+    vehicles.syncVehicles.mockResolvedValue('b');
+    galactapedia.syncGalactapedia.mockResolvedValue('c');
+    uexVehicles.syncUexVehicles.mockResolvedValue('d');
+    uexItemPrices.syncUexItemPrices.mockResolvedValue('e');
+    uexCategories.syncUexCategories.mockResolvedValue('f');
+    uexCommodityPrices.syncUexCommodityPrices.mockResolvedValue('g');
+    uexFuelPrices.syncUexFuelPrices.mockResolvedValue('h');
+    uexVehiclePurchasePrices.syncUexVehiclePurchasePrices.mockResolvedValue('i');
+    uexVehicleRentalPrices.syncUexVehicleRentalPrices.mockResolvedValue('j');
+    uexPois.syncUexPois.mockResolvedValue('k');
+
+    const res = await syncAllEndpoints();
+
+    expect(res[0]).toEqual({ endpoint: 'terminals', success: false, error: 'fail' });
+    expect(res.slice(1)).toEqual(['a','b','c','d','e','f','g','h','i','j','k']);
+    expect(uexTerminals.syncUexTerminals).toHaveBeenCalled();
+    expect(uexPois.syncUexPois).toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/channelManagement.test.js
+++ b/__tests__/botactions/channelManagement.test.js
@@ -1,0 +1,28 @@
+jest.mock('../../botactions/channelManagement/channelRegistry', () => ({ registerChannels: jest.fn() }));
+jest.mock('../../botactions/channelManagement/messageCleanup', () => ({ deleteMessages: jest.fn() }));
+jest.mock('../../botactions/channelManagement/snapChannels', () => ({
+  addSnapChannel: jest.fn(),
+  removeSnapChannel: jest.fn(),
+  listSnapChannels: jest.fn()
+}));
+
+const registry = require('../../botactions/channelManagement/channelRegistry');
+const cleanup = require('../../botactions/channelManagement/messageCleanup');
+const snaps = require('../../botactions/channelManagement/snapChannels');
+const cm = require('../../botactions/channelManagement');
+
+describe('channelManagement exports', () => {
+  test('re-exports underlying functions', async () => {
+    await cm.registerChannels('client');
+    await cm.deleteMessages('client');
+    await cm.addSnapChannel('id');
+    await cm.removeSnapChannel('id');
+    await cm.listSnapChannels();
+
+    expect(registry.registerChannels).toHaveBeenCalledWith('client');
+    expect(cleanup.deleteMessages).toHaveBeenCalledWith('client');
+    expect(snaps.addSnapChannel).toHaveBeenCalledWith('id');
+    expect(snaps.removeSnapChannel).toHaveBeenCalledWith('id');
+    expect(snaps.listSnapChannels).toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/channelManagement/messageCleanup.test.js
+++ b/__tests__/botactions/channelManagement/messageCleanup.test.js
@@ -1,0 +1,69 @@
+jest.useFakeTimers();
+
+jest.mock('../../../config/database', () => ({
+  SnapChannel: {
+    findAll: jest.fn()
+  }
+}));
+
+const db = require('../../../config/database');
+const { deleteMessages } = require('../../../botactions/channelManagement/messageCleanup');
+
+describe('deleteMessages', () => {
+  let client;
+  let channel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    channel = {
+      id: 'c1',
+      name: 'chan',
+      type: 0,
+      permissionsFor: () => ({ has: () => true }),
+      messages: { fetch: jest.fn() },
+      bulkDelete: jest.fn()
+    };
+    client = {
+      user: { id: 'bot', tag: 'bot#0001' },
+      guilds: { cache: new Map([['g1', { name: 'guild', id: 'g1' }]]) },
+      channels: { fetch: jest.fn().mockResolvedValue(channel) }
+    };
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('deletes eligible messages', async () => {
+    const now = Date.now();
+    const makeCollection = entries => {
+      const col = new Map(entries);
+      col.filter = fn => makeCollection([...col].filter(([id, m]) => fn(m)));
+      return col;
+    };
+    const msgs = makeCollection([
+      ['1', { id: '1', pinned: false, createdTimestamp: now - 2 * 86400000, author: { tag: 'a', id: 'u' } }],
+      ['2', { id: '2', pinned: false, createdTimestamp: now - 20 * 86400000, delete: jest.fn(), author: { tag: 'a', id: 'u' } }]
+    ]);
+    channel.messages.fetch.mockResolvedValue(msgs);
+    channel.messages.fetch.mockRejectedValueOnce({ code: 10008 });
+    db.SnapChannel.findAll.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 1 }]);
+    const p = deleteMessages(client);
+    jest.runAllTimers();
+    await p;
+    expect(channel.messages.fetch).toHaveBeenCalled();
+  });
+  test('logs error and continues when DB fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    db.SnapChannel.findAll.mockRejectedValue(new Error('db fail'));
+
+    const p = deleteMessages(client);
+    jest.runAllTimers();
+    await p;
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(client.channels.fetch).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/botactions/channelManagement/snapChannels.test.js
+++ b/__tests__/botactions/channelManagement/snapChannels.test.js
@@ -1,0 +1,76 @@
+jest.mock('../../../config/database', () => ({
+  SnapChannel: {
+    create: jest.fn(),
+    findOne: jest.fn(),
+    findAll: jest.fn()
+  }
+}));
+
+const db = require('../../../config/database');
+const {
+  addSnapChannel,
+  removeSnapChannel,
+  listSnapChannels
+} = require('../../../botactions/channelManagement/snapChannels');
+
+describe('snapChannels', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('addSnapChannel logs on success', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await addSnapChannel('c1', 7, 'g1');
+    expect(db.SnapChannel.create).toHaveBeenCalledWith({ channelId: 'c1', purgeTimeInDays: 7, serverId: 'g1' });
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  test('addSnapChannel logs error on failure', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    db.SnapChannel.create.mockRejectedValue(new Error('fail'));
+    await addSnapChannel('c1', 7, 'g1');
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  test('removeSnapChannel destroys when found', async () => {
+    const destroy = jest.fn();
+    db.SnapChannel.findOne.mockResolvedValue({ destroy });
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    await removeSnapChannel('c2');
+    expect(db.SnapChannel.findOne).toHaveBeenCalledWith({ where: { channelId: 'c2' } });
+    expect(destroy).toHaveBeenCalled();
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  test('removeSnapChannel logs not found', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    db.SnapChannel.findOne.mockResolvedValue(null);
+    await removeSnapChannel('c2');
+    expect(log).toHaveBeenCalledWith('Channel c2 not found.');
+    log.mockRestore();
+  });
+
+  test('removeSnapChannel logs error on failure', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    db.SnapChannel.findOne.mockRejectedValue(new Error('fail'));
+    await removeSnapChannel('c2');
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  test('listSnapChannels returns value', async () => {
+    db.SnapChannel.findAll.mockResolvedValue(['a']);
+    const res = await listSnapChannels({ where: {}});
+    expect(res).toEqual(['a']);
+    expect(db.SnapChannel.findAll).toHaveBeenCalledWith({ where: {}});
+  });
+
+  test('listSnapChannels throws on error', async () => {
+    db.SnapChannel.findAll.mockRejectedValue(new Error('fail'));
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(listSnapChannels()).rejects.toThrow('fail');
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/__tests__/botactions/channelSelector.test.js
+++ b/__tests__/botactions/channelSelector.test.js
@@ -1,0 +1,45 @@
+const discordMock = require("../../__mocks__/discord.js");
+discordMock.ChannelType = { GuildCategory: "GUILD_CATEGORY" };
+discordMock.StringSelectMenuBuilder.mockImplementation(function(){
+  const data = { options: [], customId: undefined, placeholder: undefined };
+  this.setCustomId = jest.fn(id => { data.customId = id; return this; });
+  this.setPlaceholder = jest.fn(ph => { data.placeholder = ph; return this; });
+  this.addOptions = jest.fn(opt => { data.options.push(opt); return this; });
+  this.data = data;
+  return this;
+});
+const { createChannelSelectMenu } = require('../../botactions/channelSelector');
+
+const makeCollection = entries => {
+  const col = new Map(entries);
+  col.filter = fn => makeCollection([...col].filter(([id, c]) => fn(c)));
+  col.forEach = callback => { for (const val of col.values()) callback(val); };
+  return col;
+};
+
+function buildGuild() {
+  const categories = [
+    { id: 'cat', name: 'PFCS Channels', type: 'GUILD_CATEGORY' },
+  ];
+  const text = [
+    { id: 't1', name: 'chat1', parentId: 'cat' },
+    { id: 't2', name: 'chat2', parentId: 'cat' }
+  ];
+  const all = [...categories, ...text];
+  return {
+    channels: { cache: makeCollection(all.map(c => [c.id, c])) }
+  };
+}
+
+describe('createChannelSelectMenu', () => {
+  test('throws when categories not present', async () => {
+    const guild = { channels: { cache: makeCollection([]) } };
+    await expect(createChannelSelectMenu(guild)).rejects.toThrow('None of the categories');
+  });
+
+  test('builds menu with options', async () => {
+    const guild = buildGuild();
+    const row = await createChannelSelectMenu(guild);
+    expect(row.addComponents).toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/commandHandling/channelSelector.test.js
+++ b/__tests__/botactions/commandHandling/channelSelector.test.js
@@ -1,0 +1,38 @@
+const discordMock = require("../../../__mocks__/discord.js");
+discordMock.ChannelType = { GuildCategory: "GUILD_CATEGORY" };
+discordMock.StringSelectMenuBuilder.mockImplementation(function(){
+  const data = { options: [], customId: undefined, placeholder: undefined };
+  this.setCustomId = jest.fn(id => { data.customId = id; return this; });
+  this.setPlaceholder = jest.fn(ph => { data.placeholder = ph; return this; });
+  this.addOptions = jest.fn(opt => { data.options.push(opt); return this; });
+  this.data = data;
+  return this;
+});
+const { createChannelSelectMenu } = require("../../../botactions/commandHandling/channelSelector");
+
+const makeCollection = entries => {
+  const col = new Map(entries);
+  col.filter = fn => makeCollection([...col].filter(([id, c]) => fn(c)));
+  return col;
+};
+
+function buildGuild() {
+  const cats = [{ id: 'c1', name: 'PFCS Channels', type: 'GUILD_CATEGORY' }];
+  const chans = [{ id: 'x', name: 'chan', parentId: 'c1' }];
+  return {
+    channels: { cache: makeCollection([...cats, ...chans].map(c => [c.id, c])) }
+  };
+}
+
+describe('commandHandling channelSelector', () => {
+  test('throws if no categories', async () => {
+    const guild = { channels: { cache: makeCollection([]) } };
+    await expect(createChannelSelectMenu(guild)).rejects.toThrow('None of the categories');
+  });
+
+  test('custom prefix reflected in customId', async () => {
+    const guild = buildGuild();
+    const row = await createChannelSelectMenu(guild, 'test');
+    expect(row.addComponents).toHaveBeenCalled();
+  });
+});

--- a/__tests__/botactions/commandHandling/modalHandler.test.js
+++ b/__tests__/botactions/commandHandling/modalHandler.test.js
@@ -1,0 +1,51 @@
+jest.mock('../../../botactions/scheduling/scheduleHandler', () => ({
+  saveAnnouncementToDatabase: jest.fn()
+}));
+
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+const { saveAnnouncementToDatabase } = require('../../../botactions/scheduling/scheduleHandler');
+const handler = require('../../../botactions/commandHandling/modalHandler');
+
+describe('modalHandler', () => {
+  test('ignores non modal submit', async () => {
+    const interaction = { isModalSubmit: () => false };
+    await handler.execute(interaction);
+    expect(saveAnnouncementToDatabase).not.toHaveBeenCalled();
+  });
+
+  test('rejects invalid time', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      isModalSubmit: () => true,
+      customId: 'scheduleModal',
+      fields: { getTextInputValue: jest.fn((id) => ({
+        channel: 'c1', title: 't', description: 'd', color: '', author: '', footer: '', time: 'bad'
+      })[id]) },
+      reply
+    };
+    await handler.execute(interaction);
+    expect(reply).toHaveBeenCalledWith({ content: 'Invalid time format. Please use YYYY-MM-DD HH:mm:ss', flags: MessageFlags.Ephemeral });
+    expect(saveAnnouncementToDatabase).not.toHaveBeenCalled();
+  });
+
+  test('saves announcement on valid input', async () => {
+    const reply = jest.fn();
+    const interaction = {
+      isModalSubmit: () => true,
+      customId: 'scheduleModal',
+      fields: { getTextInputValue: jest.fn((id) => ({
+        channel: 'c1',
+        title: 't',
+        description: 'd',
+        color: '#fff',
+        author: 'a',
+        footer: 'f',
+        time: '2023-01-01 10:00:00'
+      })[id]) },
+      reply
+    };
+    await handler.execute(interaction);
+    expect(saveAnnouncementToDatabase).toHaveBeenCalledWith('c1', { title: 't', description: 'd', color: '#fff', author: 'a', footer: 'f' }, '2023-01-01 10:00:00');
+    expect(reply).toHaveBeenCalledWith({ content: 'Announcement scheduled for 2023-01-01 10:00:00 in channel c1', flags: MessageFlags.Ephemeral });
+  });
+});

--- a/__tests__/botactions/configLoader.test.js
+++ b/__tests__/botactions/configLoader.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+jest.mock('fs');
+
+const { loadConfiguration } = require('../../botactions/configLoader');
+
+describe('loadConfiguration', () => {
+  test('reads and parses config file', () => {
+    fs.readFileSync.mockReturnValue('{"token":"1"}');
+    const res = loadConfiguration();
+    expect(fs.readFileSync.mock.calls[0][0]).toContain('config.json');
+    expect(res).toEqual({ token: '1' });
+  });
+});

--- a/__tests__/botactions/eventHandling.test.js
+++ b/__tests__/botactions/eventHandling.test.js
@@ -1,0 +1,26 @@
+jest.mock('../../botactions/eventHandling/interactionEvents', () => ({ handleInteraction: jest.fn() }));
+jest.mock('../../botactions/eventHandling/messageEvents', () => ({ handleMessageCreate: jest.fn() }));
+jest.mock('../../botactions/eventHandling/reactionEvents', () => ({ handleReactionAdd: jest.fn(), handleReactionRemove: jest.fn() }));
+jest.mock('../../botactions/eventHandling/voiceEvents', () => ({ handleVoiceStateUpdate: jest.fn() }));
+
+const interactionModule = require('../../botactions/eventHandling/interactionEvents');
+const messageEvents = require('../../botactions/eventHandling/messageEvents');
+const reactionEvents = require('../../botactions/eventHandling/reactionEvents');
+const voiceEvents = require('../../botactions/eventHandling/voiceEvents');
+const events = require('../../botactions/eventHandling');
+
+describe('eventHandling index', () => {
+  test('exports functions from submodules', async () => {
+    await events.interactionHandler.handleInteraction('i');
+    await events.handleMessageCreate('m');
+    await events.handleReactionAdd('r');
+    await events.handleReactionRemove('rr');
+    await events.handleVoiceStateUpdate('v');
+
+    expect(interactionModule.handleInteraction).toHaveBeenCalledWith('i');
+    expect(messageEvents.handleMessageCreate).toHaveBeenCalledWith('m');
+    expect(reactionEvents.handleReactionAdd).toHaveBeenCalledWith('r');
+    expect(reactionEvents.handleReactionRemove).toHaveBeenCalledWith('rr');
+    expect(voiceEvents.handleVoiceStateUpdate).toHaveBeenCalledWith('v');
+  });
+});

--- a/__tests__/botactions/eventHandling/interactionEvents.test.js
+++ b/__tests__/botactions/eventHandling/interactionEvents.test.js
@@ -1,0 +1,99 @@
+jest.mock('../../../botactions/eventHandling/interactionEvents/buildOptionsSummary', () => ({ buildOptionsSummary: jest.fn(() => 'summary') }));
+jest.mock('../../../botactions/eventHandling/interactionEvents/logInteraction', () => ({ logInteraction: jest.fn() }));
+jest.mock('../../../botactions/commandHandling/channelSelector', () => ({ createChannelSelectMenu: jest.fn(() => 'menu') }));
+
+const { buildOptionsSummary } = require('../../../botactions/eventHandling/interactionEvents/buildOptionsSummary');
+const { logInteraction } = require('../../../botactions/eventHandling/interactionEvents/logInteraction');
+const { createChannelSelectMenu } = require('../../../botactions/commandHandling/channelSelector');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+const { pendingChannelSelection } = require('../../../utils/pendingSelections');
+const { handleInteraction } = require('../../../botactions/eventHandling/interactionEvents');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const key in pendingChannelSelection) delete pendingChannelSelection[key];
+});
+
+describe('handleInteraction', () => {
+  test('logs error on null interaction', async () => {
+    const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await handleInteraction(null, {});
+    expect(err).toHaveBeenCalledWith('❌ Interaction is null or undefined');
+    err.mockRestore();
+  });
+
+  test('handles command interactions', async () => {
+    const execute = jest.fn();
+    const client = { commands: new Map([['test', { execute }]]) };
+    const interaction = {
+      isCommand: () => true,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      commandName: 'test',
+      guild: { id: 'g1' }
+    };
+    await handleInteraction(interaction, client);
+    expect(buildOptionsSummary).toHaveBeenCalledWith(interaction);
+    expect(logInteraction).toHaveBeenCalledWith(expect.objectContaining({ type: 'command', commandName: 'test', serverId: 'g1', optionsSummary: 'summary' }));
+    expect(execute).toHaveBeenCalledWith(interaction, client);
+  });
+
+  test('handles button interactions', async () => {
+    const button = jest.fn();
+    const client = { commands: new Map([['foo', { data: { name: 'foo' }, button }]]) };
+    const interaction = {
+      isCommand: () => false,
+      isButton: () => true,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      customId: 'foo::btn',
+      message: { interaction: { commandName: 'foo' } },
+      guild: { id: 'g1' },
+      replied: false,
+      deferred: false,
+      reply: jest.fn()
+    };
+    await handleInteraction(interaction, client);
+    expect(button).toHaveBeenCalledWith(interaction, client);
+    expect(logInteraction).toHaveBeenCalledWith(expect.objectContaining({ type: 'button', commandName: 'foo' }));
+  });
+
+  test('handles select menu interactions', async () => {
+    const option = jest.fn();
+    const client = { commands: new Map([['foo', { data: { name: 'foo' }, option }]]) };
+    const interaction = {
+      isCommand: () => false,
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      isModalSubmit: () => false,
+      customId: 'foo::select',
+      values: ['A'],
+      guild: { id: 'g1' },
+      replied: false,
+      deferred: false,
+      reply: jest.fn()
+    };
+    await handleInteraction(interaction, client);
+    expect(option).toHaveBeenCalledWith(interaction, client);
+    expect(logInteraction).toHaveBeenCalledWith(expect.objectContaining({ type: 'select_menu', commandName: 'foo', optionsSummary: 'selected: [A]' }));
+  });
+
+  test('handles modal submission with scheduleModal', async () => {
+    const interaction = {
+      isCommand: () => false,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => true,
+      customId: 'scheduleModal',
+      user: { id: 'u1' },
+      guild: {},
+      fields: { getTextInputValue: jest.fn(key => ({ title:'t', description:'d', time:'in 1 minute' }[key])) },
+      reply: jest.fn()
+    };
+    await handleInteraction(interaction, { commands: new Map() });
+    expect(createChannelSelectMenu).toHaveBeenCalled();
+    expect(pendingChannelSelection.u1.title).toBe('t');
+    expect(interaction.reply).toHaveBeenCalledWith({ content: '📢 Please select a channel:', components: ['menu'], flags: MessageFlags.Ephemeral });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for various botaction utilities
- cover syncEndpoints API wrapper
- add channel management module tests
- add tests for channel selector utilities and modal handler
- load configuration via fs mock
- verify event handling exports
- test interaction event router

## Testing
- `npm test`