### PR TITLE
Add DM notification on hunt submission rejection

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -419,16 +419,23 @@ test('reject modal updates submission', async () => {
   HuntSubmission.findByPk = jest.fn().mockResolvedValue({
     update,
     review_channel_id: 'r',
-    review_message_id: 'm'
+    review_message_id: 'm',
+    user_id: 'user1',
+    poi_id: 'p1'
   });
+  HuntPoi.findByPk.mockResolvedValue({ name: 'Alpha' });
   const msg = { edit: jest.fn(), content: 'x' };
   const ch = { messages: { fetch: jest.fn(() => Promise.resolve(msg)) } };
   const fields = { getTextInputValue: jest.fn(() => 'bad') };
+  const send = jest.fn();
   const interaction = {
     customId: 'hunt_poi_reject_form::s1',
     fields,
     user: { id: 'u' },
-    client: { channels: { fetch: jest.fn(() => Promise.resolve(ch)) } },
+    client: {
+      channels: { fetch: jest.fn(() => Promise.resolve(ch)) },
+      users: { fetch: jest.fn(() => Promise.resolve({ send })) }
+    },
     reply: jest.fn()
   };
 
@@ -438,5 +445,8 @@ test('reject modal updates submission', async () => {
   expect(ch.messages.fetch).toHaveBeenCalledWith('m');
   expect(msg.edit).toHaveBeenCalled();
   expect(interaction.reply).toHaveBeenCalled();
+  expect(interaction.client.users.fetch).toHaveBeenCalledWith('user1');
+  expect(send).toHaveBeenCalledWith(expect.stringContaining('Alpha')); 
+  expect(send).toHaveBeenCalledWith(expect.stringContaining('bad'));
 });
 

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -458,6 +458,14 @@ module.exports = {
           console.error('❌ Failed to update review message:', err);
         }
 
+        try {
+          const user = await interaction.client.users.fetch(sub.user_id);
+          const poi = await HuntPoi.findByPk(sub.poi_id);
+          await user.send(`Your submission for ${poi ? poi.name : 'this POI'} was rejected: ${reason}`);
+        } catch (err) {
+          console.error('❌ Failed to send rejection DM:', err);
+        }
+
         await interaction.reply({ content: '✅ Submission rejected.', flags: MessageFlags.Ephemeral });
       } catch (err) {
         console.error('❌ Failed to reject submission:', err);


### PR DESCRIPTION
## Summary
- notify submitter via DM when a hunt submission is rejected
- test rejection DM logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68403519eb6c832dbb3a8913d7d8b9a3