### PR TITLE
fix slash command option order

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -145,6 +145,12 @@ const ButtonStyle = {
   Secondary: 2,
 };
 
+const ChannelType = {
+  GuildText: 'GUILD_TEXT',
+  GuildVoice: 'GUILD_VOICE',
+  GuildStageVoice: 'GUILD_STAGE_VOICE'
+};
+
 const AttachmentBuilder = jest.fn(function(path) {
   this.path = path;
 });
@@ -193,6 +199,18 @@ const SlashCommandBuilder = jest.fn(() => {
       this.options.push(option);
       return this;
     },
+    addChannelOption(fn) {
+      const option = { type: 'channel', name: undefined, description: undefined, required: false, channel_types: [] };
+      const optBuilder = {
+        setName(name) { option.name = name; return this; },
+        setDescription(desc) { option.description = desc; return this; },
+        setRequired(req) { option.required = req; return this; },
+        addChannelTypes: jest.fn(function(...types) { option.channel_types.push(...types); return this; })
+      };
+      fn(optBuilder);
+      this.options.push(option);
+      return this;
+    },
     addSubcommand(fn) {
       const sub = { type: 'subcommand', name: undefined, description: undefined, options: [] };
       const subBuilder = {
@@ -217,6 +235,18 @@ const SlashCommandBuilder = jest.fn(() => {
             setRequired(r) { opt.required = r; return this; },
             addChoices: jest.fn()
           });
+          sub.options.push(opt);
+          return this;
+        },
+        addChannelOption(chFn) {
+          const opt = { type: 'channel', name: undefined, description: undefined, required: false, channel_types: [] };
+          const optBuilder = {
+            setName(n) { opt.name = n; return this; },
+            setDescription(d) { opt.description = d; return this; },
+            setRequired(r) { opt.required = r; return this; },
+            addChannelTypes: jest.fn(function(...types) { opt.channel_types.push(...types); return this; })
+          };
+          chFn(optBuilder);
           sub.options.push(opt);
           return this;
         }
@@ -261,5 +291,6 @@ module.exports = {
   TextInputStyle,
   PermissionFlagsBits,
   PermissionsBitField,
-  ComponentType
+  ComponentType,
+  ChannelType
 };

--- a/__tests__/commands/hunt/schedule.test.js
+++ b/__tests__/commands/hunt/schedule.test.js
@@ -75,3 +75,15 @@ test('handles database failure', async () => {
   expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Failed to schedule hunt.', flags: MessageFlags.Ephemeral });
   spy.mockRestore();
 });
+
+test('defines subcommand options in required-first order', () => {
+  const data = command.data();
+  const optionSummary = data.options.map(o => ({ name: o.name, required: o.required }));
+  expect(optionSummary).toEqual([
+    { name: 'name', required: true },
+    { name: 'start', required: true },
+    { name: 'end', required: true },
+    { name: 'channel', required: true },
+    { name: 'description', required: false },
+  ]);
+});

--- a/commands/hunt/schedule.js
+++ b/commands/hunt/schedule.js
@@ -9,8 +9,6 @@ module.exports = {
     .addStringOption(opt =>
       opt.setName('name').setDescription('Hunt name').setRequired(true))
     .addStringOption(opt =>
-      opt.setName('description').setDescription('Hunt description').setRequired(false))
-    .addStringOption(opt =>
       opt.setName('start').setDescription('Start time').setRequired(true))
     .addStringOption(opt =>
       opt.setName('end').setDescription('End time').setRequired(true))
@@ -18,7 +16,9 @@ module.exports = {
       opt.setName('channel')
         .setDescription('Event voice channel')
         .addChannelTypes(ChannelType.GuildVoice, ChannelType.GuildStageVoice)
-        .setRequired(true)),
+        .setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('description').setDescription('Hunt description').setRequired(false)),
 
   async execute(interaction) {
     const name = interaction.options.getString('name');


### PR DESCRIPTION
## Summary
- ensure required hunt schedule options come before optional ones
- test the option order for hunt schedule
- expand Discord mock to support channel options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dcef509e8832db0d186d2d2a88122