### PR TITLE
Add scavenger hunt foundations

### DIFF
--- a/__tests__/commands/hunt/help.test.js
+++ b/__tests__/commands/hunt/help.test.js
@@ -1,0 +1,11 @@
+const help = require('../../../commands/hunt/help');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+test('replies with help embed', async () => {
+  const interaction = { reply: jest.fn() };
+  await help.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith({
+    embeds: [expect.any(Object)],
+    flags: MessageFlags.Ephemeral
+  });
+});

--- a/__tests__/models/hunt.test.js
+++ b/__tests__/models/hunt.test.js
@@ -1,0 +1,18 @@
+const defineModel = require('../../models/hunt');
+
+describe('Hunt model', () => {
+  test('defines fields and options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('Hunt');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('starts_at');
+    expect(attrs).toHaveProperty('status');
+    expect(opts.tableName).toBe('hunts');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/huntPoi.test.js
+++ b/__tests__/models/huntPoi.test.js
@@ -1,0 +1,18 @@
+const defineModel = require('../../models/huntPoi');
+
+describe('HuntPoi model', () => {
+  test('defines fields and options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('HuntPoi');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs).toHaveProperty('name');
+    expect(attrs).toHaveProperty('hint');
+    expect(attrs).toHaveProperty('points');
+    expect(opts.tableName).toBe('hunt_pois');
+    expect(model).toEqual({});
+  });
+});

--- a/__tests__/models/huntSubmission.test.js
+++ b/__tests__/models/huntSubmission.test.js
@@ -1,0 +1,18 @@
+const defineModel = require('../../models/huntSubmission');
+
+describe('HuntSubmission model', () => {
+  test('defines fields and options', () => {
+    const define = jest.fn(() => ({}));
+    const sequelize = { define };
+    const model = defineModel(sequelize);
+    const [name, attrs, opts] = define.mock.calls[0];
+
+    expect(name).toBe('HuntSubmission');
+    expect(attrs).toHaveProperty('id');
+    expect(attrs).toHaveProperty('hunt_id');
+    expect(attrs).toHaveProperty('poi_id');
+    expect(attrs).toHaveProperty('status');
+    expect(opts.tableName).toBe('hunt_submissions');
+    expect(model).toEqual({});
+  });
+});

--- a/commands/hunt.js
+++ b/commands/hunt.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
+const data = new SlashCommandBuilder()
+  .setName('hunt')
+  .setDescription('Participate in scavenger hunts');
+
+const subcommandsDir = path.join(__dirname, 'hunt');
+const subcommandFiles = fs.readdirSync(subcommandsDir).filter(f => f.endsWith('.js'));
+
+for (const file of subcommandFiles) {
+  try {
+    const subcommandModule = require(`./hunt/${file}`);
+    if (typeof subcommandModule.data === 'function') {
+      data.addSubcommand(subcommandModule.data);
+    }
+  } catch (err) {
+    console.error(`❌ Failed to load subcommand ${file}:`, err);
+  }
+}
+
+module.exports = {
+  data,
+  async execute(interaction, client) {
+    const sub = interaction.options.getSubcommand();
+    try {
+      const subcommand = require(`./hunt/${sub}`);
+      if (subcommand && typeof subcommand.execute === 'function') {
+        await subcommand.execute(interaction, client);
+      } else {
+        await interaction.reply({ content: `❌ Subcommand "${sub}" not implemented.`, flags: MessageFlags.Ephemeral });
+      }
+    } catch (err) {
+      console.error(`❌ Failed to execute subcommand ${sub}:`, err);
+      await interaction.reply({ content: '❌ Failed to run subcommand.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};

--- a/commands/hunt/help.js
+++ b/commands/hunt/help.js
@@ -1,0 +1,15 @@
+const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('help')
+    .setDescription('Learn how the scavenger hunt works'),
+
+  async execute(interaction) {
+    const embed = new EmbedBuilder()
+      .setTitle('Scavenger Hunt')
+      .setDescription('Submit selfies at points of interest to earn points.');
+
+    await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+  }
+};

--- a/config/database.js
+++ b/config/database.js
@@ -42,6 +42,9 @@ const VerifiedUser = require('../models/verifiedUser')(sequelize);
 const AmbientMessage = require('../models/ambiEntMessage')(sequelize);
 const AmbientChannel = require('../models/ambientChannel')(sequelize);
 const AmbientSetting = require('../models/ambientSetting')(sequelize);
+const Hunt = require('../models/hunt')(sequelize);
+const HuntPoi = require('../models/huntPoi')(sequelize);
+const HuntSubmission = require('../models/huntSubmission')(sequelize);
 
 Object.values(sequelize.models).forEach(model => {
     if (typeof model.associate === 'function') {
@@ -100,5 +103,8 @@ module.exports = {
     VerifiedUser,
     AmbientMessage,
     AmbientChannel,
-    AmbientSetting
+    AmbientSetting,
+    Hunt,
+    HuntPoi,
+    HuntSubmission
 };

--- a/models/hunt.js
+++ b/models/hunt.js
@@ -1,0 +1,38 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  return sequelize.define('Hunt', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    discord_event_id: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    starts_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    ends_at: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('upcoming', 'active', 'archived'),
+      allowNull: false
+    }
+  }, {
+    tableName: 'hunts',
+    timestamps: true
+  });
+};

--- a/models/huntPoi.js
+++ b/models/huntPoi.js
@@ -1,0 +1,50 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  return sequelize.define('HuntPoi', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    created_by: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    updated_by: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    hint: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    location: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    image_url: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    points: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('active', 'archived'),
+      allowNull: false
+    }
+  }, {
+    tableName: 'hunt_pois',
+    timestamps: true
+  });
+};

--- a/models/huntSubmission.js
+++ b/models/huntSubmission.js
@@ -1,0 +1,63 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  return sequelize.define('HuntSubmission', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true
+    },
+    review_comment: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    hunt_id: {
+      type: DataTypes.UUID,
+      allowNull: false
+    },
+    poi_id: {
+      type: DataTypes.UUID,
+      allowNull: false
+    },
+    user_id: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    image_url: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'approved', 'rejected'),
+      allowNull: false
+    },
+    reviewer_id: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    review_message_id: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    review_channel_id: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    supersedes_submission_id: {
+      type: DataTypes.UUID,
+      allowNull: true
+    },
+    submitted_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW
+    },
+    reviewed_at: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  }, {
+    tableName: 'hunt_submissions',
+    timestamps: false
+  });
+};


### PR DESCRIPTION
## Summary
- add `Hunt`, `HuntPoi`, and `HuntSubmission` Sequelize models
- expose hunt models in database config
- implement `/hunt` command with `help` subcommand
- add unit tests for the new models and command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683db6dc95e8832d9efd6d0df69ac374