### PR TITLE
Implement non-admin hunt submission workflow

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -42,7 +42,7 @@ All remaining checklist items are still pending.
     * Name is fixed after creation due to Discord modal limits
   * [x] Archive immediately archives the selected POI
   * [x] Pagination updates both the embed and the select menu
-  * [ ] Admin view restricts these controls to `Admiral` and `Fleet Admiral` roles
+  * [x] Admin view restricts these controls to `Admiral` and `Fleet Admiral` roles
 * [ ] POIs exist globally and are not tied to a specific hunt
 * [ ] All POI management uses select menus and modals to avoid reliance on raw IDs
 
@@ -52,11 +52,11 @@ All remaining checklist items are still pending.
 
 * [ ] Submitting proof for the same POI multiple times will overwrite the user's previous submission
 
-* [ ] `/hunt poi list` (non-mod view) — displays a paginated embed of POIs with a select menu for current page items
+* [x] `/hunt poi list` (non-mod view) — displays a paginated embed of POIs with a select menu for current page items
 
-  * Selecting an item shows a 📸 Submit Proof button
-  * Clicking submit opens a modal or image upload interaction for selfie submission
-  * Pagination updates both the embed and select menu
+  * [x] Selecting an item shows a 📸 Submit Proof button
+  * [x] Clicking submit opens a modal or image upload interaction for selfie submission
+  * [x] Pagination updates both the embed and select menu
 
 * [ ] `/hunt my-submissions` — view own submissions for the current hunt
 

--- a/__tests__/utils/googleDrive.test.js
+++ b/__tests__/utils/googleDrive.test.js
@@ -37,3 +37,18 @@ test('creates drive client using service account key', async () => {
   expect(mockDrive).toHaveBeenCalledWith({ version: 'v3', auth: 'client' });
   expect(drive).toBe('drive');
 });
+const { uploadScreenshot } = require('../../utils/googleDrive');
+
+describe('uploadScreenshot', () => {
+  test('uploads file to user folder', async () => {
+    const create = jest.fn()
+      .mockResolvedValueOnce({ data: { id: 'folder' } })
+      .mockResolvedValueOnce({ data: { id: 'file', webViewLink: 'link' } });
+    const drive = { files: { create } };
+
+    const res = await uploadScreenshot(drive, 'root', 'user', 'file.png', Buffer.from('img'), 'image/png');
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ id: 'file', webViewLink: 'link' });
+  });
+});

--- a/utils/googleDrive.js
+++ b/utils/googleDrive.js
@@ -18,4 +18,18 @@ async function createDriveClient() {
   return google.drive({ version: 'v3', auth: authClient });
 }
 
-module.exports = { createDriveClient };
+async function uploadScreenshot(drive, rootFolderId, userFolderName, fileName, fileBuffer, mimeType) {
+  const folderRes = await drive.files.create({
+    resource: { name: userFolderName, mimeType: 'application/vnd.google-apps.folder', parents: [rootFolderId] },
+    fields: 'id'
+  });
+  const folderId = folderRes.data.id;
+  const fileRes = await drive.files.create({
+    resource: { name: fileName, parents: [folderId] },
+    media: { mimeType, body: fileBuffer },
+    fields: 'id, webViewLink'
+  });
+  return fileRes.data;
+}
+
+module.exports = { createDriveClient, uploadScreenshot };


### PR DESCRIPTION
## Summary
- enable submit button for non-admin POI listings
- upload user images to Google Drive
- handle submission modals and notify channels
- add Google Drive helper
- extend tests for new hunt submission flow
- update scavenger hunt TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e38d1e690832d850ae0f37282b95f