### PR TITLE
feat: track message edits/deletes in usage stats

### DIFF
--- a/__tests__/commands/tools/usagestats.test.js
+++ b/__tests__/commands/tools/usagestats.test.js
@@ -56,7 +56,9 @@ describe('/usagestats command', () => {
     isUserVerified.mockResolvedValue(true);
     isAdmin.mockResolvedValue(true);
     db.UsageLog.findAll.mockResolvedValue([
-      { interaction_type:'message', channel_id:'1' },
+      { interaction_type:'message', channel_id:'1', event_type:'message' },
+      { interaction_type:'message', channel_id:'1', event_type:'message_edit' },
+      { interaction_type:'message', channel_id:'1', event_type:'message_delete' },
       { interaction_type:'command', command_name:'ping' }
     ]);
     db.VoiceLog.findAll.mockResolvedValue([
@@ -69,6 +71,7 @@ describe('/usagestats command', () => {
 
     const embed = interaction.editReply.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toContain('Usage Summary');
-    expect(embed.data.fields.length).toBeGreaterThan(0);
+    expect(embed.data.fields.find(f => f.name === 'Messages Edited').value).toBe('1');
+    expect(embed.data.fields.find(f => f.name === 'Messages Deleted').value).toBe('1');
   });
 });

--- a/commands/admin/analytics.js
+++ b/commands/admin/analytics.js
@@ -9,7 +9,7 @@ module.exports = {
     .setDescription('Generate analytics reports')
     .addSubcommand(sub =>
       sub.setName('usage')
-        .setDescription('Generate a usage report')
+        .setDescription('Generate a usage report (includes message edits and deletes)')
     )
     .addSubcommand(sub =>
       sub.setName('voice')
@@ -25,7 +25,7 @@ module.exports = {
     )
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
-  help: 'Generates usage, voice, or channel-specific analytics reports. (Admin Only)',
+  help: 'Generates usage, voice, or channel-specific analytics reports. Usage reports include message edits and deletes. (Admin Only)',
   category: 'Discord',
 
   async execute(interaction, client) {

--- a/commands/tools/usagestats.js
+++ b/commands/tools/usagestats.js
@@ -57,10 +57,18 @@ const {
   
       const messageCounts = {};
       const commandCounts = {};
+      let editCount = 0;
+      let deleteCount = 0;
   
       for (const log of usageLogs) {
         if (log.interaction_type === 'message' && log.channel_id) {
           messageCounts[log.channel_id] = (messageCounts[log.channel_id] || 0) + 1;
+          if (log.event_type === 'message_edit' || log.event_type === 'message_update') {
+            editCount++;
+          }
+          if (log.event_type === 'message_delete') {
+            deleteCount++;
+          }
         }
         if (log.interaction_type === 'command' && log.command_name) {
           commandCounts[log.command_name] = (commandCounts[log.command_name] || 0) + 1;
@@ -107,6 +115,10 @@ const {
         { name: '**Messages**', value: Object.values(messageCounts).join('\n'), inline: true }
     );
     }
+    embed.addFields(
+        { name: 'Messages Edited', value: `${editCount}`, inline: true },
+        { name: 'Messages Deleted', value: `${deleteCount}`, inline: true }
+    );
 
     // ==== VOICE SECTION ====
     embed.addFields({ name: '🎙️ Voice', value: ' ' });


### PR DESCRIPTION
## Summary
- track message_update and message_delete events in `/usagestats`
- display edited and deleted counts in usage summary
- document analytics usage reports including edits/deletes
- test `/usagestats` embed shows new counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b1d968388832da9a5dd3244b6e90f