### PR TITLE
Improve set-channels coverage

### DIFF
--- a/__tests__/commands/hunt/set-channels.test.js
+++ b/__tests__/commands/hunt/set-channels.test.js
@@ -38,3 +38,7 @@ test('handles db failure', async () => {
   expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Failed to update channels.', flags: MessageFlags.Ephemeral });
   spy.mockRestore();
 });
+
+test('builder defines required channel options', () => {
+  expect(typeof command.data()).toBe('object');
+});


### PR DESCRIPTION
## Summary
- run set-channels builder in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683df313f730832dbaaa8b3399f07d6d