### PR TITLE
Fix leaderboard select menu handler

### DIFF
--- a/__tests__/commands/hunt/root.test.js
+++ b/__tests__/commands/hunt/root.test.js
@@ -24,6 +24,7 @@ jest.mock('../../../commands/hunt/poi.js', () => {
 }, { virtual: true });
 
 jest.mock('../../../commands/hunt/poi/list.js', () => ({ button: jest.fn(), option: jest.fn(), modal: jest.fn() }), { virtual: true });
+jest.mock('../../../commands/hunt/leaderboard.js', () => ({ option: jest.fn() }), { virtual: true });
 jest.mock('../../../commands/hunt/nofunc', () => ({}), { virtual: true });
 jest.mock('../../../commands/hunt/fail', () => ({ execute: jest.fn(() => { throw new Error('boom'); }) }), { virtual: true });
 jest.mock('../../../commands/hunt/badgroup', () => ({ group: true }), { virtual: true });
@@ -58,6 +59,13 @@ test('option routes to poi list handler', async () => {
   const list = require('../../../commands/hunt/poi/list.js');
   await command.option(interaction, {});
   expect(list.option).toHaveBeenCalledWith(interaction, {});
+});
+
+test('option routes to leaderboard handler', async () => {
+  const interaction = { customId: 'hunt_leaderboard_select', replied: false, deferred: false };
+  const leaderboard = require('../../../commands/hunt/leaderboard.js');
+  await command.option(interaction, {});
+  expect(leaderboard.option).toHaveBeenCalledWith(interaction, {});
 });
 
 test('modal routes to poi list handler', async () => {

--- a/commands/hunt.js
+++ b/commands/hunt.js
@@ -103,6 +103,22 @@ module.exports = {
       }
     }
 
+    if (prefix === 'hunt_leaderboard_select') {
+      try {
+        const leaderboard = require('./hunt/leaderboard');
+        if (typeof leaderboard.option === 'function') {
+          await leaderboard.option(interaction, client);
+          return;
+        }
+      } catch (err) {
+        console.error(`❌ Failed to handle option for ${prefix}:`, err);
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({ content: '❌ Something went wrong.', flags: MessageFlags.Ephemeral });
+        }
+        return;
+      }
+    }
+
     console.warn(`⚠️ [HUNT] No select menu handler found for prefix "${prefix}".`);
     if (!interaction.replied && !interaction.deferred) {
       await interaction.reply({ content: '❌ Select menu handler not found.', flags: MessageFlags.Ephemeral });


### PR DESCRIPTION
## Summary
- route `hunt_leaderboard_select` interactions to the leaderboard option handler
- test that the root command delegates leaderboard select menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f24e912e8832da8b8d1722a1191bb