### PR TITLE
Fix event location detection for hunts

### DIFF
--- a/botactions/eventHandling/scheduledEvents.js
+++ b/botactions/eventHandling/scheduledEvents.js
@@ -12,14 +12,17 @@ async function handleCreateEvent (guildScheduledEvent, client) {
         start_time: guildScheduledEvent.scheduledStartTimestamp,
         end_time: guildScheduledEvent.scheduledEndTimestamp,
         event_coordinator: guildScheduledEvent.creator.username,
-        location: guildScheduledEvent.location,
+        location: guildScheduledEvent.location || guildScheduledEvent.entityMetadata?.location,
         status: getStatus(guildScheduledEvent)
     };
 
     try {
         await saveEventToDatabase(event);
         console.log('📌 Scheduled event created and saved to database.');
-        const loc = guildScheduledEvent.location?.toLowerCase().replace(/\s+/g, ' ').trim();
+        const loc = (guildScheduledEvent.location || guildScheduledEvent.entityMetadata?.location)
+            ?.toLowerCase()
+            .replace(/\s+/g, ' ')
+            .trim();
         if (loc && /scavenger[- ]?hunt/.test(loc)) {
             await Hunt.create({
                 name: guildScheduledEvent.name,
@@ -60,7 +63,7 @@ async function handleUpdateEvent(oldGuildScheduledEvent, newGuildScheduledEvent,
         start_time: newGuildScheduledEvent.scheduledStartTimestamp,
         end_time: newGuildScheduledEvent.scheduledEndTimestamp,
         event_coordinator: newGuildScheduledEvent.creator.username,
-        location: newGuildScheduledEvent.location,
+        location: newGuildScheduledEvent.location || newGuildScheduledEvent.entityMetadata?.location,
         status: getStatus(newGuildScheduledEvent.status)
     };
 


### PR DESCRIPTION
## Summary
- handle event locations coming from entity metadata
- check entityMetadata for scheduled event location in tests
- add test case to ensure fallback to entityMetadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f47203728832db39937c482b6e289