### PR TITLE
feat(hunt): track poi for uploads

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -15,6 +15,7 @@ jest.mock('node-fetch');
 const fetch = require('node-fetch');
 const command = require('../../../../commands/hunt/poi/list');
 const { MessageFlags } = require('../../../../__mocks__/discord.js');
+const { pendingPoiUploads } = require('../../../../utils/pendingSelections');
 
 const makeInteraction = (roles = []) => ({
   reply: jest.fn(),
@@ -34,6 +35,7 @@ const makeInteraction = (roles = []) => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  for (const k of Object.keys(pendingPoiUploads)) delete pendingPoiUploads[k];
 });
 
 test('replies when no pois exist', async () => {
@@ -251,8 +253,9 @@ test('modal handles update failure', async () => {
 });
 
 test('submit button replies with upload instructions', async () => {
-  const interaction = { customId: 'hunt_poi_submit::1::0', reply: jest.fn(), member: { roles: { cache: { map: fn => [] } } } };
+  const interaction = { customId: 'hunt_poi_submit::1::0', reply: jest.fn(), member: { roles: { cache: { map: fn => [] } } }, user: { id: 'u1' } };
   await command.button(interaction);
+  expect(pendingPoiUploads['u1']).toBe('1');
   expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
     content: expect.stringContaining('/hunt poi upload'),
     flags: MessageFlags.Ephemeral

--- a/__tests__/utils/pendingSelections.test.js
+++ b/__tests__/utils/pendingSelections.test.js
@@ -1,11 +1,18 @@
 const first = require('../../utils/pendingSelections');
 const second = require('../../utils/pendingSelections');
 
-describe('pendingChannelSelection', () => {
-  test('exports singleton object', () => {
+describe('pending selections exports', () => {
+  test('channel selection is singleton', () => {
     expect(first.pendingChannelSelection).toBe(second.pendingChannelSelection);
     expect(first.pendingChannelSelection).toEqual({});
     first.pendingChannelSelection.foo = 'bar';
     expect(second.pendingChannelSelection.foo).toBe('bar');
+  });
+
+  test('poi uploads is singleton', () => {
+    expect(first.pendingPoiUploads).toBe(second.pendingPoiUploads);
+    expect(first.pendingPoiUploads).toEqual({});
+    first.pendingPoiUploads.foo = 'baz';
+    expect(second.pendingPoiUploads.foo).toBe('baz');
   });
 });

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -13,6 +13,7 @@ const {
 const { HuntPoi, Hunt, HuntSubmission, Config } = require('../../../config/database');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
 const fetch = require('node-fetch');
+const { pendingPoiUploads } = require('../../../utils/pendingSelections');
 
 const allowedRoles = ['Admiral', 'Fleet Admiral'];
 
@@ -200,7 +201,8 @@ module.exports = {
 
     if (interaction.customId.startsWith('hunt_poi_submit::')) {
       const [, poiId] = interaction.customId.split('::');
-      const content = `Use the /hunt poi upload command with POI ID \`${poiId}\` and attach your screenshot.`;
+      pendingPoiUploads[interaction.user.id] = poiId;
+      const content = 'Use the /hunt poi upload command and attach your screenshot.';
       await interaction.reply({ content, flags: MessageFlags.Ephemeral });
       return;
     }

--- a/commands/hunt/poi/upload.js
+++ b/commands/hunt/poi/upload.js
@@ -4,19 +4,25 @@ const {
 } = require('discord.js');
 const { Hunt, HuntSubmission, Config } = require('../../../config/database');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
+const { pendingPoiUploads } = require('../../../utils/pendingSelections');
 const fetch = require('node-fetch');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('upload')
     .setDescription('Upload screenshot proof for a POI')
-    .addStringOption(opt =>
-      opt.setName('poi_id').setDescription('POI ID').setRequired(true))
     .addAttachmentOption(opt =>
       opt.setName('image').setDescription('Screenshot file').setRequired(true)),
 
   async execute(interaction) {
-    const poiId = interaction.options.getString('poi_id');
+    const poiId = pendingPoiUploads[interaction.user.id];
+    if (!poiId) {
+      return interaction.reply({
+        content: '❌ No pending POI found. Use /hunt poi list and choose \`Submit Proof\` first.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+    delete pendingPoiUploads[interaction.user.id];
     const attachment = interaction.options.getAttachment('image');
 
     const botType = process.env.BOT_TYPE || 'development';

--- a/utils/pendingSelections.js
+++ b/utils/pendingSelections.js
@@ -1,7 +1,9 @@
 // utils/pendingSelections.js
 
 const pendingChannelSelection = {};
+const pendingPoiUploads = {};
 
 module.exports = {
-    pendingChannelSelection
+    pendingChannelSelection,
+    pendingPoiUploads
 };


### PR DESCRIPTION
## Summary
- keep hunt POI id server-side for submissions
- store pending POI uploads in utils
- update upload command to read pending POI id
- update list command to set pending POI id when clicking Submit Proof
- adjust related unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e47aa6dec832dbdccde66206d9845