### PR TITLE
Add hunt submissions view command

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -18,7 +18,7 @@ Initial scaffolding for the scavenger hunt exists on the `scavenger` branch. The
 * `/hunt schedule` and full POI management with select menus/modals
 * Submission workflow with Google Drive storage and review buttons
 
-The remaining work mainly covers scoring, automatic event sync, `/hunt my-submissions`, and channel gating.
+The remaining work mainly covers scoring, automatic event sync, and channel gating.
 
 ---
 
@@ -60,7 +60,7 @@ The remaining work mainly covers scoring, automatic event sync, `/hunt my-submis
   * [x] Clicking submit opens a modal or image upload interaction for selfie submission
   * [x] Pagination updates both the embed and select menu
 
-* [ ] `/hunt my-submissions` — view own submissions for the current hunt
+* [x] `/hunt my-submissions` — view own submissions for the current hunt
 
 * [x] Submissions are reviewed externally via Google Drive
 

--- a/__tests__/commands/hunt/my-submissions.test.js
+++ b/__tests__/commands/hunt/my-submissions.test.js
@@ -1,0 +1,55 @@
+jest.mock('../../../config/database', () => ({
+  Hunt: { findOne: jest.fn() },
+  HuntSubmission: { findAll: jest.fn() },
+  HuntPoi: { findAll: jest.fn() }
+}));
+
+const { Hunt, HuntSubmission, HuntPoi } = require('../../../config/database');
+const command = require('../../../commands/hunt/my-submissions');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+const makeInteraction = () => ({ user: { id: 'u1' }, reply: jest.fn() });
+
+beforeEach(() => jest.clearAllMocks());
+
+test('replies when no active hunt', async () => {
+  Hunt.findOne.mockResolvedValue(null);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+});
+
+test('replies when no submissions', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ You have no submissions for this hunt.', flags: MessageFlags.Ephemeral });
+});
+
+test('lists submissions with total points', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { poi_id: 'p1', status: 'approved' },
+    { poi_id: 'p2', status: 'rejected' }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([
+    { id: 'p1', name: 'Alpha', points: 5 },
+    { id: 'p2', name: 'Bravo', points: 8 }
+  ]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  const reply = interaction.reply.mock.calls[0][0];
+  expect(reply.embeds[0].data.title).toContain('Hunt Submissions');
+  expect(reply.embeds[0].data.description).toContain('5');
+  const fields = reply.embeds[0].data.fields;
+  expect(fields[0].name).toBe('Alpha');
+  expect(fields[0].value).toContain('approved');
+  expect(fields[1].name).toBe('Bravo');
+});

--- a/commands/hunt/help.js
+++ b/commands/hunt/help.js
@@ -15,7 +15,8 @@ module.exports = {
         { name: '/hunt schedule', value: 'Create a new hunt and Discord event (admin).' },
         { name: '/hunt set-channels', value: 'Configure activity and review channels (admin).' },
         { name: '/hunt poi create', value: 'Create a new Point of Interest (admin).' },
-        { name: '/hunt poi list', value: 'Browse POIs, submit proof, or edit/archive (admin).' }
+        { name: '/hunt poi list', value: 'Browse POIs, submit proof, or edit/archive (admin).' },
+        { name: '/hunt my-submissions', value: 'View your submissions and points earned.' }
       );
 
     await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/commands/hunt/my-submissions.js
+++ b/commands/hunt/my-submissions.js
@@ -1,0 +1,47 @@
+const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('my-submissions')
+    .setDescription('View your submissions for the current hunt'),
+
+  async execute(interaction) {
+    const userId = interaction.user.id;
+    try {
+      const hunt = await Hunt.findOne({ where: { status: 'active' } });
+      if (!hunt) {
+        return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+      }
+
+      const submissions = await HuntSubmission.findAll({
+        where: { hunt_id: hunt.id, user_id: userId },
+        order: [['submitted_at', 'ASC']]
+      });
+
+      if (!submissions.length) {
+        return interaction.reply({ content: '❌ You have no submissions for this hunt.', flags: MessageFlags.Ephemeral });
+      }
+
+      const poiIds = [...new Set(submissions.map(s => s.poi_id))];
+      const pois = await HuntPoi.findAll({ where: { id: poiIds } });
+      const poiMap = new Map(pois.map(p => [p.id, p]));
+
+      let total = 0;
+      const embed = new EmbedBuilder().setTitle('Your Hunt Submissions');
+
+      for (const sub of submissions) {
+        const poi = poiMap.get(sub.poi_id) || { name: 'Unknown', points: 0 };
+        if (sub.status === 'approved') total += poi.points;
+        const pointsText = sub.status === 'approved' ? ` (+${poi.points} pts)` : '';
+        embed.addFields({ name: poi.name, value: `Status: ${sub.status}${pointsText}` });
+      }
+
+      embed.setDescription(`Total points earned: ${total}`);
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to fetch submissions:', err);
+      await interaction.reply({ content: '❌ Failed to fetch submissions.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- support listing your scavenger hunt submissions with `/hunt my-submissions`
- document the new command in `/hunt help`
- mark todo item as complete
- tests for the new command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f10f30998832dbcabb3e22ed502c4