### PR TITLE
Implement drive upload for POI reference image

### DIFF
--- a/__tests__/commands/hunt/poi/create.test.js
+++ b/__tests__/commands/hunt/poi/create.test.js
@@ -2,9 +2,17 @@ jest.mock('../../../../config/database', () => ({
   HuntPoi: { create: jest.fn() }
 }));
 
+jest.mock('../../../../utils/googleDrive', () => ({
+  createDriveClient: jest.fn(() => ({ files: { create: jest.fn() } })),
+  uploadScreenshot: jest.fn(() => ({ webViewLink: 'refLink' }))
+}));
+jest.mock('node-fetch');
+
 const { HuntPoi } = require('../../../../config/database');
 const command = require('../../../../commands/hunt/poi/create');
 const { MessageFlags } = require('../../../../__mocks__/discord.js');
+const { uploadScreenshot } = require('../../../../utils/googleDrive');
+const fetch = require('node-fetch');
 
 const makeInteraction = (roles = ['Admiral']) => ({
   options: {
@@ -21,18 +29,33 @@ const makeInteraction = (roles = ['Admiral']) => ({
   reply: jest.fn()
 });
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetch.mockResolvedValue({
+    ok: true,
+    buffer: async () => Buffer.from('img'),
+    headers: { get: () => 'image/png' }
+  });
+  process.env.GOOGLE_DRIVE_HUNT_FOLDER = 'root';
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_DRIVE_HUNT_FOLDER;
+});
 
 test('creates poi and replies', async () => {
   const interaction = makeInteraction();
 
   await command.execute(interaction);
 
+  expect(uploadScreenshot).toHaveBeenCalled();
+  const fileName = uploadScreenshot.mock.calls[0][3];
+  expect(fileName).toMatch(/^Alpha_\d{4}-\d{2}-\d{2}_\d{4}\.jpg$/);
   expect(HuntPoi.create).toHaveBeenCalledWith(expect.objectContaining({
     name: 'Alpha',
     hint: 'Find me',
     location: 'Area18',
-    image_url: 'img',
+    image_url: 'refLink',
     points: 10,
     status: 'active',
     created_by: 'u1'
@@ -54,6 +77,7 @@ test('handles missing optional image', async () => {
 
   await command.execute(interaction);
 
+  expect(uploadScreenshot).not.toHaveBeenCalled();
   expect(HuntPoi.create).toHaveBeenCalledWith(expect.objectContaining({ image_url: null }));
 });
 
@@ -65,6 +89,7 @@ test('handles db error', async () => {
 
   await command.execute(interaction);
 
+  expect(uploadScreenshot).toHaveBeenCalled();
   expect(spy).toHaveBeenCalled();
   expect(interaction.reply).toHaveBeenCalledWith({
     content: '❌ Failed to create POI.',
@@ -82,6 +107,7 @@ test('rejects when user lacks role', async () => {
     content: expect.stringContaining('permission'),
     flags: MessageFlags.Ephemeral
   });
+  expect(uploadScreenshot).not.toHaveBeenCalled();
   expect(HuntPoi.create).not.toHaveBeenCalled();
 });
 

--- a/commands/hunt/poi/create.js
+++ b/commands/hunt/poi/create.js
@@ -1,5 +1,7 @@
 const { SlashCommandSubcommandBuilder, MessageFlags } = require('discord.js');
 const { HuntPoi } = require('../../../config/database');
+const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
+const fetch = require('node-fetch');
 
 const allowedRoles = ['Admiral', 'Fleet Admiral', 'Commodore', 'Captain', 'Commander'];
 
@@ -28,11 +30,29 @@ module.exports = {
     const userId = interaction.user.id;
 
     try {
+      let imageUrl = null;
+      if (attachment) {
+        const drive = await createDriveClient();
+        const rootFolder = process.env.GOOGLE_DRIVE_HUNT_FOLDER;
+
+        const response = await fetch(attachment.url);
+        if (!response.ok) throw new Error('Failed to fetch attachment');
+        const buffer = await response.buffer();
+        const mime = attachment.contentType || response.headers.get('content-type');
+        const pad = n => n.toString().padStart(2, '0');
+        const now = new Date();
+        const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}`;
+        const sanitizedName = name.replace(/\s+/g, '_');
+        const fileName = `${sanitizedName}_${timestamp}.jpg`;
+        const file = await uploadScreenshot(drive, rootFolder, 'reference', fileName, buffer, mime);
+        imageUrl = file.webViewLink;
+      }
+
       await HuntPoi.create({
         name,
         hint,
         location,
-        image_url: attachment ? attachment.url : null,
+        image_url: imageUrl,
         points,
         status: 'active',
         created_by: userId


### PR DESCRIPTION
## Summary
- upload POI reference images to Google Drive during creation
- store returned Drive link in `hunt_pois` table
- add tests covering Google Drive upload logic for POI creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684040211fe8832d9e13dbd853d05c19