### PR TITLE
Refactor usage stats embed

### DIFF
--- a/__tests__/commands/tools/usagestats.test.js
+++ b/__tests__/commands/tools/usagestats.test.js
@@ -71,7 +71,7 @@ describe('/usagestats command', () => {
 
     const embed = interaction.editReply.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toContain('Usage Summary');
-    expect(embed.data.fields.find(f => f.name === 'Messages Edited').value).toBe('1');
-    expect(embed.data.fields.find(f => f.name === 'Messages Deleted').value).toBe('1');
+    const field = embed.data.fields.find(f => f.name === 'Messages Edited/Deleted');
+    expect(field.value).toBe('Edits: 1\nDeletes: 1');
   });
 });

--- a/commands/tools/usagestats.js
+++ b/commands/tools/usagestats.js
@@ -112,13 +112,10 @@ const {
     } else {
     embed.addFields(
         { name: '**Channel**', value: Object.keys(messageCounts).map(id => `<#${id}>`).join('\n'), inline: true },
-        { name: '**Messages**', value: Object.values(messageCounts).join('\n'), inline: true }
+        { name: '**Messages**', value: Object.values(messageCounts).join('\n'), inline: true },
+        { name: 'Messages Edited/Deleted', value: `Edits: ${editCount}\nDeletes: ${deleteCount}`, inline: true }
     );
     }
-    embed.addFields(
-        { name: 'Messages Edited', value: `${editCount}`, inline: true },
-        { name: 'Messages Deleted', value: `${deleteCount}`, inline: true }
-    );
 
     // ==== VOICE SECTION ====
     embed.addFields({ name: '🎙️ Voice', value: ' ' });
@@ -147,4 +144,4 @@ const {
       await interaction.editReply({ embeds: [embed]});
     }
   };
-  
+


### PR DESCRIPTION
## Summary
- combine message edit/delete counts into one field
- update tests for combined field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b21ec4428832d858ce1abb753bb40