### PR TITLE
Expand command test coverage

### DIFF
--- a/__tests__/commands/admin/updateaccolade.test.js
+++ b/__tests__/commands/admin/updateaccolade.test.js
@@ -64,4 +64,21 @@ describe('/updateaccolade command', () => {
 
     expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('at least one field'), flags: MessageFlags.Ephemeral }));
   });
+
+  test('sends new message when old one missing', async () => {
+    const interaction = makeInteraction();
+    const acc = { role_id: 'r1', name: 'Test', save: jest.fn(), channel_id: 'c1', message_id: 'm1', emoji: '', description: '' };
+    Accolade.findOne.mockResolvedValue(acc);
+    buildAccoladeEmbed.mockReturnValue('embed');
+    interaction.guild.channels.fetch.mockResolvedValue({
+      type: 0,
+      messages: { fetch: jest.fn(() => Promise.reject(new Error('404'))) },
+      send: jest.fn(() => ({ id: 'new' }))
+    });
+
+    await execute(interaction);
+
+    expect(acc.save).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('updated') }));
+  });
 });

--- a/__tests__/commands/fun/highcard.test.js
+++ b/__tests__/commands/fun/highcard.test.js
@@ -89,3 +89,19 @@ test('rejects challenge when opponent already challenged', async () => {
   });
 });
 
+test('self challenge allowed with tester role', async () => {
+  const interaction = makeChallengeInteraction(true, true);
+  await highcard.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('has challenged') }));
+});
+
+test('challenge tie same value', async () => {
+  const challenge = makeChallengeInteraction();
+  await highcard.execute(challenge);
+  const accept = makeAcceptInteraction();
+  jest.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(0.24);
+  await highcard.execute(accept);
+  Math.random.mockRestore();
+  expect(accept.reply.mock.calls[0][0].content).toContain("It's a tie");
+});
+

--- a/__tests__/commands/fun/roll.test.js
+++ b/__tests__/commands/fun/roll.test.js
@@ -38,3 +38,11 @@ test('handles invalid formula error', async () => {
   errSpy.mockRestore();
 });
 
+test('omits footer when no reason provided', async () => {
+  parseDice.mockReturnValue({ total: 4, rolls: ['4'] });
+  const interaction = { options: { getString: jest.fn(key => (key === 'formula' ? 'd4' : null)) }, reply: jest.fn() };
+  await roll.execute(interaction);
+  const footer = interaction.reply.mock.calls[0][0].embeds[0].data.footer.text;
+  expect(footer).toBeNull();
+});
+

--- a/__tests__/commands/hunt/list.test.js
+++ b/__tests__/commands/hunt/list.test.js
@@ -49,3 +49,13 @@ test('handles fetch errors', async () => {
   });
   spy.mockRestore();
 });
+
+test('handles hunts with missing dates', async () => {
+  Hunt.findAll.mockResolvedValue([
+    { name: 'Test', status: 'active', starts_at: null, ends_at: null }
+  ]);
+  const interaction = makeInteraction();
+  await command.execute(interaction);
+  const value = interaction.reply.mock.calls[0][0].embeds[0].data.fields[0].value;
+  expect(value).toContain('N/A');
+});

--- a/__tests__/commands/hunt/poi/create.test.js
+++ b/__tests__/commands/hunt/poi/create.test.js
@@ -58,6 +58,13 @@ test('handles db error', async () => {
   spy.mockRestore();
 });
 
