### PR TITLE
feat(hunt): show poi name in edit modal

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -155,6 +155,7 @@ test('edit button shows modal when poi exists', async () => {
 
   expect(interaction.showModal).toHaveBeenCalled();
   const modal = interaction.showModal.mock.calls[0][0];
+  expect(modal.setTitle).toHaveBeenCalledWith(expect.stringContaining('X'));
   expect(modal.addComponents.mock.calls[0].length).toBe(5);
   expect(interaction.deferUpdate).not.toHaveBeenCalled();
 });

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -132,9 +132,9 @@ module.exports = {
         if (!poi) {
           return interaction.followUp({ content: '❌ POI not found.', flags: MessageFlags.Ephemeral });
         }
-        const modal = new ModalBuilder()
-          .setCustomId(`hunt_poi_edit_form::${poiId}`)
-          .setTitle('Edit POI');
+          const modal = new ModalBuilder()
+            .setCustomId(`hunt_poi_edit_form::${poiId}`)
+            .setTitle(`Edit POI - ${poi.name}`);
 
         const descriptionInput = new TextInputBuilder()
           .setCustomId('description')


### PR DESCRIPTION
## Summary
- show POI name in the edit modal title
- check that the modal title includes the POI name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683e33a42ca0832d8a29630dbda4e30e