### PR TITLE
Include poi image link in review post

### DIFF
--- a/__tests__/commands/hunt/poi/list.test.js
+++ b/__tests__/commands/hunt/poi/list.test.js
@@ -260,7 +260,7 @@ test('submit button processes uploaded screenshot', async () => {
     .mockResolvedValueOnce({ value: 'r' });
   HuntSubmission.create.mockResolvedValue({ id: 's1', update: jest.fn(), image_url: 'link' });
   HuntSubmission.findOne.mockResolvedValue({ id: 'prev1' });
-  HuntPoi.findByPk = jest.fn().mockResolvedValue({ name: 'Alpha Beta' });
+  HuntPoi.findByPk = jest.fn().mockResolvedValue({ name: 'Alpha Beta', image_url: 'poi.jpg' });
   const activityCh = { send: jest.fn() };
   const reviewCh = { send: jest.fn().mockResolvedValue({ id: 'm' }) };
   const client = { channels: { fetch: jest.fn(id => (id === 'a' ? activityCh : reviewCh)) } };
@@ -293,6 +293,7 @@ test('submit button processes uploaded screenshot', async () => {
   }));
   const reviewArgs = reviewCh.send.mock.calls[0][0];
   expect(reviewArgs.content).toContain('Alpha Beta');
+  expect(reviewArgs.content).toContain('[POI image](poi.jpg)');
   expect(reviewArgs.content).toContain('[View screenshot](link)');
   expect(reviewArgs.components).toEqual(expect.any(Array));
   const activityMsg = activityCh.send.mock.calls[0][0];
@@ -332,6 +333,7 @@ test('submit button omits link when no image_url', async () => {
   await command.button(interaction);
 
   const reviewArgs = reviewCh.send.mock.calls[0][0];
+  expect(reviewArgs.content).not.toContain('[POI image]');
   expect(reviewArgs.content).not.toContain('[View screenshot]');
 });
 

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -298,6 +298,9 @@ module.exports = {
         if (reviewConfig) {
           const ch = await interaction.client.channels.fetch(reviewConfig.value);
           let content = `Submission from <@${interaction.user.id}> for POI ${poi.name}.`;
+          if (poi.image_url) {
+            content += ` [POI image](${poi.image_url})`;
+          }
           if (submission.image_url) {
             content += ` [View screenshot](${submission.image_url})`;
           }


### PR DESCRIPTION
## Summary
- show POI reference image when posting hunt submissions for review
- test review post content when POI has or lacks an image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840399dbb6c832daa08ec4f4440bd8c