### PR TITLE
Add hunt modal handler

### DIFF
--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -23,7 +23,7 @@ jest.mock('../../../commands/hunt/poi.js', () => {
   };
 }, { virtual: true });
 
-jest.mock('../../../commands/hunt/poi/list.js', () => ({ button: jest.fn(), option: jest.fn() }), { virtual: true });
+jest.mock('../../../commands/hunt/poi/list.js', () => ({ button: jest.fn(), option: jest.fn(), modal: jest.fn() }), { virtual: true });
 jest.mock('../../../commands/hunt/nofunc', () => ({}), { virtual: true });
 jest.mock('../../../commands/hunt/fail', () => ({ execute: jest.fn(() => { throw new Error('boom'); }) }), { virtual: true });
 jest.mock('../../../commands/hunt/badgroup', () => ({ group: true }), { virtual: true });
@@ -58,6 +58,13 @@ test('option routes to poi list handler', async () => {
   const list = require('../../../commands/hunt/poi/list.js');
   await command.option(interaction, {});
   expect(list.option).toHaveBeenCalledWith(interaction, {});
+});
+
+test('modal routes to poi list handler', async () => {
+  const interaction = { customId: 'hunt_poi_edit_step1::1', replied: false, deferred: false };
+  const list = require('../../../commands/hunt/poi/list.js');
+  await command.modal(interaction, {});
+  expect(list.modal).toHaveBeenCalledWith(interaction, {});
 });
 
 test('option ignores unrelated ids', async () => {
@@ -139,6 +146,15 @@ test('option warns on unknown prefix', async () => {
   await command.option(interaction, {});
   expect(warnSpy).toHaveBeenCalled();
   expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Select menu handler not found.', flags: MessageFlags.Ephemeral });
+  warnSpy.mockRestore();
+});
+
+test('modal warns on unknown prefix', async () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const interaction = { customId: 'hunt_unknown::1', replied: false, deferred: false, reply: jest.fn() };
+  await command.modal(interaction, {});
+  expect(warnSpy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Modal handler not found.', flags: MessageFlags.Ephemeral });
   warnSpy.mockRestore();
 });
 

--- a/commands/hunt.js
+++ b/commands/hunt.js
@@ -80,9 +80,8 @@ module.exports = {
     if (!interaction.replied && !interaction.deferred) {
       await interaction.reply({ content: '❌ Button handler not found.', flags: MessageFlags.Ephemeral });
     }
-  }
+  },
 
-  ,
   async option(interaction, client) {
     const prefix = interaction.customId.split('::')[0];
 
@@ -107,6 +106,33 @@ module.exports = {
     console.warn(`⚠️ [HUNT] No select menu handler found for prefix "${prefix}".`);
     if (!interaction.replied && !interaction.deferred) {
       await interaction.reply({ content: '❌ Select menu handler not found.', flags: MessageFlags.Ephemeral });
+    }
+  },
+
+  async modal(interaction, client) {
+    const prefix = interaction.customId.split('::')[0];
+
+    if (!prefix.startsWith('hunt_')) return;
+
+    if (prefix.startsWith('hunt_poi_')) {
+      try {
+        const list = require('./hunt/poi/list');
+        if (typeof list.modal === 'function') {
+          await list.modal(interaction, client);
+          return;
+        }
+      } catch (err) {
+        console.error(`❌ Failed to handle modal for ${prefix}:`, err);
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({ content: '❌ Something went wrong.', flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+    }
+
+    console.warn(`⚠️ [HUNT] No modal handler found for prefix "${prefix}".`);
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({ content: '❌ Modal handler not found.', flags: MessageFlags.Ephemeral });
     }
   }
 };


### PR DESCRIPTION
## Summary
- route hunt modal submissions to POI list
- test hunt modal routing and warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dfcfeb8d4832d97455d9c12936ade