### PR TITLE
Update /hunt my-submissions embed

### DIFF
--- a/commands/hunt/my-submissions.js
+++ b/commands/hunt/my-submissions.js
@@ -14,10 +14,13 @@ module.exports = {
         return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
       }
 
-      const submissions = await HuntSubmission.findAll({
+      const allSubmissions = await HuntSubmission.findAll({
         where: { hunt_id: hunt.id, user_id: userId },
         order: [['submitted_at', 'ASC']]
       });
+
+      const supersededIds = new Set(allSubmissions.map(s => s.supersedes_submission_id).filter(Boolean));
+      const submissions = allSubmissions.filter(s => !supersededIds.has(s.id));
 
       if (!submissions.length) {
         return interaction.reply({ content: '❌ You have no submissions for this hunt.', flags: MessageFlags.Ephemeral });
@@ -28,16 +31,30 @@ module.exports = {
       const poiMap = new Map(pois.map(p => [p.id, p]));
 
       let total = 0;
-      const embed = new EmbedBuilder().setTitle('Your Hunt Submissions');
+      const pending = [];
+      const approved = [];
+      const rejected = [];
 
       for (const sub of submissions) {
         const poi = poiMap.get(sub.poi_id) || { name: 'Unknown', points: 0 };
-        if (sub.status === 'approved') total += poi.points;
-        const pointsText = sub.status === 'approved' ? ` (+${poi.points} pts)` : '';
-        embed.addFields({ name: `${poi.name} <${sub.status}>${pointsText}`, value: '\u200b' });
+        if (sub.status === 'approved') {
+          total += poi.points;
+          approved.push(`${poi.name} (+${poi.points} pts)`);
+        } else if (sub.status === 'pending') {
+          pending.push(poi.name);
+        } else if (sub.status === 'rejected') {
+          rejected.push(poi.name);
+        }
       }
 
-      embed.setDescription(`Total points earned: ${total}`);
+      const embed = new EmbedBuilder()
+        .setTitle('Your Hunt Submissions')
+        .setDescription(`Total points earned: ${total}`);
+
+      if (pending.length) embed.addFields({ name: 'Pending', value: pending.join('\n') });
+      if (approved.length) embed.addFields({ name: 'Approved', value: approved.join('\n') });
+      if (rejected.length) embed.addFields({ name: 'Rejected', value: rejected.join('\n') });
+
       await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
     } catch (err) {
       console.error('❌ Failed to fetch submissions:', err);


### PR DESCRIPTION
## Summary
- group `/hunt my-submissions` results by status
- ignore superseded submissions
- test pending/approved/rejected grouping
- test superseded submission filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f14594f40832da803e4913367e693