### PR TITLE
Implement hunt list command

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -14,7 +14,7 @@
 ### 📌 Event ("Hunt") Management
 
 * [ ] `/hunt schedule` — creates both a new scavenger hunt and a linked Discord Scheduled Event (name, description, start, end, channel)
-* [ ] `/hunt list` — list all hunts by status
+* [x] `/hunt list` — list all hunts by status
 * [ ] Hunt `status` auto-syncs based on linked Discord Event lifecycle:
 
   * scheduled → upcoming
@@ -77,7 +77,7 @@
 ### 🛡 Channel Restrictions
 
 * [ ] All `/hunt` commands fail outside the configured activity channel with a helpful error message
-* [ ] `/hunt help` is always allowed in any channel
+* [x] `/hunt help` is always allowed in any channel
 * [ ] `/hunt set-channels` — brings up a UI with currently configured channels (or blank), and allows setting:
 
   * Activity channel (where commands can be run)
@@ -87,6 +87,8 @@
 ---
 
 ## 📦 Data Models (Sequelize-style)
+
+* ✅ Sequelize models implemented for Hunt, HuntPoi and HuntSubmission
 
 ### Hunt
 

--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -30,6 +30,21 @@ const VoiceLog = {
   findAll: jest.fn()
 };
 
+const Hunt = {
+  findAll: jest.fn(),
+  create: jest.fn()
+};
+
+const HuntPoi = {
+  findAll: jest.fn(),
+  create: jest.fn()
+};
+
+const HuntSubmission = {
+  findAll: jest.fn(),
+  create: jest.fn()
+};
+
 // Simple mock Sequelize-like instance
 const sequelize = {
   models: {
@@ -71,5 +86,8 @@ module.exports = {
   UsageLog,
   VoiceLog,
   sequelize,
-  initializeDatabase
+  initializeDatabase,
+  Hunt,
+  HuntPoi,
+  HuntSubmission
 };

--- a/__tests__/commands/hunt/list.test.js
+++ b/__tests__/commands/hunt/list.test.js
@@ -1,0 +1,51 @@
+jest.mock('../../../config/database', () => ({
+  Hunt: { findAll: jest.fn() }
+}));
+
+const { Hunt } = require('../../../config/database');
+const command = require('../../../commands/hunt/list');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({ reply: jest.fn() });
+
+beforeEach(() => jest.clearAllMocks());
+
+test('replies when no hunts exist', async () => {
+  Hunt.findAll.mockResolvedValue([]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({
+    content: '❌ No scavenger hunts found.',
+    flags: MessageFlags.Ephemeral
+  });
+});
+
+test('lists hunts when present', async () => {
+  Hunt.findAll.mockResolvedValue([
+    { name: 'Test Hunt', status: 'upcoming', starts_at: new Date('2024-01-01'), ends_at: new Date('2024-01-02') }
+  ]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  const reply = interaction.reply.mock.calls[0][0];
+  expect(reply.embeds[0].data.title).toContain('Scavenger Hunts');
+  expect(reply.flags).toBe(MessageFlags.Ephemeral);
+});
+
+test('handles fetch errors', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  Hunt.findAll.mockRejectedValue(new Error('fail'));
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(spy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({
+    content: '❌ Error fetching hunts.',
+    flags: MessageFlags.Ephemeral
+  });
+  spy.mockRestore();
+});

--- a/commands/hunt/list.js
+++ b/commands/hunt/list.js
@@ -1,0 +1,29 @@
+const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const { Hunt } = require('../../config/database');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('list')
+    .setDescription('List all scavenger hunts'),
+
+  async execute(interaction) {
+    try {
+      const hunts = await Hunt.findAll({ order: [['starts_at', 'DESC']] });
+      if (!hunts.length) {
+        return interaction.reply({ content: '❌ No scavenger hunts found.', flags: MessageFlags.Ephemeral });
+      }
+
+      const embed = new EmbedBuilder().setTitle('Scavenger Hunts');
+      for (const h of hunts) {
+        const start = h.starts_at ? new Date(h.starts_at).toLocaleString() : 'N/A';
+        const end = h.ends_at ? new Date(h.ends_at).toLocaleString() : 'N/A';
+        embed.addFields({ name: `${h.name} (${h.status})`, value: `${start} → ${end}` });
+      }
+
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to fetch hunts:', err);
+      await interaction.reply({ content: '❌ Error fetching hunts.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement `/hunt list` command and tests
- extend database mocks with Hunt models
- mark `/hunt list` and `/hunt help` as done in scavenger hunt TODO
- note existing models in scavenger hunt TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683db895f8c0832da1579309359a1276