### PR TITLE
feat: add google drive integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 bot.log
 *.log
 logs/
+google-service-account.json

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ project root, or you can export them in your shell before running the bot.
 - `OPENAI_API_KEY` - API key used for OpenAI requests.
 - `OPENAI_MODEL` - Model name to use when calling the OpenAI API.
 - `UEX_API_TOKEN` - Authentication token for the UEX trading API.
+- `GOOGLE_SERVICE_ACCOUNT_FILE` - Path to your service account JSON key for Google Drive access.
+
+## 🗄️ Google Drive Setup
+
+1. Create a service account in the Google Cloud console and enable the **Drive API**.
+2. Download the JSON key file for that service account.
+3. Save the file somewhere safe, e.g. `google-service-account.json`, and add the filename to `.gitignore`.
+4. Set the environment variable `GOOGLE_SERVICE_ACCOUNT_FILE` to the path of this JSON file.
+5. The bot will use these credentials to authenticate when accessing Google Drive.
 
 ## 🏃‍♂️ Usage
 

--- a/__tests__/utils/googleDrive.test.js
+++ b/__tests__/utils/googleDrive.test.js
@@ -1,0 +1,39 @@
+const { createDriveClient } = require('../../utils/googleDrive');
+const { google } = require('googleapis');
+
+jest.mock('googleapis');
+
+const mockGetClient = jest.fn();
+const mockGoogleAuth = jest.fn(() => ({ getClient: mockGetClient }));
+const mockDrive = jest.fn();
+
+google.auth = { GoogleAuth: mockGoogleAuth };
+google.drive = mockDrive;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.GOOGLE_SERVICE_ACCOUNT_FILE = '/path/key.json';
+  mockGetClient.mockResolvedValue('client');
+  mockDrive.mockReturnValue('drive');
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_SERVICE_ACCOUNT_FILE;
+});
+
+test('throws if key file env var is missing', async () => {
+  delete process.env.GOOGLE_SERVICE_ACCOUNT_FILE;
+  await expect(createDriveClient()).rejects.toThrow('Service account key file not specified');
+});
+
+test('creates drive client using service account key', async () => {
+  const drive = await createDriveClient();
+
+  expect(mockGoogleAuth).toHaveBeenCalledWith({
+    keyFile: '/path/key.json',
+    scopes: ['https://www.googleapis.com/auth/drive']
+  });
+  expect(mockGetClient).toHaveBeenCalled();
+  expect(mockDrive).toHaveBeenCalledWith({ version: 'v3', auth: 'client' });
+  expect(drive).toBe('drive');
+});

--- a/utils/googleDrive.js
+++ b/utils/googleDrive.js
@@ -1,0 +1,21 @@
+const { google } = require('googleapis');
+
+const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive';
+
+/**
+ * Create an authenticated Google Drive client using a service account key.
+ * The path to the key file is read from the environment variable
+ * `GOOGLE_SERVICE_ACCOUNT_FILE` (or `GOOGLE_APPLICATION_CREDENTIALS`).
+ */
+async function createDriveClient() {
+  const keyFile = process.env.GOOGLE_SERVICE_ACCOUNT_FILE || process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!keyFile) {
+    throw new Error('Service account key file not specified. Set GOOGLE_SERVICE_ACCOUNT_FILE');
+  }
+
+  const auth = new google.auth.GoogleAuth({ keyFile, scopes: [DRIVE_SCOPE] });
+  const authClient = await auth.getClient();
+  return google.drive({ version: 'v3', auth: authClient });
+}
+
+module.exports = { createDriveClient };


### PR DESCRIPTION
## Summary
- add `google-service-account.json` to `.gitignore`
- document Google Drive setup steps and env var
- implement `createDriveClient` util
- test Google Drive client creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dafad7ae4832da01d397a9e52c399