+test('uses null image when not provided', async () => {
+  const interaction = makeInteraction();
+  interaction.options.getString.mockImplementation(key => ({ name:'Alpha', hint:'Find me', location:'Area18' }[key]));
+  await command.execute(interaction);
+  expect(HuntPoi.create).toHaveBeenCalledWith(expect.objectContaining({ image_url: null }));
+});
+
 test('defines command options', () => {
   const data = command.data();
   const optionSummary = data.options.map(o => ({ name: o.name, required: o.required }));

--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -72,3 +72,25 @@ test('button paginates results', async () => {
   expect(embed.data.footer.text).toContain('Page 2 of');
 });
 
+test('button ignores unrelated id', async () => {
+  const interaction = { customId: 'other', deferUpdate: jest.fn(), reply: jest.fn() };
+  await command.button(interaction);
+  expect(interaction.deferUpdate).not.toHaveBeenCalled();
+});
+
+test('editReply when interaction already replied', async () => {
+  HuntPoi.findAll.mockResolvedValue([{ name: 'A', points: 1, hint: 'h' }]);
+  const interaction = { replied: true, deferred: false, reply: jest.fn(), editReply: jest.fn() };
+  await command.execute(interaction);
+  expect(interaction.editReply).toHaveBeenCalled();
+});
+
+test('button logs error on failure', async () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  HuntPoi.findAll.mockRejectedValueOnce(new Error('fail'));
+  const interaction = { customId: 'hunt_poi_page::0', deferUpdate: jest.fn(), editReply: jest.fn(), reply: jest.fn(), deferred:false, replied:false };
+  await command.button(interaction);
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});
+

--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -56,3 +56,25 @@ test('button ignores unrelated ids', async () => {
   await command.button(interaction, {});
   expect(list.button).not.toHaveBeenCalled();
 });
+
+test('execute replies when subcommand missing', async () => {
+  const interaction = new MockInteraction({ options: { subcommand: 'missing' } });
+  await command.execute(interaction, {});
+  expect(interaction.replyContent).toMatch('Failed to run subcommand');
+});
+
+test('execute handles subcommand error', async () => {
+  const help = require('../../../commands/hunt/help.js');
+  help.execute.mockRejectedValue(new Error('fail'));
+  const interaction = new MockInteraction({ options: { subcommand: 'help' } });
+  await command.execute(interaction, {});
+  expect(interaction.replyContent).toMatch('Failed to run');
+});
+
+test('button handles errors from poi list', async () => {
+  const list = require('../../../commands/hunt/poi/list.js');
+  list.button.mockRejectedValue(new Error('bad'));
+  const interaction = { customId: 'hunt_poi_page::1', replied: false, deferred: false, reply: jest.fn() };
+  await command.button(interaction, {});
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Something went wrong') }));
+});

--- a/__tests__/commands/tools/shipdetails.test.js
+++ b/__tests__/commands/tools/shipdetails.test.js
@@ -88,3 +88,16 @@ test('logs error when fetch fails', async () => {
   expect(i.editReply).toHaveBeenCalledWith('❌ Failed to fetch or store updated vehicle details.');
 });
 
+test('warns when api data missing uuid', async () => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  const old = new Date(Date.now() - 1000);
+  db.Vehicle.findOne.mockResolvedValue({ uuid: '1', updated_at: new Date(), name: 'Ship', link: 'u' });
+  db.VehicleDetail.findByPk.mockResolvedValue({ uuid: '1', updated_at: old });
+  const { fetchSCDataByUrl } = require('../../../utils/fetchSCData');
+  fetchSCDataByUrl.mockResolvedValue({ data: { name: 'Ship', updated_at: new Date(), version: 'v' } });
+  await command.execute(i);
+  expect(console.warn).toHaveBeenCalled();
+});
+

--- a/__tests__/commands/tools/uexfinditem.test.js
+++ b/__tests__/commands/tools/uexfinditem.test.js
@@ -86,3 +86,15 @@ test('pagination generates nav buttons', async () => {
   expect(first.data.disabled).toBe(false);
   expect(second.data.disabled).toBe(true);
 });
+
+test('vehicle search branch', async () => {
+  isUserVerified.mockResolvedValue(true);
+  db.UexItemPrice.findAll.mockResolvedValue([]);
+  db.UexCommodityPrice.findAll.mockResolvedValue([]);
+  db.UexVehiclePurchasePrice.findAll
+    .mockResolvedValueOnce([{ id_vehicle: 2, vehicle_name: 'ship' }])
+    .mockResolvedValueOnce([{ price_buy: 10, price_sell: 0, terminal: { name: 'A' } }]);
+  const i = makeInteraction();
+  await command.execute(i);
+  expect(i.editReply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+});

--- a/__tests__/commands/tools/uexinventory.test.js
+++ b/__tests__/commands/tools/uexinventory.test.js
@@ -71,6 +71,15 @@ test('option handles missing terminal', async () => {
   expect(i.update).toHaveBeenCalledWith(expect.objectContaining({ content: '❌ Terminal not found.' }));
 });
 
+test('option no terminals of selected type', async () => {
+  const i = makeInteraction();
+  i.customId = 'uexinventory_type::Area18';
+  i.values = ['store'];
+  db.UexTerminal.findAll.mockResolvedValue([]);
+  await command.option(i);
+  expect(i.update).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No terminals of type') }));
+});
+
 test('option returns inventory embed', async () => {
   const i = makeInteraction();
   i.customId = 'uexinventory_terminal';

--- a/__tests__/commands/tools/uexterminals.test.js
+++ b/__tests__/commands/tools/uexterminals.test.js
@@ -81,4 +81,11 @@ describe('/uexterminals command', () => {
     expect(send).toHaveBeenCalled();
     expect(btn.deferUpdate).toHaveBeenCalled();
   });
+
+  test('button replies when no matches', async () => {
+    db.UexTerminal.findAll.mockResolvedValue([]);
+    const btn = { customId: 'uexterminals_page::Port::0::false', reply: jest.fn(), update: jest.fn() };
+    await command.button(btn);
+    expect(btn.reply).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('No terminals') }));
+  });
 });


### PR DESCRIPTION
## Summary
- add deeper tests covering error branches for hunt root command
- add branch coverage for updateaccolade command
- extend highcard dice game tests for tie and tester role
- cover optional footer branch in roll command
- add additional hunt list and poi tests
- expand coverage for shipdetails, uexfinditem, uexinventory and uexterminals

## Testing
- `npm test -- --coverage`

------
https://chatgpt.com/codex/tasks/task_b_683de58c7790832da94424f3ef656a90