### PR TITLE
Fix POI create subcommand permissions

### DIFF
--- a/__tests__/commands/hunt/poi/group.test.js
+++ b/__tests__/commands/hunt/poi/group.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const { SlashCommandSubcommandBuilder, MockInteraction, MessageFlags, PermissionFlagsBits } = require('discord.js');
+
+jest.mock('fs');
+
+const mockExecute = jest.fn();
+
+jest.mock('../../../../commands/hunt/poi/create.js', () => ({
+  data: () => new (require('discord.js').SlashCommandSubcommandBuilder)().setName('create').setDescription('desc'),
+  execute: mockExecute
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fs.readdirSync.mockReturnValue(['create.js']);
+});
+
+afterEach(() => jest.resetModules());
+
+test('blocks create without permission', async () => {
+  const command = require('../../../../commands/hunt/poi');
+  const interaction = new MockInteraction({ options: { subcommand: 'create' }, member: { permissions: { has: jest.fn(() => false) } } });
+  await command.execute(interaction, {});
+  expect(interaction.replyContent).toBe('You do not have permission to use this subcommand.');
+  expect(interaction.replyFlags).toBe(MessageFlags.Ephemeral);
+  expect(mockExecute).not.toHaveBeenCalled();
+});
+
+test('executes create with permission', async () => {
+  const command = require('../../../../commands/hunt/poi');
+  const interaction = new MockInteraction({ options: { subcommand: 'create' }, member: { permissions: { has: jest.fn(bit => bit === PermissionFlagsBits.KickMembers) } } });
+  await command.execute(interaction, {});
+  expect(mockExecute).toHaveBeenCalled();
+});

--- a/commands/hunt/poi.js
+++ b/commands/hunt/poi.js
@@ -1,4 +1,4 @@
-const { SlashCommandSubcommandGroupBuilder, MessageFlags } = require('discord.js');
+const { SlashCommandSubcommandGroupBuilder, MessageFlags, PermissionFlagsBits } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
 
@@ -29,6 +29,10 @@ module.exports = {
   group: true,
   async execute(interaction, client) {
     const sub = interaction.options.getSubcommand();
+    if (sub === 'create' && !interaction.member.permissions.has(PermissionFlagsBits.KickMembers)) {
+      await interaction.reply({ content: 'You do not have permission to use this subcommand.', flags: MessageFlags.Ephemeral });
+      return;
+    }
     try {
       const subcommand = require(`./poi/${sub}`);
       if (subcommand && typeof subcommand.execute === 'function') {

--- a/commands/hunt/poi/create.js
+++ b/commands/hunt/poi/create.js
@@ -1,4 +1,4 @@
-const { SlashCommandSubcommandBuilder, MessageFlags, PermissionFlagsBits } = require('discord.js');
+const { SlashCommandSubcommandBuilder, MessageFlags } = require('discord.js');
 const { HuntPoi } = require('../../../config/database');
 const { createDriveClient, uploadScreenshot } = require('../../../utils/googleDrive');
 const fetch = require('node-fetch');
@@ -7,7 +7,6 @@ module.exports = {
   data: () => new SlashCommandSubcommandBuilder()
     .setName('create')
     .setDescription('Create a point of interest')
-    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
     .addStringOption(opt => opt.setName('name').setDescription('POI name').setRequired(true))
     .addStringOption(opt => opt.setName('hint').setDescription('Hint for hunters').setRequired(true))
     .addStringOption(opt => opt.setName('location').setDescription('Location').setRequired(true))


### PR DESCRIPTION
## Summary
- restrict `/hunt poi create` to members with `KickMembers`
- add tests for group-level permission logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684045253434832d9ddff935236097aa