### PR TITLE
Fix POI edit modal limit

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -146,6 +146,8 @@ test('edit button shows modal when poi exists', async () => {
   await command.button(interaction);
 
   expect(interaction.showModal).toHaveBeenCalled();
+  const modal = interaction.showModal.mock.calls[0][0];
+  expect(modal.addComponents.mock.calls[0].length).toBeLessThanOrEqual(5);
   expect(interaction.deferUpdate).not.toHaveBeenCalled();
 });
 

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -143,12 +143,6 @@ module.exports = {
           .setRequired(true)
           .setValue(poi.name);
 
-        const descInput = new TextInputBuilder()
-          .setCustomId('description')
-          .setLabel('Description')
-          .setStyle(TextInputStyle.Paragraph)
-          .setRequired(true)
-          .setValue(poi.description || '');
 
         const hintInput = new TextInputBuilder()
           .setCustomId('hint')
@@ -180,7 +174,6 @@ module.exports = {
 
         modal.addComponents(
           new ActionRowBuilder().addComponents(nameInput),
-          new ActionRowBuilder().addComponents(descInput),
           new ActionRowBuilder().addComponents(hintInput),
           new ActionRowBuilder().addComponents(locationInput),
           new ActionRowBuilder().addComponents(imageInput),
@@ -232,7 +225,6 @@ module.exports = {
     if (!interaction.customId.startsWith('hunt_poi_edit_modal::')) return;
     const [, poiId] = interaction.customId.split('::');
     const name = interaction.fields.getTextInputValue('name');
-    const description = interaction.fields.getTextInputValue('description');
     const hint = interaction.fields.getTextInputValue('hint');
     const location = interaction.fields.getTextInputValue('location');
     const image = interaction.fields.getTextInputValue('image');
@@ -241,7 +233,6 @@ module.exports = {
     try {
       await HuntPoi.update({
         name,
-        description,
         hint: hint || null,
         location: location || null,
         image_url: image || null,


### PR DESCRIPTION
## Summary
- remove description field from POI edit modal to respect Discord component limit
- verify modal uses five components in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683df281d3ec832d9ab324c3005c0ca9