### PR TITLE
Update hunt schedule command options

### DIFF
--- a/__tests__/commands/hunt/schedule.test.js
+++ b/__tests__/commands/hunt/schedule.test.js
@@ -83,7 +83,7 @@ test('defines subcommand options in required-first order', () => {
     { name: 'name', required: true },
     { name: 'start', required: true },
     { name: 'end', required: true },
-    { name: 'channel', required: true },
-    { name: 'description', required: false },
+    { name: 'description', required: true },
+    { name: 'channel', required: false },
   ]);
 });

--- a/commands/hunt/schedule.js
+++ b/commands/hunt/schedule.js
@@ -12,13 +12,13 @@ module.exports = {
       opt.setName('start').setDescription('Start time').setRequired(true))
     .addStringOption(opt =>
       opt.setName('end').setDescription('End time').setRequired(true))
+    .addStringOption(opt =>
+      opt.setName('description').setDescription('Hunt description').setRequired(true))
     .addChannelOption(opt =>
       opt.setName('channel')
         .setDescription('Event voice channel')
         .addChannelTypes(ChannelType.GuildVoice, ChannelType.GuildStageVoice)
-        .setRequired(true))
-    .addStringOption(opt =>
-      opt.setName('description').setDescription('Hunt description').setRequired(false)),
+        .setRequired(false)),
 
   async execute(interaction) {
     const name = interaction.options.getString('name');


### PR DESCRIPTION
## Summary
- update `/hunt schedule` so description is required but channel is optional
- update tests for changed option requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dd1e76f84832db988e932af322d3d