### PR TITLE
Skip intermediate POI edit reply

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -189,20 +189,11 @@ test('modal updates poi information', async () => {
     customId: 'hunt_poi_edit_step1::1',
     fields: { getTextInputValue: jest.fn(() => 'val') },
     user: { id: 'u' },
-    reply: jest.fn()
+    showModal: jest.fn()
   };
 
   await command.modal(step1);
-  expect(step1.reply).toHaveBeenCalled();
-
-  const continueBtn = {
-    customId: 'hunt_poi_edit_step2_btn::1',
-    showModal: jest.fn(),
-    reply: jest.fn()
-  };
-
-  await command.button(continueBtn);
-  expect(continueBtn.showModal).toHaveBeenCalled();
+  expect(step1.showModal).toHaveBeenCalled();
 
   const step2 = {
     customId: 'hunt_poi_edit_step2::1',
@@ -221,11 +212,9 @@ test('modal handles update failure', async () => {
   HuntPoi.findByPk = jest.fn().mockResolvedValue({ location: '', image_url: '', points: 1 });
   HuntPoi.update = jest.fn(() => Promise.reject(new Error('fail')));
 
-  const step1 = { customId: 'hunt_poi_edit_step1::1', fields: { getTextInputValue: jest.fn(() => 'val') }, user: { id: 'u' }, reply: jest.fn() };
+  const step1 = { customId: 'hunt_poi_edit_step1::1', fields: { getTextInputValue: jest.fn(() => 'val') }, user: { id: 'u' }, showModal: jest.fn() };
   await command.modal(step1);
-
-  const btn = { customId: 'hunt_poi_edit_step2_btn::1', showModal: jest.fn(), reply: jest.fn() };
-  await command.button(btn);
+  expect(step1.showModal).toHaveBeenCalled();
 
   const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   const step2 = { customId: 'hunt_poi_edit_step2::1', fields: { getTextInputValue: jest.fn(() => 'val') }, user: { id: 'u' }, reply: jest.fn() };

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -172,50 +172,7 @@ module.exports = {
       return;
     }
 
-    if (interaction.customId.startsWith('hunt_poi_edit_step2_btn::')) {
-      const [, poiId] = interaction.customId.split('::');
-      try {
-        const poi = await HuntPoi.findByPk(poiId);
-        if (!poi) {
-          return interaction.reply({ content: '❌ POI not found.', flags: MessageFlags.Ephemeral });
-        }
-        const modal = new ModalBuilder()
-          .setCustomId(`hunt_poi_edit_step2::${poiId}`)
-          .setTitle('Edit POI (2/2)');
 
-        const locationInput = new TextInputBuilder()
-          .setCustomId('location')
-          .setLabel('Location')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false)
-          .setValue(poi.location || '');
-
-        const imageInput = new TextInputBuilder()
-          .setCustomId('image')
-          .setLabel('Image URL')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false)
-          .setValue(poi.image_url || '');
-
-        const pointsInput = new TextInputBuilder()
-          .setCustomId('points')
-          .setLabel('Points')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(true)
-          .setValue(String(poi.points));
-
-        modal.addComponents(
-          new ActionRowBuilder().addComponents(locationInput),
-          new ActionRowBuilder().addComponents(imageInput),
-          new ActionRowBuilder().addComponents(pointsInput)
-        );
-
-        return interaction.showModal(modal);
-      } catch (err) {
-        console.error('❌ Failed to build followup modal:', err);
-        return interaction.reply({ content: '❌ Failed to build followup modal.', flags: MessageFlags.Ephemeral });
-      }
-    }
 
     if (interaction.customId.startsWith('hunt_poi_archive::')) {
       const [, poiId, pageStr] = interaction.customId.split('::');
@@ -268,18 +225,38 @@ module.exports = {
         const timeout = setTimeout(() => pendingEdits.delete(key), EDIT_TIMEOUT);
         pendingEdits.set(key, { name, description, hint, timeout });
 
-        const button = new ButtonBuilder()
-          .setCustomId(`hunt_poi_edit_step2_btn::${poiId}`)
-          .setLabel('Continue to Step 2')
-          .setStyle(ButtonStyle.Primary);
+        const modal = new ModalBuilder()
+          .setCustomId(`hunt_poi_edit_step2::${poiId}`)
+          .setTitle('Edit POI (2/2)');
 
-        const row = new ActionRowBuilder().addComponents(button);
+        const locationInput = new TextInputBuilder()
+          .setCustomId('location')
+          .setLabel('Location')
+          .setStyle(TextInputStyle.Short)
+          .setRequired(false)
+          .setValue(poi.location || '');
 
-        return interaction.reply({
-          content: 'Step 1 saved. Click below to continue editing.',
-          components: [row],
-          flags: MessageFlags.Ephemeral
-        });
+        const imageInput = new TextInputBuilder()
+          .setCustomId('image')
+          .setLabel('Image URL')
+          .setStyle(TextInputStyle.Short)
+          .setRequired(false)
+          .setValue(poi.image_url || '');
+
+        const pointsInput = new TextInputBuilder()
+          .setCustomId('points')
+          .setLabel('Points')
+          .setStyle(TextInputStyle.Short)
+          .setRequired(true)
+          .setValue(String(poi.points));
+
+        modal.addComponents(
+          new ActionRowBuilder().addComponents(locationInput),
+          new ActionRowBuilder().addComponents(imageInput),
+          new ActionRowBuilder().addComponents(pointsInput)
+        );
+
+        return interaction.showModal(modal);
       } catch (err) {
         console.error('❌ Failed to build followup modal:', err);
         return interaction.reply({ content: '❌ Failed to build followup modal.', flags: MessageFlags.Ephemeral });


### PR DESCRIPTION
## Summary
- remove interim reply between POI modal steps
- directly show the second modal after submitting the first
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e1e1be01c832dae426992b876d3b2