### PR TITLE
Add hunt selector to leaderboard

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -83,8 +83,8 @@ per-user score breakdowns.
 * [x] Ties are broken by the most recent valid submission (later timestamp wins)
 * [x] `/hunt leaderboard` — shows scores for the current active or most recent hunt
 
-  * [ ] Displays a select menu with names of previous hunts at the bottom
-  * [ ] Selecting a past hunt updates the response to show its leaderboard
+* [x] Displays a select menu with names of previous hunts at the bottom
+* [x] Selecting a past hunt updates the response to show its leaderboard
 * [ ] `/hunt score [user]` — shows the score breakdown for yourself or another user (optional parameter)
 
 ### 🗓 Discord Integration

--- a/__tests__/commands/hunt/leaderboard.test.js
+++ b/__tests__/commands/hunt/leaderboard.test.js
@@ -1,12 +1,12 @@
 jest.mock('../../../config/database', () => ({
-  Hunt: { findOne: jest.fn() },
+  Hunt: { findOne: jest.fn(), findAll: jest.fn(), findByPk: jest.fn() },
   HuntSubmission: { findAll: jest.fn() },
   HuntPoi: { findAll: jest.fn() }
 }));
 
 const { Hunt, HuntSubmission, HuntPoi } = require('../../../config/database');
 const command = require('../../../commands/hunt/leaderboard');
-const { MessageFlags } = require('discord.js');
+const { MessageFlags, StringSelectMenuBuilder } = require('discord.js');
 
 const makeInteraction = () => ({ reply: jest.fn() });
 
