### PR TITLE
Add /hunt schedule command

### DIFF
--- a/__tests__/commands/hunt/schedule.test.js
+++ b/__tests__/commands/hunt/schedule.test.js
@@ -1,0 +1,77 @@
+jest.mock('../../../config/database', () => ({
+  Hunt: { create: jest.fn() }
+}));
+
+jest.mock('chrono-node', () => ({
+  parseDate: jest.fn()
+}));
+
+const chrono = require('chrono-node');
+const { Hunt } = require('../../../config/database');
+const command = require('../../../commands/hunt/schedule');
+const { MessageFlags } = require('discord.js');
+
+const makeInteraction = () => ({
+  options: {
+    getString: jest.fn(key => ({
+      name: 'Test Hunt',
+      description: 'desc',
+      start: 'start',
+      end: 'end'
+    }[key])),
+    getChannel: jest.fn(() => ({ id: 'chan' }))
+  },
+  guild: { scheduledEvents: { create: jest.fn().mockResolvedValue({ id: 'e1' }) } },
+  reply: jest.fn()
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('creates scheduled event and hunt', async () => {
+  chrono.parseDate.mockImplementation(str => str === 'start' ? new Date('2025-01-01T00:00:00Z') : new Date('2025-01-02T00:00:00Z'));
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.guild.scheduledEvents.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Test Hunt' }));
+  expect(Hunt.create).toHaveBeenCalledWith(expect.objectContaining({ name: 'Test Hunt', discord_event_id: 'e1' }));
+  expect(interaction.reply).toHaveBeenCalledWith({ content: expect.stringContaining('Test Hunt'), flags: MessageFlags.Ephemeral });
+});
+
+test('rejects invalid times', async () => {
+  chrono.parseDate.mockReturnValue(null);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({ content: expect.stringContaining('Invalid'), flags: MessageFlags.Ephemeral });
+});
+
+test('handles event creation failure', async () => {
+  chrono.parseDate.mockImplementation(str => str === 'start' ? new Date('2025-01-01T00:00:00Z') : new Date('2025-01-02T00:00:00Z'));
+  const interaction = makeInteraction();
+  const err = new Error('fail');
+  interaction.guild.scheduledEvents.create.mockRejectedValue(err);
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await command.execute(interaction);
+
+  expect(spy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Failed to schedule hunt.', flags: MessageFlags.Ephemeral });
+  spy.mockRestore();
+});
+
+test('handles database failure', async () => {
+  chrono.parseDate.mockImplementation(str => str === 'start' ? new Date('2025-01-01T00:00:00Z') : new Date('2025-01-02T00:00:00Z'));
+  const interaction = makeInteraction();
+  Hunt.create.mockRejectedValue(new Error('dbfail'));
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await command.execute(interaction);
+
+  expect(spy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Failed to schedule hunt.', flags: MessageFlags.Ephemeral });
+  spy.mockRestore();
+});

--- a/commands/hunt/schedule.js
+++ b/commands/hunt/schedule.js
@@ -1,0 +1,63 @@
+const { SlashCommandSubcommandBuilder, ChannelType, MessageFlags } = require('discord.js');
+const { Hunt } = require('../../config/database');
+const chrono = require('chrono-node');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('schedule')
+    .setDescription('Schedule a new scavenger hunt')
+    .addStringOption(opt =>
+      opt.setName('name').setDescription('Hunt name').setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('description').setDescription('Hunt description').setRequired(false))
+    .addStringOption(opt =>
+      opt.setName('start').setDescription('Start time').setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('end').setDescription('End time').setRequired(true))
+    .addChannelOption(opt =>
+      opt.setName('channel')
+        .setDescription('Event voice channel')
+        .addChannelTypes(ChannelType.GuildVoice, ChannelType.GuildStageVoice)
+        .setRequired(true)),
+
+  async execute(interaction) {
+    const name = interaction.options.getString('name');
+    const description = interaction.options.getString('description');
+    const startInput = interaction.options.getString('start');
+    const endInput = interaction.options.getString('end');
+    const channel = interaction.options.getChannel('channel');
+
+    const start = chrono.parseDate(startInput);
+    const end = chrono.parseDate(endInput);
+
+    if (!start || !end || isNaN(start) || isNaN(end) || end <= start) {
+      return interaction.reply({ content: '❌ Invalid start or end time.', flags: MessageFlags.Ephemeral });
+    }
+
+    try {
+      const event = await interaction.guild.scheduledEvents.create({
+        name,
+        description,
+        scheduledStartTime: start,
+        scheduledEndTime: end,
+        privacyLevel: 2, // GuildOnly
+        entityType: 2, // Voice
+        channel,
+      });
+
+      await Hunt.create({
+        name,
+        description,
+        discord_event_id: event.id,
+        starts_at: start,
+        ends_at: end,
+        status: 'upcoming',
+      });
+
+      await interaction.reply({ content: `✅ Hunt "${name}" scheduled.`, flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to schedule hunt:', err);
+      await interaction.reply({ content: '❌ Failed to schedule hunt.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- implement `/hunt schedule` subcommand to create a hunt and linked scheduled event
- test scheduling logic and error paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dc787be10832da0819da1e0b1f915