### PR TITLE
Improve coverage for event handlers

### DIFF
--- a/__tests__/botactions/eventHandling/interactionEvents.test.js
+++ b/__tests__/botactions/eventHandling/interactionEvents.test.js
@@ -96,4 +96,55 @@ describe('handleInteraction', () => {
     expect(pendingChannelSelection.u1.title).toBe('t');
     expect(interaction.reply).toHaveBeenCalledWith({ content: '📢 Please select a channel:', components: ['menu'], flags: MessageFlags.Ephemeral });
   });
+
+  test('replies when command not found', async () => {
+    const interaction = {
+      isCommand: () => true,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      commandName: 'missing',
+      guild: { id: 'g1' },
+      reply: jest.fn()
+    };
+    await handleInteraction(interaction, { commands: new Map() });
+    expect(interaction.reply).toHaveBeenCalledWith('❌ Unable to find command...');
+  });
+
+  test('checks roles before executing command', async () => {
+    const execute = jest.fn();
+    const client = { commands: new Map([['test', { execute, roles: ['Admin'], data: { name: 'test' } }]]) };
+    const interaction = {
+      isCommand: () => true,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      commandName: 'test',
+      guild: { id: 'g1' },
+      member: { roles: { cache: { some: cb => cb({ name: 'User' }) } } },
+      reply: jest.fn()
+    };
+    await handleInteraction(interaction, client);
+    expect(execute).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({ content: "You don't have the required role to use this command.", flags: MessageFlags.Ephemeral });
+  });
+
+  test('handles command execution errors', async () => {
+    const execute = jest.fn().mockRejectedValue(new Error('boom'));
+    const client = { commands: new Map([['test', { execute, data: { name: 'test' } }]]) };
+    const interaction = {
+      isCommand: () => true,
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+      commandName: 'test',
+      guild: { id: 'g1' },
+      replied: false,
+      deferred: false,
+      reply: jest.fn(),
+      editReply: jest.fn()
+    };
+    await handleInteraction(interaction, client);
+    expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ There was an error while executing this command!', flags: MessageFlags.Ephemeral });
+  });
 });


### PR DESCRIPTION
## Summary
- extend message cleanup tests for error paths and old message deletion
- cover additional branches in messageEvents
- test more handleInteraction command scenarios

## Testing
- `npm test`