@@ -48,6 +48,7 @@ test('builds leaderboard from approved submissions', async () => {
     { id: 's2', user_id: 'u2', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-02') }
   ]);
   HuntPoi.findAll.mockResolvedValue([{ id: 'p1', points: 5 }]);
+  Hunt.findAll.mockResolvedValue([{ id: 'h1', name: 'Hunt' }]);
   const interaction = makeInteraction();
 
   await command.execute(interaction);
@@ -58,4 +59,33 @@ test('builds leaderboard from approved submissions', async () => {
   const lines = reply.embeds[0].data.description.split('\n');
   expect(lines[0]).toContain('<@u2>');
   expect(lines[1]).toContain('<@u1>');
+});
+
+test('includes select menu with hunts', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1', name: 'H1' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { id: 's1', user_id: 'u1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-01') }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([{ id: 'p1', points: 3 }]);
+  Hunt.findAll.mockResolvedValue([{ id: 'h1', name: 'H1' }, { id: 'h2', name: 'Old' }]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  const options = StringSelectMenuBuilder.mock.instances[0].data.options;
+  expect(options).toHaveLength(2);
+});
+
+test('option updates leaderboard for selected hunt', async () => {
+  Hunt.findByPk.mockResolvedValue({ id: 'h2', name: 'Old' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { id: 's1', user_id: 'u1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-01') }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([{ id: 'p1', points: 2 }]);
+  Hunt.findAll.mockResolvedValue([{ id: 'h1', name: 'H1' }, { id: 'h2', name: 'Old' }]);
+  const update = jest.fn();
+
+  await command.option({ customId: 'hunt_leaderboard_select', values: ['h2'], update });
+
+  expect(update).toHaveBeenCalled();
 });

--- a/commands/hunt/leaderboard.js
+++ b/commands/hunt/leaderboard.js
@@ -1,5 +1,68 @@
-const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const {
+  SlashCommandSubcommandBuilder,
+  EmbedBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  MessageFlags
+} = require('discord.js');
 const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
+
+async function generateLeaderboardEmbed(hunt) {
+  const allSubs = await HuntSubmission.findAll({
+    where: { hunt_id: hunt.id },
+    order: [['submitted_at', 'ASC']]
+  });
+
+  if (!allSubs.length) {
+    return { error: '❌ No submissions yet for this hunt.' };
+  }
+
+  const supersededIds = new Set(allSubs.map(s => s.supersedes_submission_id).filter(Boolean));
+  const submissions = allSubs.filter(s => s.status === 'approved' && !supersededIds.has(s.id));
+
+  if (!submissions.length) {
+    return { error: '❌ No approved submissions yet for this hunt.' };
+  }
+
+  const poiIds = [...new Set(submissions.map(s => s.poi_id))];
+  const pois = await HuntPoi.findAll({ where: { id: poiIds } });
+  const poiMap = new Map(pois.map(p => [p.id, p]));
+
+  const scores = new Map();
+  for (const sub of submissions) {
+    const poi = poiMap.get(sub.poi_id);
+    const points = poi ? poi.points : 0;
+    const data = scores.get(sub.user_id) || { points: 0, latest: new Date(0) };
+    data.points += points;
+    const subTime = new Date(sub.submitted_at);
+    if (subTime > data.latest) data.latest = subTime;
+    scores.set(sub.user_id, data);
+  }
+
+  const entries = Array.from(scores.entries()).map(([userId, data]) => ({ userId, ...data }));
+  entries.sort((a, b) => {
+    if (b.points !== a.points) return b.points - a.points;
+    return b.latest - a.latest;
+  });
+
+  const embed = new EmbedBuilder()
+    .setTitle(`🏅 ${hunt.name} Leaderboard`)
+    .setColor('Gold')
+    .setFooter({ text: 'Top hunters ranked by total points' })
+    .setTimestamp();
+
+  const medals = ['🥇', '🥈', '🥉'];
+  const list = entries
+    .map((entry, index) => {
+      const rank = medals[index] ?? `#${index + 1}`;
+      const paddedPoints = entry.points.toString().padStart(3, ' ');
+      return `${rank} ${paddedPoints} pts — <@${entry.userId}>`;
+    })
+    .join('\n');
+
+  embed.setDescription(list);
+  return { embed };
+}
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
@@ -16,65 +79,52 @@ module.exports = {
         return interaction.reply({ content: '❌ No scavenger hunts found.', flags: MessageFlags.Ephemeral });
       }
 
-      const allSubs = await HuntSubmission.findAll({
-        where: { hunt_id: hunt.id },
-        order: [['submitted_at', 'ASC']]
-      });
-
-      if (!allSubs.length) {
-        return interaction.reply({ content: '❌ No submissions yet for this hunt.', flags: MessageFlags.Ephemeral });
+      const { embed, error } = await generateLeaderboardEmbed(hunt);
+      if (error) {
+        return interaction.reply({ content: error, flags: MessageFlags.Ephemeral });
       }
 
-      const supersededIds = new Set(allSubs.map(s => s.supersedes_submission_id).filter(Boolean));
-      const submissions = allSubs.filter(s => s.status === 'approved' && !supersededIds.has(s.id));
+      const hunts = await Hunt.findAll({ order: [['starts_at', 'DESC']] });
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId('hunt_leaderboard_select')
+        .setPlaceholder('Select a hunt')
+        .addOptions(hunts.map(h => ({ label: h.name, value: h.id })));
 
-      if (!submissions.length) {
-        return interaction.reply({ content: '❌ No approved submissions yet for this hunt.', flags: MessageFlags.Ephemeral });
-      }
+      const row = new ActionRowBuilder().addComponents(menu);
 
-      const poiIds = [...new Set(submissions.map(s => s.poi_id))];
-      const pois = await HuntPoi.findAll({ where: { id: poiIds } });
-      const poiMap = new Map(pois.map(p => [p.id, p]));
-
-      const scores = new Map();
-      for (const sub of submissions) {
-        const poi = poiMap.get(sub.poi_id);
-        const points = poi ? poi.points : 0;
-        const data = scores.get(sub.user_id) || { points: 0, latest: new Date(0) };
-        data.points += points;
-        const subTime = new Date(sub.submitted_at);
-        if (subTime > data.latest) data.latest = subTime;
-        scores.set(sub.user_id, data);
-      }
-
-      const entries = Array.from(scores.entries()).map(([userId, data]) => ({ userId, ...data }));
-      entries.sort((a, b) => {
-        if (b.points !== a.points) return b.points - a.points;
-        return b.latest - a.latest;
-      });
-
-      const embed = new EmbedBuilder()
-      .setTitle(`🏅 ${hunt.name} Leaderboard`)
-      .setColor('Gold')
-      .setFooter({ text: 'Top hunters ranked by total points' })
-      .setTimestamp();
-    
-    const medals = ['🥇', '🥈', '🥉'];
-    
-    const list = entries
-      .map((entry, index) => {
-        const rank = medals[index] ?? `#${index + 1}`;
-        const paddedPoints = entry.points.toString().padStart(3, ' ');
-        return `${rank} ${paddedPoints} pts — <@${entry.userId}>`;
-      })
-      .join('\n');
-    
-    embed.setDescription(list);    
-
-      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+      await interaction.reply({ embeds: [embed], components: [row], flags: MessageFlags.Ephemeral });
     } catch (err) {
       console.error('❌ Failed to build leaderboard:', err);
       await interaction.reply({ content: '❌ Failed to load leaderboard.', flags: MessageFlags.Ephemeral });
+    }
+  },
+
+  async option(interaction) {
+    if (interaction.customId !== 'hunt_leaderboard_select') return;
+
+    const huntId = interaction.values[0];
+    try {
+      const hunt = await Hunt.findByPk(huntId);
+      if (!hunt) {
+        return interaction.update({ content: '❌ Hunt not found.', components: [], flags: MessageFlags.Ephemeral });
+      }
+
+      const { embed, error } = await generateLeaderboardEmbed(hunt);
+      if (error) {
+        return interaction.update({ content: error, components: [], flags: MessageFlags.Ephemeral });
+      }
+
+      const hunts = await Hunt.findAll({ order: [['starts_at', 'DESC']] });
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId('hunt_leaderboard_select')
+        .setPlaceholder('Select a hunt')
+        .addOptions(hunts.map(h => ({ label: h.name, value: h.id })));
+      const row = new ActionRowBuilder().addComponents(menu);
+
+      await interaction.update({ embeds: [embed], components: [row], flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to update leaderboard:', err);
+      await interaction.update({ content: '❌ Failed to load leaderboard.', components: [], flags: MessageFlags.Ephemeral });
     }
   }
 };


### PR DESCRIPTION
## Summary
- show leaderboard for current/most recent hunt with select menu
- update leaderboard when another hunt is selected
- mark TODO items as complete
- expand leaderboard tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f20fc6acc832db6c43ffa9a45292c