### PR TITLE
Add moderation logging and fix voice events

### DIFF
--- a/__tests__/botactions/eventHandling.test.js
+++ b/__tests__/botactions/eventHandling.test.js
@@ -6,11 +6,17 @@ jest.mock('../../botactions/eventHandling/messageEvents', () => ({
 }));
 jest.mock('../../botactions/eventHandling/reactionEvents', () => ({ handleReactionAdd: jest.fn(), handleReactionRemove: jest.fn() }));
 jest.mock('../../botactions/eventHandling/voiceEvents', () => ({ handleVoiceStateUpdate: jest.fn() }));
+jest.mock('../../botactions/eventHandling/moderationEvents', () => ({
+  handleGuildMemberRemove: jest.fn(),
+  handleGuildBanAdd: jest.fn(),
+  handleGuildMemberUpdate: jest.fn(),
+}));
 
 const interactionModule = require('../../botactions/eventHandling/interactionEvents');
 const messageEvents = require('../../botactions/eventHandling/messageEvents');
 const reactionEvents = require('../../botactions/eventHandling/reactionEvents');
 const voiceEvents = require('../../botactions/eventHandling/voiceEvents');
+const moderationEvents = require('../../botactions/eventHandling/moderationEvents');
 const events = require('../../botactions/eventHandling');
 
 describe('eventHandling index', () => {
@@ -22,6 +28,9 @@ describe('eventHandling index', () => {
     await events.handleReactionAdd('r');
     await events.handleReactionRemove('rr');
     await events.handleVoiceStateUpdate('v');
+    await events.handleGuildMemberRemove('mr');
+    await events.handleGuildBanAdd('ban');
+    await events.handleGuildMemberUpdate('om', 'nm');
 
     expect(interactionModule.handleInteraction).toHaveBeenCalledWith('i');
     expect(messageEvents.handleMessageCreate).toHaveBeenCalledWith('m');
@@ -30,5 +39,8 @@ describe('eventHandling index', () => {
     expect(reactionEvents.handleReactionAdd).toHaveBeenCalledWith('r');
     expect(reactionEvents.handleReactionRemove).toHaveBeenCalledWith('rr');
     expect(voiceEvents.handleVoiceStateUpdate).toHaveBeenCalledWith('v');
+    expect(moderationEvents.handleGuildMemberRemove).toHaveBeenCalledWith('mr');
+    expect(moderationEvents.handleGuildBanAdd).toHaveBeenCalledWith('ban');
+    expect(moderationEvents.handleGuildMemberUpdate).toHaveBeenCalledWith('om', 'nm');
   });
 });

--- a/__tests__/botactions/eventHandling/moderationEvents.test.js
+++ b/__tests__/botactions/eventHandling/moderationEvents.test.js
@@ -1,0 +1,61 @@
+const { handleGuildMemberRemove, handleGuildBanAdd, handleGuildMemberUpdate } = require('../../../botactions/eventHandling/moderationEvents');
+const { UsageLog } = require('../../../config/database');
+
+jest.mock('../../../config/database', () => ({
+  UsageLog: { create: jest.fn() }
+}));
+
+describe('moderationEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleGuildMemberRemove', () => {
+    test('logs kick when audit entry matches', async () => {
+      const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const guild = {
+        id: 's1',
+        fetchAuditLogs: jest.fn().mockResolvedValue({
+          entries: { first: () => ({ target: { id: 'u1' }, createdTimestamp: Date.now() }) }
+        })
+      };
+      const member = { id: 'u1', guild };
+      await handleGuildMemberRemove(member);
+      expect(UsageLog.create).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'kick', user_id: 'u1', server_id: 's1' }));
+      log.mockRestore();
+    });
+
+    test('does not log when audit entry differs', async () => {
+      const guild = {
+        id: 's1',
+        fetchAuditLogs: jest.fn().mockResolvedValue({
+          entries: { first: () => ({ target: { id: 'u2' }, createdTimestamp: Date.now() }) }
+        })
+      };
+      const member = { id: 'u1', guild };
+      await handleGuildMemberRemove(member);
+      expect(UsageLog.create).not.toHaveBeenCalled();
+    });
+  });
+
+  test('handleGuildBanAdd logs ban', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const ban = { user: { id: 'u1' }, guild: { id: 's1' } };
+    await handleGuildBanAdd(ban);
+    expect(UsageLog.create).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'ban', user_id: 'u1', server_id: 's1' }));
+    log.mockRestore();
+  });
+
+  test('handleGuildMemberUpdate logs timeout start and end', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const guild = { id: 's1' };
+    const oldMember = { id: 'u1', guild, communicationDisabledUntil: null };
+    const newMember = { id: 'u1', guild, communicationDisabledUntil: new Date(Date.now() + 1000) };
+    await handleGuildMemberUpdate(oldMember, newMember);
+    expect(UsageLog.create).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'timeout_start' }));
+    UsageLog.create.mockClear();
+    await handleGuildMemberUpdate(newMember, { ...oldMember, communicationDisabledUntil: null });
+    expect(UsageLog.create).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'timeout_end' }));
+    log.mockRestore();
+  });
+});

