### PR TITLE
fix: handle scavenger hunt event case insensitively

### DIFF
--- a/__tests__/botactions/eventHandling/scheduledEvents.test.js
+++ b/__tests__/botactions/eventHandling/scheduledEvents.test.js
@@ -36,9 +36,9 @@ describe('scheduledEvents handlers', () => {
     log.mockRestore();
   });
 
-  test('handleCreateEvent creates hunt when location matches', async () => {
+  test('handleCreateEvent creates hunt when location matches case-insensitively', async () => {
     const { Hunt } = require('../../../config/database');
-    event.location = 'Scavenger Hunt';
+    event.location = 'sCaVeNgEr HuNt';
     await events.handleCreateEvent(event);
     expect(Hunt.create).toHaveBeenCalledWith(expect.objectContaining({
       name: 'Test',

--- a/botactions/eventHandling/scheduledEvents.js
+++ b/botactions/eventHandling/scheduledEvents.js
@@ -19,7 +19,7 @@ async function handleCreateEvent (guildScheduledEvent, client) {
     try {
         await saveEventToDatabase(event);
         console.log('📌 Scheduled event created and saved to database.');
-        if (guildScheduledEvent.location === 'Scavenger Hunt') {
+        if (guildScheduledEvent.location && guildScheduledEvent.location.toLowerCase() === 'scavenger hunt') {
             await Hunt.create({
                 name: guildScheduledEvent.name,
                 description: guildScheduledEvent.description,


### PR DESCRIPTION
## Summary
- fix scheduled event handling to check `Scavenger Hunt` location ignoring case
- test case-insensitive check in scheduledEvents handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f3fde5d54832d9de95a1836854984