### PR TITLE
fix: consolidate hunt poi editing into one modal

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -38,7 +38,8 @@ All remaining checklist items are still pending.
 * [x] `/hunt poi list` — displays a paginated embed of POIs with a select menu for current page items
 
   * [x] Selecting an item highlights the POI and displays buttons to either ✏️ Edit or 📦 Archive
-  * [x] Edit opens a modal with prefilled data (name, description, hint, location, image url, points)
+  * [x] Edit opens a modal with prefilled data (description, hint, location, image url, points)
+    * Name is fixed after creation due to Discord modal limits
   * [x] Archive immediately archives the selected POI
   * [x] Pagination updates both the embed and the select menu
   * [ ] Admin view restricts these controls to `Admiral` and `Fleet Admiral` roles

--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -61,7 +61,7 @@ test('option routes to poi list handler', async () => {
 });
 
 test('modal routes to poi list handler', async () => {
-  const interaction = { customId: 'hunt_poi_edit_step1::1', replied: false, deferred: false };
+  const interaction = { customId: 'hunt_poi_edit_form::1', replied: false, deferred: false };
   const list = require('../../../commands/hunt/poi/list.js');
   await command.modal(interaction, {});
   expect(list.modal).toHaveBeenCalledWith(interaction, {});


### PR DESCRIPTION
## Summary
- allow editing all POI attributes except name in a single modal
- adjust POI edit flow tests for new modal
- update root command modal routing test
- note modal limit in `SCAVENGER_HUNT_TODO.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e214975b4832d823dc400f391d4a3