### PR TITLE
Add loglookup admin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A powerful Discord bot built for the **Pyro Freelancers Corps**, designed to man
 - ✅ Log file creation & Discord log channel syncing
 - ✅ Handles guild member updates & role assignments
 - ✅ Modular design for scalability
+- ✅ `/loglookup` command for quick audit of recent events (admin only)
 
 ## 🛠️ Installation
 

--- a/__tests__/commands/admin/loglookup.test.js
+++ b/__tests__/commands/admin/loglookup.test.js
@@ -1,0 +1,58 @@
+jest.mock('../../../config/database', () => ({ UsageLog: { findAll: jest.fn() } }));
+
+const { MessageFlags } = require('discord.js');
+const { UsageLog } = require('../../../config/database');
+const command = require('../../../commands/admin/loglookup');
+
+function makeInteraction(opts = {}) {
+  return {
+    guild: { id: 'guild' },
+    options: { getString: jest.fn(name => opts[name]) },
+    reply: jest.fn(),
+  };
+}
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('/loglookup command', () => {
+  test('queries with provided filters', async () => {
+    UsageLog.findAll.mockResolvedValue([]);
+    const interaction = makeInteraction({ user: 'u1', event: 'message_delete', 'message-id': 'm1' });
+
+    await command.execute(interaction);
+
+    expect(UsageLog.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        server_id: 'guild',
+        user_id: 'u1',
+        event_type: 'message_delete',
+        message_id: 'm1',
+      }),
+      order: [['timestamp', 'DESC']],
+      limit: 20,
+    }));
+    expect(interaction.reply).toHaveBeenCalledWith({ content: 'No matching logs found.', flags: MessageFlags.Ephemeral });
+  });
+
+  test('formats embed with log entries', async () => {
+    const log = { user_id: 'u1', event_type: 'message_create', channel_id: 'c1', message_content: 'hi', message_id: '123', timestamp: '2023-01-01T00:00:00.000Z' };
+    UsageLog.findAll.mockResolvedValue([log]);
+    const interaction = makeInteraction();
+
+    await command.execute(interaction);
+
+    const embed = interaction.reply.mock.calls[0][0].embeds[0];
+    expect(embed.data.title).toBe('Usage Log Results');
+    expect(embed.data.fields[0].name).toContain('message_create');
+    expect(embed.data.fields[0].value).toContain('hi');
+  });
+
+  test('handles query errors', async () => {
+    UsageLog.findAll.mockRejectedValue(new Error('fail'));
+    const interaction = makeInteraction();
+
+    await command.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('error'), flags: MessageFlags.Ephemeral }));
+  });
+});

--- a/commands/admin/loglookup.js
+++ b/commands/admin/loglookup.js
@@ -1,0 +1,69 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
+const { UsageLog } = require('../../config/database');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('loglookup')
+    .setDescription('Query UsageLog entries by user, event, or message ID')
+    .addStringOption(opt =>
+      opt.setName('user')
+        .setDescription('Discord user ID to filter by')
+        .setRequired(false))
+    .addStringOption(opt =>
+      opt.setName('event')
+        .setDescription('Event type to filter by')
+        .setRequired(false))
+    .addStringOption(opt =>
+      opt.setName('message-id')
+        .setDescription('Specific message ID to look up')
+        .setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  help: 'Searches recent usage logs with optional filters for user, event type, or message ID. (Admin Only)',
+  category: 'Admin',
+
+  async execute(interaction) {
+    const userId = interaction.options.getString('user');
+    const eventType = interaction.options.getString('event');
+    const messageId = interaction.options.getString('message-id');
+
+    const where = { server_id: interaction.guild.id };
+    if (userId) where.user_id = userId;
+    if (eventType) where.event_type = eventType;
+    if (messageId) where.message_id = messageId;
+
+    try {
+      const logs = await UsageLog.findAll({
+        where,
+        order: [['timestamp', 'DESC']],
+        limit: 20,
+      });
+
+      if (!logs.length) {
+        return interaction.reply({ content: 'No matching logs found.', flags: MessageFlags.Ephemeral });
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('Usage Log Results')
+        .setColor(0x3498db)
+        .setTimestamp();
+
+      for (const log of logs) {
+        const details = [];
+        details.push(`User: <@${log.user_id}>`);
+        if (log.channel_id) details.push(`Channel: <#${log.channel_id}>`);
+        if (log.message_id) details.push(`Message ID: ${log.message_id}`);
+        if (log.message_content) details.push(`Content: ${log.message_content.slice(0, 80)}`);
+
+        embed.addFields({
+          name: `${log.event_type} – ${new Date(log.timestamp).toLocaleString()}`,
+          value: details.join('\n'),
+        });
+      }
+
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (error) {
+      console.error('Error fetching usage logs:', error);
+      await interaction.reply({ content: 'There was an error while retrieving the logs.', flags: MessageFlags.Ephemeral });
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add `/loglookup` admin command for querying UsageLog
- test database filtering and embed output
- document the command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b1db3ba94832db75d6c0bc4a0218d