### PR TITLE
Add HTTPS support for server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ node bot.js
 Restart the command after each change, or use a tool like `nodemon` to
 watch your files and automatically restart the bot during development.
 
+### Running the HTTPS server
+
+The included `server.js` serves API responses for the website. Provide TLS
+certificates named `key.pem` and `cert.pem` in the project root (or specify
+their paths using `HTTPS_KEY_PATH` and `HTTPS_CERT_PATH`). Start it with:
+
+```bash
+node server.js
+```
+
+If no certificates are found, the server will attempt to acquire them
+automatically using **Greenlock**.
+
 ## 📂 Project Structure
 
 | Path | Purpose |


### PR DESCRIPTION
## Summary
- enable HTTPS support by reading local TLS certs when available
- fallback to Greenlock if certs are missing
- document how to start the HTTPS server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841aa31b92c832db1597e6e96eb0040