### PR TITLE
Fix POI subcommand registration

### DIFF
--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder, MockInteraction } = require('discord.js');
+
+jest.mock('fs');
+
+jest.mock('../../../commands/hunt/help.js', () => {
+  const { SlashCommandSubcommandBuilder } = require('discord.js');
+  const builder = new SlashCommandSubcommandBuilder().setName('help').setDescription('help');
+  return {
+    data: () => builder,
+    execute: jest.fn()
+  };
+}, { virtual: true });
+
+jest.mock('../../../commands/hunt/poi.js', () => {
+  const { SlashCommandSubcommandGroupBuilder } = require('discord.js');
+  const builder = new SlashCommandSubcommandGroupBuilder().setName('poi').setDescription('POI');
+  builder.addSubcommand(sub => sub.setName('create').setDescription('c'));
+  return {
+    data: () => builder,
+    group: true,
+    execute: jest.fn()
+  };
+}, { virtual: true });
+
+fs.readdirSync.mockReturnValue(['help.js', 'poi.js']);
+
+const command = require('../../../commands/hunt');
+
+test('registers subcommand group', () => {
+  const types = command.data.options.map(o => o.type);
+  expect(types).toContain('subcommandgroup');
+});
+
+test('routes to group execute', async () => {
+  const interaction = new MockInteraction({ options: { subcommandGroup: 'poi', subcommand: 'create' } });
+  await command.execute(interaction, {});
+  const poiModule = require('../../../commands/hunt/poi.js');
+  expect(poiModule.execute).toHaveBeenCalled();
+});

--- a/commands/hunt/poi.js
+++ b/commands/hunt/poi.js
@@ -2,26 +2,31 @@ const { SlashCommandSubcommandGroupBuilder, MessageFlags } = require('discord.js
 const fs = require('fs');
 const path = require('path');
 
-const data = new SlashCommandSubcommandGroupBuilder()
-  .setName('poi')
-  .setDescription('Manage hunt points of interest');
+function buildGroup() {
+  const group = new SlashCommandSubcommandGroupBuilder()
+    .setName('poi')
+    .setDescription('Manage hunt points of interest');
 
-const subcommandsDir = path.join(__dirname, 'poi');
-const subcommandFiles = fs.readdirSync(subcommandsDir).filter(f => f.endsWith('.js'));
+  const subcommandsDir = path.join(__dirname, 'poi');
+  const subcommandFiles = fs.readdirSync(subcommandsDir).filter(f => f.endsWith('.js'));
 
-for (const file of subcommandFiles) {
-  try {
-    const subcommand = require(`./poi/${file}`);
-    if (typeof subcommand.data === 'function') {
-      data.addSubcommand(subcommand.data);
+  for (const file of subcommandFiles) {
+    try {
+      const subcommand = require(`./poi/${file}`);
+      if (typeof subcommand.data === 'function') {
+        group.addSubcommand(subcommand.data);
+      }
+    } catch (err) {
+      console.error(`❌ Failed to load POI subcommand ${file}:`, err);
     }
-  } catch (err) {
-    console.error(`❌ Failed to load POI subcommand ${file}:`, err);
   }
+
+  return group;
 }
 
 module.exports = {
-  data,
+  data: buildGroup,
+  group: true,
   async execute(interaction, client) {
     const sub = interaction.options.getSubcommand();
     try {


### PR DESCRIPTION
## Summary
- expose `group: true` on `poi` to identify as a subcommand group
- register subcommand groups in `hunt.js`
- build POI subcommand group dynamically
- extend discord.js mock with `addSubcommandGroup` and `getSubcommandGroup`
- test registration and execution of POI subcommands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683ddaa3ce24832da239198ce3fd0e28