### PR TITLE
Log message delete/update events

### DIFF
--- a/__tests__/botactions/eventHandling.test.js
+++ b/__tests__/botactions/eventHandling.test.js
@@ -1,5 +1,9 @@
 jest.mock('../../botactions/eventHandling/interactionEvents', () => ({ handleInteraction: jest.fn() }));
-jest.mock('../../botactions/eventHandling/messageEvents', () => ({ handleMessageCreate: jest.fn() }));
+jest.mock('../../botactions/eventHandling/messageEvents', () => ({
+  handleMessageCreate: jest.fn(),
+  handleMessageDelete: jest.fn(),
+  handleMessageUpdate: jest.fn()
+}));
 jest.mock('../../botactions/eventHandling/reactionEvents', () => ({ handleReactionAdd: jest.fn(), handleReactionRemove: jest.fn() }));
 jest.mock('../../botactions/eventHandling/voiceEvents', () => ({ handleVoiceStateUpdate: jest.fn() }));
 
@@ -13,12 +17,16 @@ describe('eventHandling index', () => {
   test('exports functions from submodules', async () => {
     await events.interactionHandler.handleInteraction('i');
     await events.handleMessageCreate('m');
+    await events.handleMessageDelete('d');
+    await events.handleMessageUpdate('o', 'n');
     await events.handleReactionAdd('r');
     await events.handleReactionRemove('rr');
     await events.handleVoiceStateUpdate('v');
 
     expect(interactionModule.handleInteraction).toHaveBeenCalledWith('i');
     expect(messageEvents.handleMessageCreate).toHaveBeenCalledWith('m');
+    expect(messageEvents.handleMessageDelete).toHaveBeenCalledWith('d');
+    expect(messageEvents.handleMessageUpdate).toHaveBeenCalledWith('o', 'n');
     expect(reactionEvents.handleReactionAdd).toHaveBeenCalledWith('r');
     expect(reactionEvents.handleReactionRemove).toHaveBeenCalledWith('rr');
     expect(voiceEvents.handleVoiceStateUpdate).toHaveBeenCalledWith('v');

--- a/bot.js
+++ b/bot.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { initClient } = require('./botactions/initClient');
-const { interactionHandler, handleMessageCreate, handleReactionAdd, handleReactionRemove, handleVoiceStateUpdate } = require('./botactions/eventHandling');
+const { interactionHandler, handleMessageCreate, handleMessageDelete, handleMessageUpdate, handleReactionAdd, handleReactionRemove, handleVoiceStateUpdate } = require('./botactions/eventHandling');
 const { registerChannels } = require('./botactions/channelManagement');
 const { registerCommands } = require('./utils/commandRegistration');
 const { initializeDatabase } = require('./config/database');
@@ -113,6 +113,8 @@ const initializeBot = async () => {
     await interactionHandler.handleInteraction(interaction, client);
   });
   client.on('messageCreate', message => handleMessageCreate(message, client));
+  client.on('messageDelete', message => handleMessageDelete(message));
+  client.on('messageUpdate', (oldMessage, newMessage) => handleMessageUpdate(oldMessage, newMessage));
   client.on('messageReactionAdd', (reaction, user) => handleReactionAdd(reaction, user));
   client.on('messageReactionRemove', (reaction, user) => handleReactionRemove(reaction, user));
   client.on('voiceStateUpdate', (oldState, newState) => handleVoiceStateUpdate(oldState, newState, client));

--- a/botactions/eventHandling.js
+++ b/botactions/eventHandling.js
@@ -1,11 +1,13 @@
 const interactionHandler = require('./eventHandling/interactionEvents');
-const { handleMessageCreate } = require('./eventHandling/messageEvents');
+const { handleMessageCreate, handleMessageDelete, handleMessageUpdate } = require('./eventHandling/messageEvents');
 const { handleReactionAdd, handleReactionRemove } = require('./eventHandling/reactionEvents');
 const { handleVoiceStateUpdate } = require('./eventHandling/voiceEvents');
 
 module.exports = {
     interactionHandler,
     handleMessageCreate,
+    handleMessageDelete,
+    handleMessageUpdate,
     handleReactionAdd,
     handleReactionRemove,
     handleVoiceStateUpdate

--- a/botactions/eventHandling/messageEvents.js
+++ b/botactions/eventHandling/messageEvents.js
@@ -180,6 +180,50 @@ module.exports = {
         }
     },
 
+    handleMessageDelete: async function (message) {
+        if (!message.guild || message.author?.bot) return;
+
+        const serverId = message.guild.id;
+
+        try {
+            await UsageLog.create({
+                user_id: message.author?.id,
+                interaction_type: 'message',
+                event_type: 'message_delete',
+                message_id: message.id,
+                message_content: message.content,
+                channel_id: message.channel.id,
+                server_id: serverId,
+                event_time: new Date(),
+            });
+            console.log('🗑️ Message delete logged successfully');
+        } catch (error) {
+            console.error('❌ Error logging message delete:', error);
+        }
+    },
+
+    handleMessageUpdate: async function (oldMessage, newMessage) {
+        if (!newMessage.guild || newMessage.author?.bot) return;
+
+        const serverId = newMessage.guild.id;
+
+        try {
+            await UsageLog.create({
+                user_id: newMessage.author?.id,
+                interaction_type: 'message',
+                event_type: 'message_edit',
+                message_id: newMessage.id,
+                message_content: newMessage.content,
+                channel_id: newMessage.channel.id,
+                server_id: serverId,
+                event_time: new Date(),
+            });
+            console.log('✏️ Message edit logged successfully');
+        } catch (error) {
+            console.error('❌ Error logging message edit:', error);
+        }
+    },
+
     performAction: function (message, client, actionDetail) {
         if (actionDetail.action === "personal") {
             if (


### PR DESCRIPTION
## Summary
- handle `messageDelete` and `messageUpdate` in `messageEvents`
- export new handlers from `eventHandling`
- listen for these events in `bot.js`
- extend tests for new handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b17783a90832d966b951dfe1e18e9