### PR TITLE
Improve hunt.js test coverage

### DIFF
--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder, MockInteraction } = require('discord.js');
+const { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder, MockInteraction, MessageFlags } = require('discord.js');
 
 jest.mock('fs');
 
@@ -24,6 +24,9 @@ jest.mock('../../../commands/hunt/poi.js', () => {
 }, { virtual: true });
 
 jest.mock('../../../commands/hunt/poi/list.js', () => ({ button: jest.fn() }), { virtual: true });
+jest.mock('../../../commands/hunt/nofunc', () => ({}), { virtual: true });
+jest.mock('../../../commands/hunt/fail', () => ({ execute: jest.fn(() => { throw new Error('boom'); }) }), { virtual: true });
+jest.mock('../../../commands/hunt/badgroup', () => ({ group: true }), { virtual: true });
 
 fs.readdirSync.mockReturnValue(['help.js', 'poi.js']);
 
@@ -55,4 +58,71 @@ test('button ignores unrelated ids', async () => {
   const list = require('../../../commands/hunt/poi/list.js');
   await command.button(interaction, {});
   expect(list.button).not.toHaveBeenCalled();
+});
+
+test('replies when subcommand not implemented', async () => {
+  const interaction = new MockInteraction({ options: { subcommand: 'nofunc' } });
+  const replySpy = jest.spyOn(interaction, 'reply');
+  await command.execute(interaction, {});
+  expect(replySpy).toHaveBeenCalledWith({
+    content: '❌ Subcommand "nofunc" not implemented.',
+    flags: MessageFlags.Ephemeral
+  });
+});
+
+test('handles subcommand error', async () => {
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const interaction = new MockInteraction({ options: { subcommand: 'fail' } });
+  const replySpy = jest.spyOn(interaction, 'reply');
+  await command.execute(interaction, {});
+  expect(errSpy).toHaveBeenCalled();
+  expect(replySpy).toHaveBeenCalledWith({
+    content: '❌ Failed to run subcommand.',
+    flags: MessageFlags.Ephemeral
+  });
+  errSpy.mockRestore();
+});
+
+test('logs error when subcommand fails to load', () => {
+  fs.readdirSync.mockReturnValue(['bad.js']);
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.isolateModules(() => {
+    jest.doMock('../../../commands/hunt/bad.js', () => { throw new Error('nope'); }, { virtual: true });
+    require('../../../commands/hunt');
+  });
+  expect(errSpy).toHaveBeenCalled();
+  errSpy.mockRestore();
+  fs.readdirSync.mockReturnValue(['help.js', 'poi.js']);
+});
+
+test('button handles list load error', async () => {
+  jest.resetModules();
+  const fsMock = require('fs');
+  fsMock.readdirSync.mockReturnValue(['help.js', 'poi.js']);
+  jest.doMock('../../../commands/hunt/poi/list.js', () => { throw new Error('fail'); }, { virtual: true });
+  const commandErr = require('../../../commands/hunt');
+  const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const interaction = { customId: 'hunt_poi_page::1', replied: false, deferred: false, reply: jest.fn() };
+  await commandErr.button(interaction, {});
+  expect(errSpy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Something went wrong.', flags: MessageFlags.Ephemeral });
+  errSpy.mockRestore();
+  jest.dontMock('../../../commands/hunt/poi/list.js');
+});
+
+test('button warns on unknown prefix', async () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const interaction = { customId: 'hunt_unknown::1', replied: false, deferred: false, reply: jest.fn() };
+  await command.button(interaction, {});
+  expect(warnSpy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Button handler not found.', flags: MessageFlags.Ephemeral });
+  warnSpy.mockRestore();
+});
+
+test('falls back to subcommand when group execute missing', async () => {
+  const interaction = new MockInteraction({ options: { subcommandGroup: 'badgroup', subcommand: 'help' } });
+  const helpModule = require('../../../commands/hunt/help.js');
+  const spy = helpModule.execute;
+  await command.execute(interaction, {});
+  expect(spy).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- expand hunt command root tests to exercise error paths

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683de557ce80832d861f82be74e5ff0b