### PR TITLE
Implement /hunt score command

### DIFF
--- a/SCAVENGER_HUNT_TODO.md
+++ b/SCAVENGER_HUNT_TODO.md
@@ -85,7 +85,7 @@ per-user score breakdowns.
 
 * [x] Displays a select menu with names of previous hunts at the bottom
 * [x] Selecting a past hunt updates the response to show its leaderboard
-* [ ] `/hunt score [user]` — shows the score breakdown for yourself or another user (optional parameter)
+* [x] `/hunt score [user]` — shows the score breakdown for yourself or another user (optional parameter)
 
 ### 🗓 Discord Integration
 

--- a/__tests__/commands/hunt/score.test.js
+++ b/__tests__/commands/hunt/score.test.js
@@ -1,0 +1,96 @@
+jest.mock('../../../config/database', () => ({
+  Hunt: { findOne: jest.fn() },
+  HuntSubmission: { findAll: jest.fn() },
+  HuntPoi: { findAll: jest.fn() }
+}));
+
+const { Hunt, HuntSubmission, HuntPoi } = require('../../../config/database');
+const command = require('../../../commands/hunt/score');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+const makeInteraction = (targetId = null) => ({
+  user: { id: 'u1', username: 'Req' },
+  options: { getUser: jest.fn(() => (targetId ? { id: targetId, username: 'Other' } : null)) },
+  reply: jest.fn()
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+test('replies when no active hunt', async () => {
+  Hunt.findOne.mockResolvedValue(null);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+});
+
+test('replies when no submissions', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([]);
+  const interaction = makeInteraction('u2');
+
+  await command.execute(interaction);
+
+  expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Other has no submissions for this hunt.', flags: MessageFlags.Ephemeral });
+});
+
+test('lists submissions grouped by status', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null },
+    { id: 's2', poi_id: 'p2', status: 'rejected', supersedes_submission_id: null },
+    { id: 's3', poi_id: 'p3', status: 'pending', supersedes_submission_id: null }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([
+    { id: 'p1', name: 'Alpha', points: 5 },
+    { id: 'p2', name: 'Bravo', points: 8 },
+    { id: 'p3', name: 'Charlie', points: 3 }
+  ]);
+  const interaction = makeInteraction();
+
+  await command.execute(interaction);
+
+  const reply = interaction.reply.mock.calls[0][0];
+  expect(reply.embeds[0].data.title).toBe('🎯 Your Hunt Submissions');
+  expect(reply.embeds[0].data.description).toBe('**Total Points Earned:** 🏆 5');
+  const fields = reply.embeds[0].data.fields;
+  expect(fields[0].name).toBe('⏳ Pending Submissions');
+  expect(fields[0].value).toBe('• Charlie');
+  expect(fields[1].name).toBe('✅ Approved Submissions');
+  expect(fields[1].value).toBe('+ 5 • Alpha');
+  expect(fields[2].name).toBe('❌ Rejected Submissions');
+  expect(fields[2].value).toBe('• Bravo');
+});
+
+test("uses username in title when targeting another user", async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([{ id: 'p1', name: 'Alpha', points: 5 }]);
+  const interaction = makeInteraction('u2');
+
+  await command.execute(interaction);
+
+  const title = interaction.reply.mock.calls[0][0].embeds[0].data.title;
+  expect(title).toBe("🎯 Other's Hunt Submissions");
+});
+
+test('filters superseded submissions', async () => {
+  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  HuntSubmission.findAll.mockResolvedValue([
+    { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null },
+    { id: 's2', poi_id: 'p1', status: 'approved', supersedes_submission_id: 's1' }
+  ]);
+  HuntPoi.findAll.mockResolvedValue([
+    { id: 'p1', name: 'Alpha', points: 5 }
+  ]);
+  const interaction = makeInteraction('u1');
+
+  await command.execute(interaction);
+
+  const fields = interaction.reply.mock.calls[0][0].embeds[0].data.fields;
+  expect(fields.length).toBe(1);
+  expect(fields[0].value).toBe('+ 5 • Alpha');
+});

