### PR TITLE
Add Google Drive test command

### DIFF
--- a/__tests__/commands/tools/gdrivetest.test.js
+++ b/__tests__/commands/tools/gdrivetest.test.js
@@ -1,0 +1,83 @@
+const command = require('../../../commands/tools/gdrivetest');
+const { MessageFlags, PermissionFlagsBits } = require('../../../__mocks__/discord.js');
+
+jest.mock('../../../utils/googleDrive', () => ({
+  createDriveClient: jest.fn()
+}));
+
+const { createDriveClient } = require('../../../utils/googleDrive');
+
+const makeInteraction = (isAdmin = true) => ({
+  member: { permissions: { has: jest.fn(() => isAdmin) } },
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  reply: jest.fn()
+});
+
+describe('/gdrivetest command', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GOOGLE_DRIVE_TEST_FOLDER = 'root';
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_DRIVE_TEST_FOLDER;
+  });
+
+  test('rejects non-admin users', async () => {
+    const interaction = makeInteraction(false);
+
+    await command.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      flags: MessageFlags.Ephemeral
+    }));
+    expect(createDriveClient).not.toHaveBeenCalled();
+  });
+
+  test('rejects when env var missing', async () => {
+    const interaction = makeInteraction();
+    delete process.env.GOOGLE_DRIVE_TEST_FOLDER;
+
+    await command.execute(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      flags: MessageFlags.Ephemeral
+    }));
+    expect(createDriveClient).not.toHaveBeenCalled();
+  });
+
+  test('performs drive operations', async () => {
+    const interaction = makeInteraction();
+    const list = jest.fn().mockResolvedValue({ data: { files: [] } });
+    const create = jest.fn()
+      .mockResolvedValueOnce({ data: { id: 'folder' } })
+      .mockResolvedValueOnce({ data: { id: 'file', webViewLink: 'link' } });
+    createDriveClient.mockResolvedValue({ files: { list, create } });
+
+    await command.execute(interaction);
+
+    expect(createDriveClient).toHaveBeenCalled();
+    expect(list).toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('link'),
+      flags: MessageFlags.Ephemeral
+    }));
+  });
+
+  test('handles errors gracefully', async () => {
+    const interaction = makeInteraction();
+    createDriveClient.mockRejectedValue(new Error('fail'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await command.execute(interaction);
+
+    expect(errSpy).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: '❌ Drive test failed.',
+      flags: MessageFlags.Ephemeral
+    });
+    errSpy.mockRestore();
+  });
+});

--- a/commands/tools/gdrivetest.js
+++ b/commands/tools/gdrivetest.js
@@ -1,0 +1,58 @@
+const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { createDriveClient } = require('../../utils/googleDrive');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('gdrivetest')
+    .setDescription('Verify Google Drive permissions by creating a test file')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  help: 'Runs a series of Google Drive operations to confirm the bot has access.',
+  category: 'Admin',
+  async execute(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+      return interaction.reply({
+        content: '❌ Only administrators can use this command.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    const rootFolderId = process.env.GOOGLE_DRIVE_TEST_FOLDER;
+    if (!rootFolderId) {
+      return interaction.reply({
+        content: '❌ GOOGLE_DRIVE_TEST_FOLDER not configured.',
+        flags: MessageFlags.Ephemeral
+      });
+    }
+
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    try {
+      console.log('🛠️ Starting Google Drive test...');
+      const drive = await createDriveClient();
+
+      console.log('🛠️ Listing files...');
+      await drive.files.list({
+        q: `'${rootFolderId}' in parents and trashed=false`,
+        fields: 'files(id,name)'
+      });
+
+      console.log('🛠️ Creating folder...');
+      const folderRes = await drive.files.create({
+        resource: { name: 'QMTest', mimeType: 'application/vnd.google-apps.folder', parents: [rootFolderId] },
+        fields: 'id'
+      });
+
+      console.log('🛠️ Creating file...');
+      const fileRes = await drive.files.create({
+        resource: { name: 'test.txt', parents: [folderRes.data.id] },
+        media: { mimeType: 'text/plain', body: 'Quartermaster Drive Test' },
+        fields: 'id, webViewLink'
+      });
+
+      console.log('✅ Google Drive test complete');
+      await interaction.editReply({ content: `✅ Created test file: ${fileRes.data.webViewLink}`, flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Drive test failed:', err);
+      await interaction.editReply({ content: '❌ Drive test failed.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `/gdrivetest` command to verify Google Drive access
- cover command with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683eedaaf4f0832d8863f9015d55886f