--- a/bot.js
+++ b/bot.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { initClient } = require('./botactions/initClient');
-const { interactionHandler, handleMessageCreate, handleMessageDelete, handleMessageUpdate, handleReactionAdd, handleReactionRemove, handleVoiceStateUpdate } = require('./botactions/eventHandling');
+const { interactionHandler, handleMessageCreate, handleMessageDelete, handleMessageUpdate, handleReactionAdd, handleReactionRemove, handleVoiceStateUpdate, handleGuildMemberRemove, handleGuildBanAdd, handleGuildMemberUpdate } = require('./botactions/eventHandling');
 const { registerChannels } = require('./botactions/channelManagement');
 const { registerCommands } = require('./utils/commandRegistration');
 const { initializeDatabase } = require('./config/database');
@@ -118,6 +118,8 @@ const initializeBot = async () => {
   client.on('messageReactionAdd', (reaction, user) => handleReactionAdd(reaction, user));
   client.on('messageReactionRemove', (reaction, user) => handleReactionRemove(reaction, user));
   client.on('voiceStateUpdate', (oldState, newState) => handleVoiceStateUpdate(oldState, newState, client));
+  client.on('guildMemberRemove', member => handleGuildMemberRemove(member));
+  client.on('guildBanAdd', ban => handleGuildBanAdd(ban));
   client.on('guildScheduledEventCreate', async event => handleCreateEvent(event, client));
   client.on('guildScheduledEventUpdate', async (oldEvent, newEvent) => handleUpdateEvent(oldEvent, newEvent, client));
   client.on('guildScheduledEventDelete', async event => handleDeleteEvent(event, client));
@@ -134,6 +136,7 @@ const initializeBot = async () => {
   client.on('guildMemberUpdate', async (oldMember, newMember) => {
     await handleRoleAssignment(oldMember, newMember, client);
     await enforceNicknameFormat(oldMember, newMember);
+    await handleGuildMemberUpdate(oldMember, newMember);
   });
 
   client.once('ready', async () => {

--- a/botactions/eventHandling.js
+++ b/botactions/eventHandling.js
@@ -2,6 +2,7 @@ const interactionHandler = require('./eventHandling/interactionEvents');
 const { handleMessageCreate, handleMessageDelete, handleMessageUpdate } = require('./eventHandling/messageEvents');
 const { handleReactionAdd, handleReactionRemove } = require('./eventHandling/reactionEvents');
 const { handleVoiceStateUpdate } = require('./eventHandling/voiceEvents');
+const { handleGuildMemberRemove, handleGuildBanAdd, handleGuildMemberUpdate } = require('./eventHandling/moderationEvents');
 
 module.exports = {
     interactionHandler,
@@ -10,5 +11,8 @@ module.exports = {
     handleMessageUpdate,
     handleReactionAdd,
     handleReactionRemove,
-    handleVoiceStateUpdate
+    handleVoiceStateUpdate,
+    handleGuildMemberRemove,
+    handleGuildBanAdd,
+    handleGuildMemberUpdate
 }

--- a/botactions/eventHandling/moderationEvents.js
+++ b/botactions/eventHandling/moderationEvents.js
@@ -1,0 +1,73 @@
+const { UsageLog } = require('../../config/database');
+
+module.exports = {
+  handleGuildMemberRemove: async function(member) {
+    const guild = member.guild;
+    const serverId = guild.id;
+    try {
+      const logs = await guild.fetchAuditLogs({ type: 20, limit: 1 });
+      const entry = logs?.entries?.first?.();
+      const isKick = entry && entry.target && entry.target.id === member.id &&
+        Date.now() - entry.createdTimestamp < 5000;
+      if (isKick) {
+        await UsageLog.create({
+          user_id: member.id,
+          interaction_type: 'moderation',
+          event_type: 'kick',
+          server_id: serverId,
+          event_time: new Date(),
+        });
+        console.log('✅ Kick logged successfully');
+      }
+    } catch (err) {
+      console.error('❌ Error logging kick:', err);
+    }
+  },
+
+  handleGuildBanAdd: async function(ban) {
+    const { user, guild } = ban;
+    try {
+      await UsageLog.create({
+        user_id: user.id,
+        interaction_type: 'moderation',
+        event_type: 'ban',
+        server_id: guild.id,
+        event_time: new Date(),
+      });
+      console.log('✅ Ban logged successfully');
+    } catch (err) {
+      console.error('❌ Error logging ban:', err);
+    }
+  },
+
+  handleGuildMemberUpdate: async function(oldMember, newMember) {
+    const oldTimeout = oldMember.communicationDisabledUntil;
+    const newTimeout = newMember.communicationDisabledUntil;
+    if (oldTimeout === newTimeout) return;
+    const serverId = newMember.guild.id;
+    const userId = newMember.id;
+    try {
+      if (!oldTimeout && newTimeout) {
+        await UsageLog.create({
+          user_id: userId,
+          interaction_type: 'moderation',
+          event_type: 'timeout_start',
+          server_id: serverId,
+          event_time: new Date(),
+        });
+        console.log('✅ Timeout started logged successfully');
+      } else if (oldTimeout && !newTimeout) {
+        await UsageLog.create({
+          user_id: userId,
+          interaction_type: 'moderation',
+          event_type: 'timeout_end',
+          server_id: serverId,
+          event_time: new Date(),
+        });
+        console.log('✅ Timeout ended logged successfully');
+      }
+    } catch (err) {
+      console.error('❌ Error logging timeout:', err);
+    }
+  }
+};

--- a/botactions/eventHandling/voiceEvents.js
+++ b/botactions/eventHandling/voiceEvents.js
@@ -12,7 +12,7 @@ module.exports = {
         const oldChannelName = oldChannelId ? await getChannelNameById(oldChannelId, client).catch(() => null) : null;
         const userName = userId ? await getUserNameById(userId, client).catch(() => null) : null;
 
-        console.log(`🎧 Voice state update: old = ${oldChannelName}, new = ${newChannelName}`);
+        console.log(`📌 Voice state update: old = ${oldChannelName}, new = ${newChannelName}`);
 
         if (!oldChannelId && newChannelId) {
             await VoiceLog.create({
@@ -22,7 +22,7 @@ module.exports = {
                 server_id: serverId,
                 start_time: new Date(),
             });
-            console.log(`➕ ${userName} joined voice channel: ${newChannelName}`);
+            console.log(`✅ ${userName} joined voice channel: ${newChannelName}`);
         } else if (oldChannelId && !newChannelId) {
             const joinLog = await VoiceLog.findOne({
                 where: {
@@ -47,7 +47,7 @@ module.exports = {
                     start_time: joinTimestamp,
                     end_time: leaveTimestamp,
                 });
-                console.log(`➖ ${userName} left voice channel: ${oldChannelName}`);
+                console.log(`✅ ${userName} left voice channel: ${oldChannelName}`);
             }
         } else if (oldChannelId && newChannelId && oldChannelId !== newChannelId) {
             console.log(`🔁 ${userName} moved from ${oldChannelName} to ${newChannelName}`);
@@ -74,7 +74,7 @@ module.exports = {
                     start_time: joinTimestamp,
                     end_time: switchTimestamp,
                 });
-                console.log(`📤 Logged leave: ${userName} from ${oldChannelName}`);
+                console.log(`📌 Logged leave: ${userName} from ${oldChannelName}`);
 
                 await VoiceLog.create({
                     user_id: userId,
@@ -83,7 +83,7 @@ module.exports = {
                     server_id: serverId,
                     start_time: switchTimestamp,
                 });
-                console.log(`📥 Logged join: ${userName} to ${newChannelName}`);
+                console.log(`📌 Logged join: ${userName} to ${newChannelName}`);
             } else {
                 await VoiceLog.create({
                     user_id: userId,


### PR DESCRIPTION
## Summary
- ensure voice state logging uses standard emojis
- log kicks, bans, and timeouts via new moderationEvents handler
- expose new handlers from eventHandling and wire them up in bot.js
- test new moderationEvents module and update existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b21d9af38832db4a18397c237f485