--- a/commands/hunt/help.js
+++ b/commands/hunt/help.js
@@ -16,7 +16,8 @@ module.exports = {
         { name: '/hunt set-channels', value: 'Configure activity and review channels (admin).' },
         { name: '/hunt poi create', value: 'Create a new Point of Interest (admin).' },
         { name: '/hunt poi list', value: 'Browse POIs, submit proof, or edit/archive (admin).' },
-        { name: '/hunt my-submissions', value: 'View your submissions and points earned.' }
+        { name: '/hunt my-submissions', value: 'View your submissions and points earned.' },
+        { name: '/hunt score [user]', value: 'View a user\'s submissions and points earned.' }
       );
 
     await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/commands/hunt/score.js
+++ b/commands/hunt/score.js
@@ -1,0 +1,108 @@
+const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('score')
+    .setDescription('View a user\'s submissions for the current hunt')
+    .addUserOption(opt =>
+      opt.setName('user')
+        .setDescription('User to view the score for')
+        .setRequired(false)),
+
+  async execute(interaction) {
+    const targetUser = interaction.options.getUser('user') || interaction.user;
+    const userId = targetUser.id;
+    try {
+      const hunt = await Hunt.findOne({ where: { status: 'active' } });
+      if (!hunt) {
+        return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
+      }
+
+      const allSubmissions = await HuntSubmission.findAll({
+        where: { hunt_id: hunt.id, user_id: userId },
+        order: [['submitted_at', 'ASC']]
+      });
+
+      const supersededIds = new Set(allSubmissions.map(s => s.supersedes_submission_id).filter(Boolean));
+      const submissions = allSubmissions.filter(s => !supersededIds.has(s.id));
+
+      if (!submissions.length) {
+        const name = targetUser.id === interaction.user.id ? 'You have' : `${targetUser.username} has`;
+        return interaction.reply({ content: `❌ ${name} no submissions for this hunt.`, flags: MessageFlags.Ephemeral });
+      }
+
+      const poiIds = [...new Set(submissions.map(s => s.poi_id))];
+      const pois = await HuntPoi.findAll({ where: { id: poiIds } });
+      const poiMap = new Map(pois.map(p => [p.id, p]));
+
+      let total = 0;
+      const pending = [];
+      const approved = [];
+      const rejected = [];
+
+      for (const sub of submissions) {
+        const poi = poiMap.get(sub.poi_id) || { name: 'Unknown', points: 0 };
+        if (sub.status === 'approved') {
+          total += poi.points;
+          approved.push(`${poi.name} (+${poi.points} pts)`);
+        } else if (sub.status === 'pending') {
+          pending.push(poi.name);
+        } else if (sub.status === 'rejected') {
+          rejected.push(poi.name);
+        }
+      }
+
+      const title = targetUser.id === interaction.user.id
+        ? '🎯 Your Hunt Submissions'
+        : `🎯 ${targetUser.username}\'s Hunt Submissions`;
+
+      const embed = new EmbedBuilder()
+        .setTitle(title)
+        .setDescription(`**Total Points Earned:** 🏆 ${total}`)
+        .setColor('Gold')
+        .setTimestamp()
+        .setFooter({ text: 'Keep hunting, Commander.' });
+
+      const formatList = (list, withPoints = false) =>
+        list
+          .map(entry => {
+            if (withPoints) {
+              const match = entry.match(/(.+?) \(\+(\d+) pts\)/);
+              if (match) {
+                const [, name, pts] = match;
+                return `+${pts.padStart(2)} • ${name}`;
+              }
+            }
+            return `• ${entry}`;
+          })
+          .join('\n');
+
+      if (pending.length)
+        embed.addFields({
+          name: '⏳ Pending Submissions',
+          value: formatList(pending),
+          inline: false,
+        });
+
+      if (approved.length)
+        embed.addFields({
+          name: '✅ Approved Submissions',
+          value: formatList(approved, true),
+          inline: false,
+        });
+
+      if (rejected.length)
+        embed.addFields({
+          name: '❌ Rejected Submissions',
+          value: formatList(rejected),
+          inline: false,
+        });
+
+      await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('❌ Failed to fetch submissions:', err);
+      await interaction.reply({ content: '❌ Failed to fetch submissions.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `/hunt score [user]` command to view a user's scavenger hunt submissions
- document new command in help embed
- mark TODO item for `/hunt score` as complete
- test new score command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f2f6aa62c832d84ca3b0376815b8b