### PR TITLE
Switch POI create command to attachment

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -10,6 +10,7 @@ class MockInteraction {
   }) {
     this.options = {
       getString: jest.fn().mockImplementation(key => options[key]),
+      getAttachment: jest.fn().mockImplementation(key => options[key]),
       getSubcommand: jest.fn(() => options.subcommand || null),
       getSubcommandGroup: jest.fn(() => options.subcommandGroup || null),
     };
@@ -191,6 +192,16 @@ const SlashCommandBuilder = jest.fn(() => {
       this.options.push(option);
       return this;
     },
+    addAttachmentOption(fn) {
+      const option = { type: 'attachment', name: undefined, description: undefined, required: false };
+      fn({
+        setName(name) { option.name = name; return this; },
+        setDescription(desc) { option.description = desc; return this; },
+        setRequired(req) { option.required = req; return this; },
+      });
+      this.options.push(option);
+      return this;
+    },
     addUserOption(fn) {
       const option = { type: 'user', name: undefined, description: undefined, required: false };
       fn({
@@ -278,17 +289,27 @@ const SlashCommandBuilder = jest.fn(() => {
               sub.options.push(opt);
               return this;
             },
-            addIntegerOption(intFn) {
-              const opt = { type: 'integer', name: undefined, description: undefined, required: false };
-              intFn({
-                setName(nm) { opt.name = nm; return this; },
-                setDescription(ds) { opt.description = ds; return this; },
-                setRequired(r) { opt.required = r; return this; },
-              });
-              sub.options.push(opt);
-              return this;
-            },
-          };
+        addIntegerOption(intFn) {
+          const opt = { type: 'integer', name: undefined, description: undefined, required: false };
+          intFn({
+            setName(nm) { opt.name = nm; return this; },
+            setDescription(ds) { opt.description = ds; return this; },
+            setRequired(r) { opt.required = r; return this; },
+          });
+          sub.options.push(opt);
+          return this;
+        },
+        addAttachmentOption(attFn) {
+          const opt = { type: 'attachment', name: undefined, description: undefined, required: false };
+          attFn({
+            setName(nm) { opt.name = nm; return this; },
+            setDescription(ds) { opt.description = ds; return this; },
+            setRequired(r) { opt.required = r; return this; },
+          });
+          sub.options.push(opt);
+          return this;
+        },
+      };
           subFn(subBuilder);
           group.options.push(sub);
           return this;

--- a/__tests__/commands/hunt/poi/create.test.js
+++ b/__tests__/commands/hunt/poi/create.test.js
@@ -11,9 +11,9 @@ const makeInteraction = () => ({
     getString: jest.fn(key => ({
       name: 'Alpha',
       hint: 'Find me',
-      location: 'Area18',
-      image: 'img'
+      location: 'Area18'
     }[key])),
+    getAttachment: jest.fn(() => ({ url: 'img' })),
     getInteger: jest.fn(() => 10)
   },
   user: { id: 'u1' },
@@ -47,9 +47,9 @@ test('handles missing optional image', async () => {
   interaction.options.getString = jest.fn(key => ({
     name: 'Bravo',
     hint: 'hint',
-    location: 'loc',
-    image: null
+    location: 'loc'
   }[key]));
+  interaction.options.getAttachment = jest.fn(() => null);
 
   await command.execute(interaction);
 

--- a/commands/hunt/poi/create.js
+++ b/commands/hunt/poi/create.js
@@ -9,13 +9,13 @@ module.exports = {
     .addStringOption(opt => opt.setName('hint').setDescription('Hint for hunters').setRequired(true))
     .addStringOption(opt => opt.setName('location').setDescription('Location').setRequired(true))
     .addIntegerOption(opt => opt.setName('points').setDescription('Point value').setRequired(true))
-    .addStringOption(opt => opt.setName('image').setDescription('Image URL').setRequired(false)),
+    .addAttachmentOption(opt => opt.setName('image').setDescription('Image file').setRequired(false)),
 
   async execute(interaction) {
     const name = interaction.options.getString('name');
     const hint = interaction.options.getString('hint');
     const location = interaction.options.getString('location');
-    const image = interaction.options.getString('image');
+    const attachment = interaction.options.getAttachment('image');
     const points = interaction.options.getInteger('points');
     const userId = interaction.user.id;
 
@@ -24,7 +24,7 @@ module.exports = {
         name,
         hint,
         location,
-        image_url: image || null,
+        image_url: attachment ? attachment.url : null,
         points,
         status: 'active',
         created_by: userId


### PR DESCRIPTION
## Summary
- allow uploading a file for POI creation
- adjust tests for new attachment input
- extend discord.js mock to support `getAttachment` and `addAttachmentOption`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e3d6999cc832da5474a3fc129fc4c