### PR TITLE
feat(hunt): compact my-submissions output

### DIFF
--- a/__tests__/commands/hunt/my-submissions.test.js
+++ b/__tests__/commands/hunt/my-submissions.test.js
@@ -49,7 +49,7 @@ test('lists submissions with total points', async () => {
   expect(reply.embeds[0].data.title).toContain('Hunt Submissions');
   expect(reply.embeds[0].data.description).toContain('5');
   const fields = reply.embeds[0].data.fields;
-  expect(fields[0].name).toBe('Alpha');
-  expect(fields[0].value).toContain('approved');
-  expect(fields[1].name).toBe('Bravo');
+  expect(fields[0].name).toBe('Alpha <approved> (+5 pts)');
+  expect(fields[0].value).toBe('\u200b');
+  expect(fields[1].name).toBe('Bravo <rejected>');
 });

--- a/commands/hunt/my-submissions.js
+++ b/commands/hunt/my-submissions.js
@@ -34,7 +34,7 @@ module.exports = {
         const poi = poiMap.get(sub.poi_id) || { name: 'Unknown', points: 0 };
         if (sub.status === 'approved') total += poi.points;
         const pointsText = sub.status === 'approved' ? ` (+${poi.points} pts)` : '';
-        embed.addFields({ name: poi.name, value: `Status: ${sub.status}${pointsText}` });
+        embed.addFields({ name: `${poi.name} <${sub.status}>${pointsText}`, value: '\u200b' });
       }
 
       embed.setDescription(`Total points earned: ${total}`);


### PR DESCRIPTION
## Summary
- inline hunt submission status and points in `my-submissions`
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f12d07ec0832d8631153d7b51df74