### PR TITLE
Add /hunt set-channels command

### DIFF
--- a/__tests__/commands/hunt/set-channels.test.js
+++ b/__tests__/commands/hunt/set-channels.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../../config/database', () => ({
+  Config: { upsert: jest.fn() }
+}));
+
+const { Config } = require('../../../config/database');
+const command = require('../../../commands/hunt/set-channels');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({
+  options: {
+    getChannel: jest.fn(name => ({ id: name === 'activity' ? 'a1' : 'r1' }))
+  },
+  reply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+test('stores channel ids and replies', async () => {
+  const interaction = makeInteraction();
+  await command.execute(interaction);
+  expect(Config.upsert).toHaveBeenCalledWith({ key: 'hunt_activity_channel', value: 'a1', botType: 'development' });
+  expect(Config.upsert).toHaveBeenCalledWith({ key: 'hunt_review_channel', value: 'r1', botType: 'development' });
+  expect(interaction.reply).toHaveBeenCalledWith({
+    content: expect.stringContaining('Hunt channels updated'),
+    flags: MessageFlags.Ephemeral
+  });
+});
+
+test('handles db failure', async () => {
+  const interaction = makeInteraction();
+  const err = new Error('fail');
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  Config.upsert.mockRejectedValue(err);
+
+  await command.execute(interaction);
+
+  expect(spy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Failed to update channels.', flags: MessageFlags.Ephemeral });
+  spy.mockRestore();
+});

--- a/commands/hunt/set-channels.js
+++ b/commands/hunt/set-channels.js
@@ -1,0 +1,37 @@
+const { SlashCommandSubcommandBuilder, ChannelType, MessageFlags } = require('discord.js');
+const { Config } = require('../../config/database');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('set-channels')
+    .setDescription('Configure hunt activity and review channels')
+    .addChannelOption(opt =>
+      opt.setName('activity')
+        .setDescription('Channel where /hunt commands are allowed')
+        .addChannelTypes(ChannelType.GuildText)
+        .setRequired(true))
+    .addChannelOption(opt =>
+      opt.setName('review')
+        .setDescription('Channel where submissions are reviewed')
+        .addChannelTypes(ChannelType.GuildText)
+        .setRequired(true)),
+
+  async execute(interaction) {
+    const activity = interaction.options.getChannel('activity');
+    const review = interaction.options.getChannel('review');
+    const botType = process.env.BOT_TYPE || 'development';
+
+    try {
+      await Config.upsert({ key: 'hunt_activity_channel', value: activity.id, botType });
+      await Config.upsert({ key: 'hunt_review_channel', value: review.id, botType });
+
+      await interaction.reply({
+        content: `✅ Hunt channels updated:\n• Activity: <#${activity.id}>\n• Review: <#${review.id}>`,
+        flags: MessageFlags.Ephemeral
+      });
+    } catch (err) {
+      console.error('❌ Failed to update hunt channels:', err);
+      await interaction.reply({ content: '❌ Failed to update channels.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement `/hunt set-channels` for configuring scavenger hunt activity and review channels
- test the new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dbc66a9f4832db49d676341538934