### PR TITLE
Fix usage stats formatting

### DIFF
--- a/__tests__/commands/tools/usagestats.test.js
+++ b/__tests__/commands/tools/usagestats.test.js
@@ -71,7 +71,7 @@ describe('/usagestats command', () => {
 
     const embed = interaction.editReply.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toContain('Usage Summary');
-    const field = embed.data.fields.find(f => f.name === 'Messages Edited/Deleted');
-    expect(field.value).toBe('Edits: 1\nDeletes: 1');
+    const field = embed.data.fields.find(f => f.name === '**Messages Sent/Edited/Deleted**');
+    expect(field.value.trim()).toBe('1 / 1 / 1');
   });
 });


### PR DESCRIPTION
## Summary
- display edited and deleted message counts per channel
- consolidate message statistics into a single column
- update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683b294b0194832d8dabbd2a626319c3