### PR TITLE
Align usage stats numbers

### DIFF
--- a/__tests__/commands/tools/usagestats.test.js
+++ b/__tests__/commands/tools/usagestats.test.js
@@ -72,6 +72,6 @@ describe('/usagestats command', () => {
     const embed = interaction.editReply.mock.calls[0][0].embeds[0];
     expect(embed.data.title).toContain('Usage Summary');
     const field = embed.data.fields.find(f => f.name === '**Messages Sent/Edited/Deleted**');
-    expect(field.value.trim()).toBe('1 / 1 / 1');
+    expect(field.value.trim()).toBe('```    1 /     1 /     1```');
   });
 });

--- a/commands/tools/usagestats.js
+++ b/commands/tools/usagestats.js
@@ -112,14 +112,13 @@ const {
     embed.addFields({ name: 'No text activity', value: 'No messages sent during the last 30 days.', inline: false });
     } else {
       const channels = Object.keys(messageStats);
-      const maxSent = Math.max(...channels.map(id => String(messageStats[id].sent).length));
-      const maxEdit = Math.max(...channels.map(id => String(messageStats[id].edited).length));
-      const maxDel = Math.max(...channels.map(id => String(messageStats[id].deleted).length));
+      const COLUMN_WIDTH = 5; // support up to 5 digit numbers for alignment
       const format = (num, width) => String(num).padStart(width, ' ');
-      const messageValues = channels.map(id => {
+      const messageLines = channels.map(id => {
         const s = messageStats[id];
-        return `${format(s.sent, maxSent)} / ${format(s.edited, maxEdit)} / ${format(s.deleted, maxDel)}`;
-      }).join('\n');
+        return `${format(s.sent, COLUMN_WIDTH)} / ${format(s.edited, COLUMN_WIDTH)} / ${format(s.deleted, COLUMN_WIDTH)}`;
+      });
+      const messageValues = `\`\`\`${messageLines.join('\n')}\`\`\``;
     embed.addFields(
         { name: '**Channel**', value: channels.map(id => `<#${id}>`).join('\n'), inline: true },
         { name: '**Messages Sent/Edited/Deleted**', value: messageValues, inline: true }


### PR DESCRIPTION
## Summary
- align `/usagestats` message counts by wrapping values in a code block so spaces show
- update usage stats tests for the new formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683b2b21dfac832d87eb43a83203efd5