### PR TITLE
Add file upload option for POI submissions

### DIFF
--- a/__tests__/commands/hunt/poi/upload.test.js
+++ b/__tests__/commands/hunt/poi/upload.test.js
@@ -1,0 +1,76 @@
+jest.mock('../../../../config/database', () => ({
+  Hunt: { findOne: jest.fn() },
+  HuntSubmission: { create: jest.fn() },
+  Config: { findOne: jest.fn() }
+}));
+
+const { Hunt, HuntSubmission, Config } = require('../../../../config/database');
+jest.mock('../../../../utils/googleDrive', () => ({
+  createDriveClient: jest.fn(() => ({ files: { create: jest.fn() } })),
+  uploadScreenshot: jest.fn(() => ({ id: 'f', webViewLink: 'link' }))
+}));
+const { uploadScreenshot } = require('../../../../utils/googleDrive');
+jest.mock('node-fetch');
+const fetch = require('node-fetch');
+const command = require('../../../../commands/hunt/poi/upload');
+const { MessageFlags } = require('../../../../__mocks__/discord.js');
+
+beforeEach(() => jest.clearAllMocks());
+
+test('creates submission with attachment', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  Config.findOne.mockResolvedValueOnce({ value: 'a' }).mockResolvedValueOnce({ value: 'r' });
+  const activityCh = { send: jest.fn() };
+  const reviewCh = { send: jest.fn().mockResolvedValue({ id: 'm' }) };
+  const client = { channels: { fetch: jest.fn(id => (id === 'a' ? activityCh : reviewCh)) } };
+  fetch.mockResolvedValue({ ok: true, buffer: async () => Buffer.from('img'), headers: { get: () => 'image/png' } });
+  const interaction = {
+    options: {
+      getString: jest.fn(() => '1'),
+      getAttachment: jest.fn(() => ({ url: 'http://img', contentType: 'image/png' }))
+    },
+    user: { id: 'u' },
+    client,
+    reply: jest.fn()
+  };
+  process.env.GOOGLE_DRIVE_HUNT_FOLDER = 'root';
+  await command.execute(interaction);
+  expect(HuntSubmission.create).toHaveBeenCalled();
+  expect(uploadScreenshot).toHaveBeenCalled();
+  expect(activityCh.send).toHaveBeenCalled();
+  expect(reviewCh.send).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ flags: MessageFlags.Ephemeral }));
+  delete process.env.GOOGLE_DRIVE_HUNT_FOLDER;
+});
+
+test('handles fetch failure', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  fetch.mockResolvedValue({ ok: false });
+  const interaction = {
+    options: {
+      getString: jest.fn(() => '1'),
+      getAttachment: jest.fn(() => ({ url: 'http://img', contentType: 'image/png' }))
+    },
+    user: { id: 'u' },
+    client: {},
+    reply: jest.fn()
+  };
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  await command.execute(interaction);
+  expect(spy).toHaveBeenCalled();
+  expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({ content: '❌ Failed to submit proof.' }));
+  spy.mockRestore();
+});
+
+test('no active hunt', async () => {
+  Hunt.findOne.mockResolvedValue(null);
+  const interaction = {
+    options: {
+      getString: jest.fn(() => '1'),
+      getAttachment: jest.fn(() => ({ url: 'http://img', contentType: 'image/png' }))
+    },
+    reply: jest.fn()
+  };
+  await command.execute(interaction);
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+});

--- a/commands/hunt/poi/upload.js
+++ b/commands/hunt/poi/upload.js
@@ -1,0 +1,63 @@
+const {
+  SlashCommandSubcommandBuilder,
+  MessageFlags
+} = require('discord.js');
+const { Hunt, HuntSubmission, Config } = require('../../../config/database');
+const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
+const fetch = require('node-fetch');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('upload')
+    .setDescription('Upload screenshot proof for a POI')
+    .addStringOption(opt =>
+      opt.setName('poi_id').setDescription('POI ID').setRequired(true))
+    .addAttachmentOption(opt =>
+      opt.setName('image').setDescription('Screenshot file').setRequired(true)),
+
+  async execute(interaction) {
+    const poiId = interaction.options.getString('poi_id');
+    const attachment = interaction.options.getAttachment('image');
+
+    const botType = process.env.BOT_TYPE || 'development';
+    try {
+      const hunt = await Hunt.findOne({ where: { status: 'active' } });
+      if (!hunt) {
+        return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+      }
+      const activityConfig = await Config.findOne({ where: { key: 'hunt_activity_channel', botType } });
+      const reviewConfig = await Config.findOne({ where: { key: 'hunt_review_channel', botType } });
+      const drive = await createDriveClient();
+      const rootFolder = process.env.GOOGLE_DRIVE_HUNT_FOLDER;
+
+      const response = await fetch(attachment.url);
+      if (!response.ok) throw new Error('Failed to fetch attachment');
+      const buffer = await response.buffer();
+      const mime = attachment.contentType || response.headers.get('content-type');
+      const file = await uploadScreenshot(drive, rootFolder, interaction.user.id, `${poiId}.jpg`, buffer, mime);
+
+      const submission = await HuntSubmission.create({
+        hunt_id: hunt.id,
+        poi_id: poiId,
+        user_id: interaction.user.id,
+        image_url: file.webViewLink,
+        status: 'pending'
+      });
+
+      if (activityConfig) {
+        const ch = await interaction.client.channels.fetch(activityConfig.value);
+        await ch.send(`<@${interaction.user.id}> submitted evidence for POI ${poiId}`);
+      }
+      if (reviewConfig) {
+        const ch = await interaction.client.channels.fetch(reviewConfig.value);
+        const msg = await ch.send(`Submission from <@${interaction.user.id}> for POI ${poiId}: ${file.webViewLink}`);
+        await submission.update({ review_channel_id: ch.id, review_message_id: msg.id });
+      }
+
+      return interaction.reply({ content: '✅ Submission received.', flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to submit proof:', err);
+      return interaction.reply({ content: '❌ Failed to submit proof.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- support uploading an image attachment to submit proof for a POI
- test POI file-upload flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e3b7c17f4832db818b162591a1a45