### PR TITLE
Add admin help for /hunt

### DIFF
--- a/__tests__/commands/hunt/help-admin.test.js
+++ b/__tests__/commands/hunt/help-admin.test.js
@@ -1,0 +1,16 @@
+const help = require('../../../commands/hunt/help-admin');
+const { MessageFlags } = require('../../../__mocks__/discord.js');
+
+test('replies with admin help embed', async () => {
+  const interaction = { reply: jest.fn() };
+  await help.execute(interaction);
+
+  const reply = interaction.reply.mock.calls[0][0];
+  expect(reply.flags).toBe(MessageFlags.Ephemeral);
+  const fields = reply.embeds[0].data.fields.map(f => f.name);
+  expect(fields).toEqual([
+    '🛡️ /hunt set-channels',
+    '✨ /hunt poi create',
+    '📝 /hunt poi list'
+  ]);
+});

--- a/commands/hunt/help-admin.js
+++ b/commands/hunt/help-admin.js
@@ -1,0 +1,26 @@
+const { SlashCommandSubcommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+
+module.exports = {
+  data: () => new SlashCommandSubcommandBuilder()
+    .setName('help-admin')
+    .setDescription('Moderation and configuration guide'),
+
+  async execute(interaction) {
+    const embed = new EmbedBuilder()
+      .setTitle('🛠️ Scavenger Hunt Admin Guide')
+      .setColor(0xff8800)
+      .setDescription([
+        'These commands are reserved for moderators and fleet staff.',
+        '',
+        'Manage the hunt and keep things running smoothly:'
+      ].join('\n'))
+      .addFields(
+        { name: '🛡️ /hunt set-channels', value: 'Configure activity and review channels.' },
+        { name: '✨ /hunt poi create', value: 'Add a new Point of Interest to the global list.' },
+        { name: '📝 /hunt poi list', value: 'Edit or archive existing POIs and review submissions.' }
+      )
+      .setFooter({ text: 'Only users with the Admiral roles can run these commands.' });
+
+    await interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+  }
+};


### PR DESCRIPTION
## Summary
- add `help-admin` subcommand to list hunt configuration tools
- test new admin help subcommand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840512a6ab4832d9acc3ad27c805ee1