### PR TITLE
Increase filterHandler branch coverage

### DIFF
--- a/__tests__/botactions/eventHandling/messageEvents/filterHandler.test.js
+++ b/__tests__/botactions/eventHandling/messageEvents/filterHandler.test.js
@@ -16,8 +16,13 @@ describe('handleFiltering', () => {
   let message, client;
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
     message = { content: 'foo bad', author: { id: 'u1', username: 'User' }, channel: { send: jest.fn() } };
     client = {};
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
   });
 
   test('triggers personal action when phrase matches', async () => {
@@ -33,5 +38,26 @@ describe('handleFiltering', () => {
   test('does nothing when no matches', async () => {
     await handleFiltering({ ...message, content: 'clean' }, client);
     expect(performAction).not.toHaveBeenCalled();
+  });
+
+  test('returns early on regular trigger', async () => {
+    performAction.mockReturnValueOnce(true);
+    await handleFiltering({ ...message, content: 'bad foooo' }, client);
+    expect(performAction).toHaveBeenCalledTimes(1);
+    expect(performAction).toHaveBeenCalledWith(expect.any(Object), client, expect.objectContaining({ response: 'no' }));
+  });
+
+  test('returns early on regex trigger', async () => {
+    performAction.mockReturnValueOnce(true);
+    await handleFiltering({ ...message, content: 'foooo' }, client);
+    expect(performAction).toHaveBeenCalledTimes(1);
+    expect(performAction).toHaveBeenCalledWith(expect.any(Object), client, expect.objectContaining({ response: 'regex' }));
+  });
+
+  test('personal action can return true', async () => {
+    performAction.mockReturnValueOnce(true);
+    await handleFiltering({ ...message, content: 'personal' }, client);
+    expect(performAction).toHaveBeenCalledTimes(1);
+    expect(performAction).toHaveBeenCalledWith(expect.any(Object), client, expect.objectContaining({ response: 'hey' }));
   });
 });


### PR DESCRIPTION
## Notes
- expanded filterHandler tests with additional branches
- console output is suppressed via spies per repo guidelines

## Summary
- added early-return cases for regular, regex and personal triggers
- ensured console logging is mocked to avoid noise

## Testing
- `npm test --silent`