### PR TITLE
Refactor active hunt logic to use dates

### DIFF
--- a/__tests__/commands/hunt/leaderboard.test.js
+++ b/__tests__/commands/hunt/leaderboard.test.js
@@ -3,8 +3,10 @@ jest.mock('../../../config/database', () => ({
   HuntSubmission: { findAll: jest.fn() },
   HuntPoi: { findAll: jest.fn() }
 }));
+jest.mock('../../../utils/hunt', () => ({ getActiveHunt: jest.fn() }));
 
 const { Hunt, HuntSubmission, HuntPoi } = require('../../../config/database');
+const { getActiveHunt } = require('../../../utils/hunt');
 const command = require('../../../commands/hunt/leaderboard');
 const { MessageFlags, StringSelectMenuBuilder } = require('discord.js');
 
@@ -23,7 +25,8 @@ afterAll(() => {
 beforeEach(() => jest.clearAllMocks());
 
 test('replies when no hunts exist', async () => {
-  Hunt.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+  getActiveHunt.mockResolvedValueOnce(null);
+  Hunt.findOne.mockResolvedValueOnce(null);
   const interaction = makeInteraction();
 
   await command.execute(interaction);
@@ -32,7 +35,8 @@ test('replies when no hunts exist', async () => {
 });
 
 test('shows message when no submissions', async () => {
-  Hunt.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'h1', name: 'Recent' });
+  getActiveHunt.mockResolvedValueOnce(null);
+  Hunt.findOne.mockResolvedValueOnce({ id: 'h1', name: 'Recent' });
   HuntSubmission.findAll.mockResolvedValue([]);
   Hunt.findAll.mockResolvedValue([{ id: 'h1', name: 'Recent' }]);
   const interaction = makeInteraction();
@@ -45,7 +49,8 @@ test('shows message when no submissions', async () => {
 });
 
 test('shows message when submissions not approved', async () => {
-  Hunt.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'h1', name: 'Recent' });
+  getActiveHunt.mockResolvedValueOnce(null);
+  Hunt.findOne.mockResolvedValueOnce({ id: 'h1', name: 'Recent' });
   HuntSubmission.findAll.mockResolvedValue([{ id: 's1', status: 'pending', supersedes_submission_id: null }]);
   Hunt.findAll.mockResolvedValue([{ id: 'h1', name: 'Recent' }]);
   const interaction = makeInteraction();
@@ -57,7 +62,7 @@ test('shows message when submissions not approved', async () => {
 });
 
 test('builds leaderboard from approved submissions', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1', name: 'Hunt' });
+  getActiveHunt.mockResolvedValue({ id: 'h1', name: 'Hunt' });
   HuntSubmission.findAll.mockResolvedValue([
     { id: 's1', user_id: 'u1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-01') },
     { id: 's2', user_id: 'u2', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-02') }
@@ -77,7 +82,7 @@ test('builds leaderboard from approved submissions', async () => {
 });
 
 test('includes select menu with hunts', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1', name: 'H1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1', name: 'H1' });
   HuntSubmission.findAll.mockResolvedValue([
     { id: 's1', user_id: 'u1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null, submitted_at: new Date('2024-01-01') }
   ]);

--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -4,8 +4,10 @@ jest.mock('../../../../config/database', () => ({
   HuntSubmission: { create: jest.fn(), findOne: jest.fn() },
   Config: { findOne: jest.fn() }
 }));
+jest.mock('../../../../utils/hunt', () => ({ getActiveHunt: jest.fn() }));
 
 const { HuntPoi, Hunt, HuntSubmission, Config } = require('../../../../config/database');
+const { getActiveHunt } = require('../../../../utils/hunt');
 jest.mock('../../../../utils/googleDrive', () => ({
   createDriveClient: jest.fn(() => ({ files: { create: jest.fn() } })),
   uploadScreenshot: jest.fn(() => ({ id: 'f', webViewLink: 'link' }))
@@ -252,7 +254,7 @@ test('modal handles update failure', async () => {
 });
 
 test('submit button processes uploaded screenshot', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   Config.findOne
     .mockResolvedValueOnce({ value: 'a' })
     .mockResolvedValueOnce({ value: 'r' });
@@ -320,7 +322,7 @@ test('submit button handles timeout', async () => {
 });
 
 test('submit button deletes message when upload fails', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   Config.findOne
     .mockResolvedValueOnce({ value: 'a' })
     .mockResolvedValueOnce({ value: 'r' });
@@ -352,7 +354,7 @@ test('submit button deletes message when upload fails', async () => {
 });
 
 test('submit button with no existing submission sets supersedes to null', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   Config.findOne
     .mockResolvedValueOnce({ value: 'a' })
     .mockResolvedValueOnce({ value: 'r' });

--- a/__tests__/commands/hunt/score.test.js
+++ b/__tests__/commands/hunt/score.test.js
@@ -3,8 +3,10 @@ jest.mock('../../../config/database', () => ({
   HuntSubmission: { findAll: jest.fn() },
   HuntPoi: { findAll: jest.fn() }
 }));
+jest.mock('../../../utils/hunt', () => ({ getActiveHunt: jest.fn() }));
 
 const { Hunt, HuntSubmission, HuntPoi } = require('../../../config/database');
+const { getActiveHunt } = require('../../../utils/hunt');
 const command = require('../../../commands/hunt/score');
 const { MessageFlags } = require('../../../__mocks__/discord.js');
 
@@ -17,7 +19,7 @@ const makeInteraction = (targetId = null) => ({
 beforeEach(() => jest.clearAllMocks());
 
 test('replies when no active hunt', async () => {
-  Hunt.findOne.mockResolvedValue(null);
+  getActiveHunt.mockResolvedValue(null);
   const interaction = makeInteraction();
 
   await command.execute(interaction);
@@ -26,7 +28,7 @@ test('replies when no active hunt', async () => {
 });
 
 test('replies when no submissions', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   HuntSubmission.findAll.mockResolvedValue([]);
   const interaction = makeInteraction('u2');
 
@@ -36,7 +38,7 @@ test('replies when no submissions', async () => {
 });
 
 test('lists submissions grouped by status', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   HuntSubmission.findAll.mockResolvedValue([
     { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null },
     { id: 's2', poi_id: 'p2', status: 'rejected', supersedes_submission_id: null },
@@ -64,7 +66,7 @@ test('lists submissions grouped by status', async () => {
 });
 
 test("uses username in title when targeting another user", async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   HuntSubmission.findAll.mockResolvedValue([
     { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null }
   ]);
@@ -78,7 +80,7 @@ test("uses username in title when targeting another user", async () => {
 });
 
 test('filters superseded submissions', async () => {
-  Hunt.findOne.mockResolvedValue({ id: 'h1' });
+  getActiveHunt.mockResolvedValue({ id: 'h1' });
   HuntSubmission.findAll.mockResolvedValue([
     { id: 's1', poi_id: 'p1', status: 'approved', supersedes_submission_id: null },
     { id: 's2', poi_id: 'p1', status: 'approved', supersedes_submission_id: 's1' }

--- a/__tests__/models/hunt.test.js
+++ b/__tests__/models/hunt.test.js
@@ -11,7 +11,6 @@ describe('Hunt model', () => {
     expect(attrs).toHaveProperty('id');
     expect(attrs).toHaveProperty('name');
     expect(attrs).toHaveProperty('starts_at');
-    expect(attrs).toHaveProperty('status');
     expect(opts.tableName).toBe('hunts');
     expect(model).toEqual({});
   });

--- a/commands/hunt/leaderboard.js
+++ b/commands/hunt/leaderboard.js
@@ -6,6 +6,7 @@ const {
   MessageFlags
 } = require('discord.js');
 const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
+const { getActiveHunt } = require('../../utils/hunt');
 
 async function generateLeaderboardEmbed(hunt) {
   const allSubs = await HuntSubmission.findAll({
@@ -75,7 +76,7 @@ module.exports = {
 
   async execute(interaction) {
     try {
-      let hunt = await Hunt.findOne({ where: { status: 'active' } });
+      let hunt = await getActiveHunt();
       if (!hunt) {
         hunt = await Hunt.findOne({ order: [['starts_at', 'DESC']] });
       }

--- a/commands/hunt/list.js
+++ b/commands/hunt/list.js
@@ -1,5 +1,6 @@
 const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const { Hunt } = require('../../config/database');
+const { getHuntStatus } = require('../../utils/hunt');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
@@ -17,7 +18,8 @@ module.exports = {
       for (const h of hunts) {
         const start = h.starts_at ? new Date(h.starts_at).toLocaleString() : 'N/A';
         const end = h.ends_at ? new Date(h.ends_at).toLocaleString() : 'N/A';
-        embed.addFields({ name: `${h.name} (${h.status})`, value: `${start} → ${end}` });
+        const status = getHuntStatus(h);
+        embed.addFields({ name: `${h.name} (${status})`, value: `${start} → ${end}` });
       }
 
       await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -11,6 +11,7 @@ const {
   MessageFlags
 } = require('discord.js');
 const { HuntPoi, Hunt, HuntSubmission, Config } = require('../../../config/database');
+const { getActiveHunt } = require('../../../utils/hunt');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
 const fetch = require('node-fetch');
 
@@ -238,7 +239,7 @@ module.exports = {
 
       const botType = process.env.BOT_TYPE || 'development';
       try {
-        const hunt = await Hunt.findOne({ where: { status: 'active' } });
+        const hunt = await getActiveHunt();
         if (!hunt) {
           return interaction.followUp({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
         }

--- a/commands/hunt/schedule.js
+++ b/commands/hunt/schedule.js
@@ -59,7 +59,6 @@ module.exports = {
         discord_event_id: event.id,
         starts_at: start,
         ends_at: end,
-        status: 'upcoming',
       });
 
       await interaction.reply({ content: `✅ Hunt "${name}" scheduled.`, flags: MessageFlags.Ephemeral });

--- a/commands/hunt/score.js
+++ b/commands/hunt/score.js
@@ -1,5 +1,6 @@
 const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const { Hunt, HuntSubmission, HuntPoi } = require('../../config/database');
+const { getActiveHunt } = require('../../utils/hunt');
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
@@ -14,7 +15,7 @@ module.exports = {
     const targetUser = interaction.options.getUser('user') || interaction.user;
     const userId = targetUser.id;
     try {
-      const hunt = await Hunt.findOne({ where: { status: 'active' } });
+      const hunt = await getActiveHunt();
       if (!hunt) {
         return interaction.reply({ content: '❌ No active hunt.', flags: MessageFlags.Ephemeral });
       }

--- a/models/hunt.js
+++ b/models/hunt.js
@@ -26,10 +26,6 @@ module.exports = (sequelize) => {
     ends_at: {
       type: DataTypes.DATE,
       allowNull: false
-    },
-    status: {
-      type: DataTypes.ENUM('upcoming', 'active', 'archived'),
-      allowNull: false
     }
   }, {
     tableName: 'hunts',

--- a/utils/hunt.js
+++ b/utils/hunt.js
@@ -1,0 +1,21 @@
+const { Op } = require('sequelize');
+const { Hunt } = require('../config/database');
+
+function getHuntStatus(hunt, now = new Date()) {
+  if (!hunt.starts_at || !hunt.ends_at) return 'unknown';
+  if (now < hunt.starts_at) return 'upcoming';
+  if (now > hunt.ends_at) return 'archived';
+  return 'active';
+}
+
+async function getActiveHunt(now = new Date()) {
+  return Hunt.findOne({
+    where: {
+      starts_at: { [Op.lte]: now },
+      ends_at: { [Op.gte]: now }
+    },
+    order: [['starts_at', 'DESC']]
+  });
+}
+
+module.exports = { getActiveHunt, getHuntStatus };


### PR DESCRIPTION
## Summary
- remove `status` field from `Hunt` model
- select active hunts using new `getActiveHunt` utility
- compute hunt status with `getHuntStatus` for listing
- update hunt commands and tests to use new helpers
- drop status expectation in hunt model tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f3376b868832dbc2843c160b3c7fd