### PR TITLE
Improve branch coverage for multiple commands

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -136,6 +136,7 @@ const TextInputBuilder = jest.fn().mockImplementation(function () {
     setStyle: jest.fn().mockReturnThis(),
     setPlaceholder: jest.fn().mockReturnThis(),
     setRequired: jest.fn().mockReturnThis(),
+    setValue: jest.fn().mockReturnThis(),
   };
 });
 

--- a/__tests__/commands/fun/roll.test.js
+++ b/__tests__/commands/fun/roll.test.js
@@ -24,6 +24,16 @@ test('sends embed with dice result', async () => {
   expect(embed.fields[1].value).toBe('**7**');
 });
 
+test('sends embed without reason when not provided', async () => {
+  parseDice.mockReturnValue({ total: 4, rolls: ['4'] });
+  const interaction = { options: { getString: jest.fn(key => (key === 'formula' ? 'd4' : null)) }, reply: jest.fn() };
+
+  await roll.execute(interaction);
+
+  const embed = interaction.reply.mock.calls[0][0].embeds[0].toJSON();
+  expect(embed.footer).toEqual({ text: null });
+});
+
 test('handles invalid formula error', async () => {
   parseDice.mockImplementation(() => { throw new Error('bad'); });
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/__tests__/commands/hunt/list.test.js
+++ b/__tests__/commands/hunt/list.test.js
@@ -35,6 +35,18 @@ test('lists hunts when present', async () => {
   expect(reply.flags).toBe(MessageFlags.Ephemeral);
 });
 
+test('lists hunts with missing dates as N/A', async () => {
+  Hunt.findAll.mockResolvedValue([
+    { name: 'No Dates', status: 'active', starts_at: null, ends_at: null }
+  ]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
+  expect(fields[0].value).toContain('N/A');
+});
+
 test('handles fetch errors', async () => {
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   Hunt.findAll.mockRejectedValue(new Error('fail'));

--- a/__tests__/commands/hunt/poi/create.test.js
+++ b/__tests__/commands/hunt/poi/create.test.js
@@ -42,6 +42,20 @@ test('creates poi and replies', async () => {
   });
 });
 
+test('handles missing optional image', async () => {
+  const interaction = makeInteraction();
+  interaction.options.getString = jest.fn(key => ({
+    name: 'Bravo',
+    hint: 'hint',
+    location: 'loc',
+    image: null
+  }[key]));
+
+  await command.execute(interaction);
+
+  expect(HuntPoi.create).toHaveBeenCalledWith(expect.objectContaining({ image_url: null }));
+});
+
 test('handles db error', async () => {
   const interaction = makeInteraction();
   const err = new Error('fail');

--- a/__tests__/commands/tools/galactapedia.test.js
+++ b/__tests__/commands/tools/galactapedia.test.js
@@ -124,3 +124,16 @@ test('fetches and stores detail when missing', async () => {
   expect(db.GalactapediaTag.upsert).toHaveBeenCalled();
   expect(i.editReply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
 });
+
+test('handles missing translation content gracefully', async () => {
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  db.GalactapediaEntry.findOne.mockResolvedValue({ id: 4, title: 'n', rsi_url: 'u', api_url: 'api' });
+  db.GalactapediaDetail.findByPk.mockResolvedValue(null);
+  fetchSCDataByUrl.mockResolvedValue({ data: { } });
+  db.GalactapediaDetail.findByPk.mockResolvedValueOnce(null).mockResolvedValueOnce({ content: 'No content found.' });
+
+  await command.execute(i);
+
+  expect(i.editReply).toHaveBeenCalledWith(expect.objectContaining({ embeds: expect.any(Array) }));
+});

--- a/__tests__/commands/tools/shipdetails.test.js
+++ b/__tests__/commands/tools/shipdetails.test.js
@@ -74,6 +74,29 @@ test('fetches detail when outdated', async () => {
   expect(fetchSCDataByUrl).toHaveBeenCalled();
 });
 
+test('no vehicles found', async () => {
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  db.Vehicle.findOne.mockResolvedValue(null);
+  db.Vehicle.findAll.mockResolvedValue([]);
+
+  await command.execute(i);
+
+  expect(i.editReply).toHaveBeenCalledWith(expect.stringContaining('No vehicles'));
+});
+
+test('selection timeout handled', async () => {
+  isUserVerified.mockResolvedValue(true);
+  const i = makeInteraction();
+  db.Vehicle.findOne.mockResolvedValue(null);
+  db.Vehicle.findAll.mockResolvedValue([{ uuid: '1', name: 'Ship', version: 'v' }]);
+  i.channel.awaitMessageComponent.mockRejectedValue(new Error('timeout'));
+
+  await command.execute(i);
+
+  expect(i.editReply).toHaveBeenLastCalledWith({ content: expect.stringContaining('Timed out'), components: [] });
+});
+
 test('logs error when fetch fails', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
   isUserVerified.mockResolvedValue(true);

--- a/__tests__/commands/tools/uexfinditem.test.js
+++ b/__tests__/commands/tools/uexfinditem.test.js
@@ -86,3 +86,11 @@ test('pagination generates nav buttons', async () => {
   expect(first.data.disabled).toBe(false);
   expect(second.data.disabled).toBe(true);
 });
+
+test('pagination previous page', async () => {
+  const i = { customId: 'uexfinditem::commodity::1::0', deferUpdate: jest.fn(), editReply: jest.fn() };
+  const records = Array.from({ length: 15 }, () => ({ price_buy: 1, price_sell: 0, terminal: { name: 'T' } }));
+  db.UexCommodityPrice.findAll.mockResolvedValue(records);
+  await command.button(i);
+  expect(i.editReply).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- expand command tests to cover more branches
- handle optional fields and failure cases
- expand mocks to support modal input values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683de80d0ef8832da735f2a9f278fdfe