### PR TITLE
Refactor hunt activation logic

### DIFF
--- a/__tests__/models/hunt.test.js
+++ b/__tests__/models/hunt.test.js
@@ -11,7 +11,6 @@ describe('Hunt model', () => {
     expect(attrs).toHaveProperty('id');
     expect(attrs).toHaveProperty('name');
     expect(attrs).toHaveProperty('starts_at');
-    expect(attrs).toHaveProperty('status');
     expect(opts.tableName).toBe('hunts');
     expect(model).toEqual({});
   });

--- a/commands/hunt/help.js
+++ b/commands/hunt/help.js
@@ -11,7 +11,7 @@ module.exports = {
       .setDescription('Submit selfies at points of interest to earn points. Use the commands below to participate or manage hunts.')
       .addFields(
         { name: '/hunt help', value: 'Show this help message.' },
-        { name: '/hunt list', value: 'List all hunts and their current status.' },
+        { name: '/hunt list', value: 'List all hunts with their dates.' },
         { name: '/hunt schedule', value: 'Create a new hunt and Discord event (admin).' },
         { name: '/hunt set-channels', value: 'Configure activity and review channels (admin).' },
         { name: '/hunt poi create', value: 'Create a new Point of Interest (admin).' },

--- a/commands/hunt/leaderboard.js
+++ b/commands/hunt/leaderboard.js
@@ -5,6 +5,7 @@ const {
   StringSelectMenuBuilder,
   MessageFlags
 } = require('discord.js');
+const { Op } = require('sequelize');
 const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
 
 async function generateLeaderboardEmbed(hunt) {
@@ -75,7 +76,12 @@ module.exports = {
 
   async execute(interaction) {
     try {
-      let hunt = await Hunt.findOne({ where: { status: 'active' } });
+      let hunt = await Hunt.findOne({
+        where: {
+          starts_at: { [Op.lte]: new Date() },
+          ends_at: { [Op.gte]: new Date() }
+        }
+      });
       if (!hunt) {
         hunt = await Hunt.findOne({ order: [['starts_at', 'DESC']] });
       }

--- a/commands/hunt/list.js
+++ b/commands/hunt/list.js
@@ -17,7 +17,7 @@ module.exports = {
       for (const h of hunts) {
         const start = h.starts_at ? new Date(h.starts_at).toLocaleString() : 'N/A';
         const end = h.ends_at ? new Date(h.ends_at).toLocaleString() : 'N/A';
-        embed.addFields({ name: `${h.name} (${h.status})`, value: `${start} → ${end}` });
+        embed.addFields({ name: h.name, value: `${start} → ${end}` });
       }
 
       await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/commands/hunt/my-submissions.js
+++ b/commands/hunt/my-submissions.js
@@ -1,4 +1,5 @@
 const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const { Op } = require('sequelize');
 const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
 
 module.exports = {
@@ -9,7 +10,12 @@ module.exports = {
   async execute(interaction) {
     const userId = interaction.user.id;
     try {
-      const hunt = await Hunt.findOne({ where: { status: 'active' } });
+      const hunt = await Hunt.findOne({
+        where: {
+          starts_at: { [Op.lte]: new Date() },
+          ends_at: { [Op.gte]: new Date() }
+        }
+      });
       if (!hunt) {
         return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
       }

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -10,6 +10,7 @@ const {
   ButtonStyle,
   MessageFlags
 } = require('discord.js');
+const { Op } = require('sequelize');
 const { HuntPoi, Hunt, HuntSubmission, Config } = require('../../../config/database');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
 const fetch = require('node-fetch');
@@ -238,7 +239,12 @@ module.exports = {
 
       const botType = process.env.BOT_TYPE || 'development';
       try {
-        const hunt = await Hunt.findOne({ where: { status: 'active' } });
+        const hunt = await Hunt.findOne({
+          where: {
+            starts_at: { [Op.lte]: new Date() },
+            ends_at: { [Op.gte]: new Date() }
+          }
+        });
         if (!hunt) {
           return interaction.followUp({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
         }

--- a/commands/hunt/schedule.js
+++ b/commands/hunt/schedule.js
@@ -59,7 +59,6 @@ module.exports = {
         discord_event_id: event.id,
         starts_at: start,
         ends_at: end,
-        status: 'upcoming',
       });
 
       await interaction.reply({ content: `✅ Hunt "${name}" scheduled.`, flags: MessageFlags.Ephemeral });

--- a/models/hunt.js
+++ b/models/hunt.js
@@ -26,10 +26,6 @@ module.exports = (sequelize) => {
     ends_at: {
       type: DataTypes.DATE,
       allowNull: false
-    },
-    status: {
-      type: DataTypes.ENUM('upcoming', 'active', 'archived'),
-      allowNull: false
     }
   }, {
     tableName: 'hunts',


### PR DESCRIPTION
## Summary
- remove status column from Hunt model
- use start/end dates when determining the active hunt
- update help text and hunt listing
- drop status assertion from Hunt model test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f301f0594832d94f84b4e18a42fa6