### PR TITLE
Fix edit POI modal interaction

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -130,6 +130,7 @@ test('edit button replies when poi missing', async () => {
   await command.button(interaction);
 
   expect(interaction.followUp).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('POI not found') }));
+  expect(interaction.deferUpdate).not.toHaveBeenCalled();
 });
 
 test('edit button shows modal when poi exists', async () => {
@@ -145,6 +146,7 @@ test('edit button shows modal when poi exists', async () => {
   await command.button(interaction);
 
   expect(interaction.showModal).toHaveBeenCalled();
+  expect(interaction.deferUpdate).not.toHaveBeenCalled();
 });
 
 test('archive button archives poi', async () => {

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -127,7 +127,6 @@ module.exports = {
     if (interaction.customId.startsWith('hunt_poi_edit::')) {
       const [, poiId, pageStr] = interaction.customId.split('::');
       const page = parseInt(pageStr, 10) || 0;
-      await interaction.deferUpdate();
       try {
         const poi = await HuntPoi.findByPk(poiId);
         if (!poi) {


### PR DESCRIPTION
## Summary
- remove `deferUpdate` before opening the POI edit modal
- assert no deferred reply for POI edit in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683df14bcf0c832d8b3fcae01ba803a0