### PR TITLE
Fix scavenger hunt detection for hyphenated locations

### DIFF
--- a/__tests__/botactions/eventHandling/scheduledEvents.test.js
+++ b/__tests__/botactions/eventHandling/scheduledEvents.test.js
@@ -53,6 +53,20 @@ describe('scheduledEvents handlers', () => {
     expect(Hunt.create).toHaveBeenCalled();
   });
 
+  test('handleCreateEvent creates hunt when location uses hyphen', async () => {
+    const { Hunt } = require('../../../config/database');
+    event.location = 'Scavenger-Hunt area';
+    await events.handleCreateEvent(event);
+    expect(Hunt.create).toHaveBeenCalled();
+  });
+
+  test('handleCreateEvent creates hunt when location has no spaces', async () => {
+    const { Hunt } = require('../../../config/database');
+    event.location = 'ScavengerHunt';
+    await events.handleCreateEvent(event);
+    expect(Hunt.create).toHaveBeenCalled();
+  });
+
   test('handleUpdateEvent deletes when ended', async () => {
     await events.handleUpdateEvent(event, { ...event, status: 3 });
     expect(handler.deleteEventFromDatabase).toHaveBeenCalled();

--- a/botactions/eventHandling/scheduledEvents.js
+++ b/botactions/eventHandling/scheduledEvents.js
@@ -19,8 +19,8 @@ async function handleCreateEvent (guildScheduledEvent, client) {
     try {
         await saveEventToDatabase(event);
         console.log('📌 Scheduled event created and saved to database.');
-        const loc = guildScheduledEvent.location?.toLowerCase().trim();
-        if (loc && loc.includes('scavenger hunt')) {
+        const loc = guildScheduledEvent.location?.toLowerCase().replace(/\s+/g, ' ').trim();
+        if (loc && /scavenger[- ]?hunt/.test(loc)) {
             await Hunt.create({
                 name: guildScheduledEvent.name,
                 description: guildScheduledEvent.description,


### PR DESCRIPTION
## Summary
- accept more variations of "scavenger hunt" in event locations
- add tests for hyphenated and space-less variations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f45d6f7c0832db2408e4e06ad5ec9