### PR TITLE
Use KickMembers permission for admin commands

### DIFF
--- a/__mocks__/discord.js
+++ b/__mocks__/discord.js
@@ -76,7 +76,8 @@ const EmbedBuilder = jest.fn().mockImplementation(() => {
 const PermissionFlagsBits = {
   Administrator: 0x00000008,
   ManageGuild: 0x00000020,
-  ManageRoles: 0x00010000
+  ManageRoles: 0x00010000,
+  KickMembers: 0x00000002
 };
 
 const PermissionsBitField = {

--- a/__tests__/commands/admin/listannouncements.test.js
+++ b/__tests__/commands/admin/listannouncements.test.js
@@ -6,12 +6,10 @@ const { getScheduledAnnouncements } = require('../../../botactions/scheduling/sc
 const { MessageFlags } = require('discord.js');
 const { execute } = require('../../../commands/admin/listannouncements');
 
-function createInteraction(roleNames = ['Admiral']) {
+function createInteraction(hasPerm = true) {
   return {
     member: {
-      roles: {
-        cache: { map: fn => roleNames.map(name => fn({ name })) }
-      }
+      permissions: { has: jest.fn(() => hasPerm) }
     },
     reply: jest.fn()
   };
@@ -23,7 +21,7 @@ describe('/listannouncements command', () => {
   });
 
   test('blocks users without required role', async () => {
-    const interaction = createInteraction(['Member']);
+    const interaction = createInteraction(false);
     await execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'You do not have permission to use this command.',
@@ -32,14 +30,14 @@ describe('/listannouncements command', () => {
   });
 
   test('informs when no announcements', async () => {
-    const interaction = createInteraction();
+    const interaction = createInteraction(true);
     getScheduledAnnouncements.mockResolvedValue([]);
     await execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith('There are no scheduled announcements.');
   });
 
   test('lists announcements when present', async () => {
-    const interaction = createInteraction();
+    const interaction = createInteraction(true);
     getScheduledAnnouncements.mockResolvedValue([
       { id: 1, embedData: JSON.stringify({ title: 'Hello' }), time: 't' }
     ]);

--- a/__tests__/commands/admin/removesnapchannel.test.js
+++ b/__tests__/commands/admin/removesnapchannel.test.js
@@ -6,8 +6,8 @@ jest.mock('../../../botactions/channelManagement/snapChannels', () => ({
   removeSnapChannel: jest.fn()
 }));
 
-const makeInteraction = (roles = []) => ({
-  member: { roles: { cache: { map: fn => roles.map(r => fn({ name: r })) } } },
+const makeInteraction = (hasPerm = false) => ({
+  member: { permissions: { has: jest.fn(() => hasPerm) } },
   options: { getChannel: jest.fn(() => ({ id: 'c1', name: 'chan' })) },
   guild: {},
   reply: jest.fn()
@@ -17,7 +17,7 @@ beforeEach(() => jest.clearAllMocks());
 
 describe('/removesnapchannel command', () => {
   test('rejects users without role', async () => {
-    const interaction = makeInteraction(['User']);
+    const interaction = makeInteraction(false);
     await execute(interaction);
     expect(interaction.reply).toHaveBeenCalledWith({
       content: expect.stringContaining('permission'),
@@ -27,7 +27,7 @@ describe('/removesnapchannel command', () => {
   });
 
   test('removes channel when authorized', async () => {
-    const interaction = makeInteraction(['Admiral']);
+    const interaction = makeInteraction(true);
     await execute(interaction);
     expect(removeSnapChannel).toHaveBeenCalledWith('c1');
     expect(interaction.reply).toHaveBeenCalledWith({
@@ -37,7 +37,7 @@ describe('/removesnapchannel command', () => {
   });
 
   test('handles errors gracefully', async () => {
-    const interaction = makeInteraction(['Fleet Admiral']);
+    const interaction = makeInteraction(true);
     const err = new Error('fail');
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     removeSnapChannel.mockRejectedValue(err);

--- a/__tests__/commands/hunt/poi/create.test.js
+++ b/__tests__/commands/hunt/poi/create.test.js
@@ -6,7 +6,7 @@ const { HuntPoi } = require('../../../../config/database');
 const command = require('../../../../commands/hunt/poi/create');
 const { MessageFlags } = require('../../../../__mocks__/discord.js');
 
-const makeInteraction = (roles = ['Admiral']) => ({
+const makeInteraction = (hasPerm = true) => ({
   options: {
     getString: jest.fn(key => ({
       name: 'Alpha',
@@ -16,7 +16,7 @@ const makeInteraction = (roles = ['Admiral']) => ({
     getAttachment: jest.fn(() => ({ url: 'img' })),
     getInteger: jest.fn(() => 10)
   },
-  member: { roles: { cache: { map: fn => roles.map(r => fn({ name: r })) } } },
+  member: { permissions: { has: jest.fn(() => hasPerm) } },
   user: { id: 'u1' },
   reply: jest.fn()
 });
@@ -24,7 +24,7 @@ const makeInteraction = (roles = ['Admiral']) => ({
 beforeEach(() => jest.clearAllMocks());
 
 test('creates poi and replies', async () => {
-  const interaction = makeInteraction();
+  const interaction = makeInteraction(true);
 
   await command.execute(interaction);
 
@@ -44,7 +44,7 @@ test('creates poi and replies', async () => {
 });
 
 test('handles missing optional image', async () => {
-  const interaction = makeInteraction();
+  const interaction = makeInteraction(true);
   interaction.options.getString = jest.fn(key => ({
     name: 'Bravo',
     hint: 'hint',
@@ -58,7 +58,7 @@ test('handles missing optional image', async () => {
 });
 
 test('handles db error', async () => {
-  const interaction = makeInteraction();
+  const interaction = makeInteraction(true);
   const err = new Error('fail');
   HuntPoi.create.mockRejectedValue(err);
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -74,7 +74,7 @@ test('handles db error', async () => {
 });
 
 test('rejects when user lacks role', async () => {
-  const interaction = makeInteraction(['Member']);
+  const interaction = makeInteraction(false);
 
   await command.execute(interaction);
 

--- a/commands/admin/addsnapchannel.js
+++ b/commands/admin/addsnapchannel.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { addSnapChannel } = require('../../botactions/channelManagement/snapChannels');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Require Kick Members permission instead of a specific role list
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -16,13 +16,12 @@ module.exports = {
             option.setName('purgetime')
                 .setDescription('Purge time in days (default: 30)')
                 .setRequired(false))
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
     help: 'Adds a channel to the snap purge list. Messages in snap channels are auto-deleted after a set time. (Admin Only)',
     category: 'Discord',
                 
     async execute(interaction) {
-        const memberRoles = interaction.member.roles.cache.map(role => role.name);
-        if (!allowedRoles.some(role => memberRoles.includes(role))) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
             await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
             return;
         }

--- a/commands/admin/analytics.js
+++ b/commands/admin/analytics.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { generateUsageReport, generateVoiceActivityReport, generateReportByChannel } = require('../../utils/generateAnalytics');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Authorization will be handled via Kick Members permission
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -23,15 +23,13 @@ module.exports = {
             .setDescription('Channel to report on')
             .setRequired(true))
     )
-    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
 
   help: 'Generates usage, voice, or channel-specific analytics reports. Usage reports include message edits and deletes. (Admin Only)',
   category: 'Discord',
 
   async execute(interaction, client) {
-    const memberRoles = interaction.member.roles.cache.map(role => role.name);
-
-    if (!allowedRoles.some(role => memberRoles.includes(role))) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
       return interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
     }
     const sub = interaction.options.getSubcommand();

--- a/commands/admin/deleteannouncements.js
+++ b/commands/admin/deleteannouncements.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { deleteScheduledAnnouncement } = require('../../botactions/scheduling/scheduleHandler');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Use Kick Members permission instead of role list
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -11,12 +11,11 @@ module.exports = {
             option.setName('id')
                 .setDescription('The ID of the announcement to delete')
                 .setRequired(true))// Already includes:
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
     help: 'Deletes a scheduled announcement by its ID. Only available to Admirals and Fleet Admirals. (Admin Only)',
     category: 'Discord',                
     async execute(interaction) {
-        const memberRoles = interaction.member.roles.cache.map(role => role.name);
-        if (!allowedRoles.some(role => memberRoles.includes(role))) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
             await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
             return;
         }

--- a/commands/admin/listannouncements.js
+++ b/commands/admin/listannouncements.js
@@ -1,19 +1,18 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { getScheduledAnnouncements } = require('../../botactions/scheduling/scheduleHandler');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Authorization via Kick Members permission
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('listannouncements')
         .setDescription('List all scheduled announcements')
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
         
     help: 'Lists all snap channels configured for automatic purge. (Admin Only)',
     category: 'Discord',        
     async execute(interaction) {
-        const memberRoles = interaction.member.roles.cache.map(role => role.name);
-        if (!allowedRoles.some(role => memberRoles.includes(role))) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
             await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
             return;
         }

--- a/commands/admin/listsnapchannels.js
+++ b/commands/admin/listsnapchannels.js
@@ -2,18 +2,17 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { listSnapChannels } = require('../../botactions/channelManagement/snapChannels');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Authorization via Kick Members permission rather than role list
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('listsnapchannels')
         .setDescription('Lists all snap channels')
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
     help: 'Lists all snap channels configured for automatic purge. (Admin Only)',
     category: 'Discord',
     async execute(interaction) {
-        const memberRoles = interaction.member.roles.cache.map(role => role.name);
-        if (!allowedRoles.some(role => memberRoles.includes(role))) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
             await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
             return;
         }

--- a/commands/admin/removesnapchannel.js
+++ b/commands/admin/removesnapchannel.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { PermissionFlagsBits, MessageFlags } = require('discord.js');
 const { removeSnapChannel } = require('../../botactions/channelManagement/snapChannels');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Authorization will use Kick Members permission
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,13 +12,12 @@ module.exports = {
             option.setName('channel')
                 .setDescription('The snap channel to remove')
                 .setRequired(true))
-        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
     help: 'Removes a channel from the snap purge list. (Admin Only)',
     category: 'Discord',
 
     async execute(interaction) {
-        const memberRoles = interaction.member.roles.cache.map(role => role.name);
-        if (!allowedRoles.some(role => memberRoles.includes(role))) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
             await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
             return;
         }

--- a/commands/hunt/poi/create.js
+++ b/commands/hunt/poi/create.js
@@ -1,7 +1,7 @@
-const { SlashCommandSubcommandBuilder, MessageFlags } = require('discord.js');
+const { SlashCommandSubcommandBuilder, MessageFlags, PermissionFlagsBits } = require('discord.js');
 const { HuntPoi } = require('../../../config/database');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral', 'Commodore', 'Captain', 'Commander'];
+// Authorized via Kick Members permission
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
@@ -14,8 +14,7 @@ module.exports = {
     .addAttachmentOption(opt => opt.setName('image').setDescription('Image file').setRequired(false)),
 
   async execute(interaction) {
-    const memberRoles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-    if (!allowedRoles.some(r => memberRoles.includes(r))) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
       await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
       return;
     }

--- a/commands/hunt/poi/list.js
+++ b/commands/hunt/poi/list.js
@@ -8,14 +8,15 @@ const {
   TextInputBuilder,
   TextInputStyle,
   ButtonStyle,
-  MessageFlags
+  MessageFlags,
+  PermissionFlagsBits
 } = require('discord.js');
 const { HuntPoi, Hunt, HuntSubmission, Config } = require('../../../config/database');
 const { getActiveHunt } = require('../../../utils/hunt');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
 const fetch = require('node-fetch');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Use Kick Members permission for admin capabilities
 
 const PAGE_SIZE = 10;
 
@@ -123,8 +124,7 @@ module.exports = {
     .setDescription('List available POIs'),
 
   async execute(interaction) {
-    const roles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-    const isAdmin = allowedRoles.some(r => roles.includes(r));
+    const isAdmin = interaction.member.permissions.has(PermissionFlagsBits.KickMembers);
     try {
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
       await sendPage(interaction, 0, null, isAdmin);
@@ -140,8 +140,7 @@ module.exports = {
       const [, pageStr] = interaction.customId.split('::');
       const page = parseInt(pageStr, 10) || 0;
       await interaction.deferUpdate();
-      const roles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-      const isAdmin = allowedRoles.some(r => roles.includes(r));
+      const isAdmin = interaction.member.permissions.has(PermissionFlagsBits.KickMembers);
       try {
         await sendPage(interaction, page, null, isAdmin);
       } catch (err) {
@@ -379,8 +378,7 @@ module.exports = {
           return interaction.followUp({ content: '❌ POI not found.', flags: MessageFlags.Ephemeral });
         }
         await poi.update({ status: 'archived', updated_by: interaction.user.id });
-        const roles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-        const isAdmin = allowedRoles.some(r => roles.includes(r));
+        const isAdmin = interaction.member.permissions.has(PermissionFlagsBits.KickMembers);
         await sendPage(interaction, page, null, isAdmin);
       } catch (err) {
         console.error('❌ Failed to archive POI:', err);
@@ -394,8 +392,7 @@ module.exports = {
     const page = parseInt(pageStr, 10) || 0;
     const poiId = interaction.values[0];
     await interaction.deferUpdate();
-    const roles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-    const isAdmin = allowedRoles.some(r => roles.includes(r));
+    const isAdmin = interaction.member.permissions.has(PermissionFlagsBits.KickMembers);
     try {
       await sendPage(interaction, page, poiId, isAdmin);
     } catch (err) {

--- a/commands/hunt/set-channels.js
+++ b/commands/hunt/set-channels.js
@@ -1,11 +1,12 @@
 const {
   SlashCommandSubcommandBuilder,
   ChannelType,
-  MessageFlags
+  MessageFlags,
+  PermissionFlagsBits
 } = require('discord.js');
 const { Config } = require('../../config/database');
 
-const allowedRoles = ['Admiral', 'Fleet Admiral'];
+// Authorization via Kick Members permission
 
 module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
@@ -23,8 +24,7 @@ module.exports = {
         .setRequired(true)),
 
   async execute(interaction) {
-    const memberRoles = interaction.member?.roles?.cache?.map(r => r.name) || [];
-    if (!allowedRoles.some(r => memberRoles.includes(r))) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
       await interaction.reply({ content: 'You do not have permission to use this command.', flags: MessageFlags.Ephemeral });
       return;
     }


### PR DESCRIPTION
## Summary
- restrict several admin and hunt commands using `KickMembers` permission
- update tests to match permission checks
- add `KickMembers` to Discord mock

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68403a46e23c832db665ba873bca32f1