### PR TITLE
Increase branch coverage for messageCleanup

### DIFF
--- a/__tests__/botactions/channelManagement/messageCleanup.test.js
+++ b/__tests__/botactions/channelManagement/messageCleanup.test.js
@@ -115,4 +115,109 @@ describe('deleteMessages', () => {
     expect(oldMsg.delete).toHaveBeenCalled();
     expect(channel.bulkDelete).not.toHaveBeenCalled();
   });
+
+  test('warns when message still exists after delete', async () => {
+    const now = Date.now();
+    const makeCollection = entries => {
+      const col = new Map(entries);
+      col.filter = fn => makeCollection([...col].filter(([id, m]) => fn(m)));
+      return col;
+    };
+    const oldMsg = {
+      id: '1',
+      pinned: false,
+      createdTimestamp: now - 20 * 86400000,
+      delete: jest.fn(),
+      author: { tag: 'a', id: 'u' }
+    };
+    const msgs = makeCollection([['1', oldMsg]]);
+    channel.messages.fetch
+      .mockResolvedValueOnce(msgs)
+      .mockResolvedValueOnce(oldMsg);
+    db.SnapChannel.findAll.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 1 }]);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const p = deleteMessages(client);
+    await jest.runAllTimersAsync();
+    await p;
+
+    expect(oldMsg.delete).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('still exists'));
+    warnSpy.mockRestore();
+  });
+
+  test('handles delete errors for permission and ghost cases', async () => {
+    const now = Date.now();
+    const makeCollection = entries => {
+      const col = new Map(entries);
+      col.filter = fn => makeCollection([...col].filter(([id, m]) => fn(m)));
+      return col;
+    };
+    const msg1 = {
+      id: '1',
+      pinned: false,
+      createdTimestamp: now - 20 * 86400000,
+      delete: jest.fn().mockRejectedValue({ code: 50013 }),
+      author: { tag: 'a', id: 'u' }
+    };
+    const msg2 = {
+      id: '2',
+      pinned: false,
+      createdTimestamp: now - 20 * 86400000,
+      delete: jest.fn().mockRejectedValue({ code: 10008 }),
+      author: { tag: 'a', id: 'u' }
+    };
+    const msgs = makeCollection([
+      ['1', msg1],
+      ['2', msg2]
+    ]);
+    channel.messages.fetch.mockResolvedValueOnce(msgs);
+    db.SnapChannel.findAll.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 1 }]);
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const p = deleteMessages(client);
+    await jest.runAllTimersAsync();
+    await p;
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Missing permissions'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('ghost'));
+    errorSpy.mockRestore();
+  });
+
+  test('logs error when fetching messages fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    db.SnapChannel.findAll.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 1 }]);
+    channel.messages.fetch.mockRejectedValue(new Error('oops'));
+
+    const p = deleteMessages(client);
+    await jest.runAllTimersAsync();
+    await p;
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(channel.bulkDelete).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  test('logs when no messages are found to delete', async () => {
+    const makeCollection = entries => {
+      const col = new Map(entries);
+      col.filter = fn => makeCollection([...col].filter(([id, m]) => fn(m)));
+      return col;
+    };
+    const msgs = makeCollection([]);
+    channel.messages.fetch.mockResolvedValueOnce(msgs);
+    db.SnapChannel.findAll.mockResolvedValue([{ channelId: 'c1', purgeTimeInDays: 1 }]);
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const p = deleteMessages(client);
+    await jest.runAllTimersAsync();
+    await p;
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('No messages to delete'));
+    expect(channel.bulkDelete).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- expand messageCleanup tests with additional cases
- achieve over 80% branch coverage

## Testing
- `npm test`