### PR TITLE
Increase UexVehiclePurchasePrice coverage

### DIFF
--- a/models/uexVehiclePurchasePrice.js
+++ b/models/uexVehiclePurchasePrice.js
@@ -27,10 +27,6 @@ module.exports = (sequelize) => {
       as: 'terminal'
     });
   };
-
-  UexVehiclePurchasePrice.associate = (models) => {
-    UexVehiclePurchasePrice.belongsTo(models.UexTerminal, { foreignKey: 'id_terminal', as: 'terminal' });
-  };
   
   return UexVehiclePurchasePrice
 };


### PR DESCRIPTION
## Summary
- remove duplicate `associate` definition from UexVehiclePurchasePrice model

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_683e487cd1a4832d813589edb9f66c22