### PR TITLE
Add review approval workflow

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -42,7 +42,9 @@ const HuntPoi = {
 
 const HuntSubmission = {
   findAll: jest.fn(),
-  create: jest.fn()
+  findByPk: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn()
 };
 
 // Simple mock Sequelize-like instance

--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -146,6 +146,8 @@ const TextInputStyle = { Short: 1, Paragraph: 2 };
 const ButtonStyle = {
   Primary: 1,
   Secondary: 2,
+  Success: 3,
+  Danger: 4,
 };
 
 const ChannelType = {


### PR DESCRIPTION
## Summary
- mock DB extended for HuntSubmission updates
- support Success/Danger button styles in discord mocks
- add approve/reject buttons when submissions are sent to the review channel
- handle approval and rejection workflows including modal capture of rejection reason
- expand hunt POI tests for new review flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683effa0c478832da33996df7fa93431