### PR TITLE
Allow HTTP mode for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ node server.js
 ```
 
 If no certificates are found, the server will attempt to acquire them
-automatically using **Greenlock**.
+automatically using **Greenlock**. Set `HTTP_ONLY=true` to disable TLS
+entirely and serve the API over plain HTTP (useful when certificate
+issuance isn't possible).
 
 ## 📂 Project Structure
 

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+
+jest.mock('../db', () => ({ sequelize: {} }));
+jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: jest.fn() })));
+jest.mock('../config.json', () => ({ clientId: 'id', clientSecret: 'secret', callbackURL: 'url' }), { virtual: true });
+
+jest.mock('http', () => ({
+  createServer: jest.fn(() => ({
+    listen: jest.fn((port, cb) => cb && cb())
+  }))
+}));
+
+jest.mock('https', () => ({
+  createServer: jest.fn(() => ({
+    listen: jest.fn((port, cb) => cb && cb())
+  }))
+}));
+
+jest.mock('greenlock-express', () => ({
+  init: jest.fn(() => ({ serve: jest.fn() }))
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.HTTP_ONLY;
+  jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+  jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+describe('server startup modes', () => {
+  test('starts HTTP server when HTTP_ONLY is true', () => {
+    process.env.HTTP_ONLY = 'true';
+    require('../server');
+    const http = require('http');
+    const https = require('https');
+    const greenlock = require('greenlock-express');
+
+    expect(http.createServer).toHaveBeenCalled();
+    expect(https.createServer).not.toHaveBeenCalled();
+    expect(greenlock.init).not.toHaveBeenCalled();
+  });
+
+  test('starts HTTPS server when certs exist', () => {
+    fs.existsSync.mockReturnValue(true);
+    require('../server');
+    const https = require('https');
+    const http = require('http');
+    const greenlock = require('greenlock-express');
+
+    expect(https.createServer).toHaveBeenCalled();
+    expect(http.createServer).not.toHaveBeenCalled();
+    expect(greenlock.init).not.toHaveBeenCalled();
+  });
+
+  test('falls back to greenlock when no certs', () => {
+    require('../server');
+    const greenlock = require('greenlock-express');
+    const http = require('http');
+    const https = require('https');
+
+    expect(greenlock.init).toHaveBeenCalled();
+    expect(http.createServer).not.toHaveBeenCalled();
+    expect(https.createServer).not.toHaveBeenCalled();
+  });
+});

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const DiscordStrategy = require('passport-discord').Strategy;
 const path = require('path');
 const cors = require('cors');
 const https = require('https');
+const http = require('http');
 const fs = require('fs');
 const { sequelize } = require('./db');
 const defineSiteContent = require('./models/siteContent');
@@ -100,8 +101,13 @@ app.get('/logout', (req, res) => {
 const PORT = process.env.PORT || 3000;
 const keyPath = process.env.HTTPS_KEY_PATH || 'key.pem';
 const certPath = process.env.HTTPS_CERT_PATH || 'cert.pem';
+const HTTP_ONLY = process.env.HTTP_ONLY === 'true';
 
-if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+if (HTTP_ONLY) {
+  http.createServer(app).listen(PORT, () => {
+    console.log(`🚀 HTTP server running on port ${PORT}`);
+  });
+} else if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
   const httpsOptions = {
     key: fs.readFileSync(keyPath),
     cert: fs.readFileSync(certPath)


### PR DESCRIPTION
## Summary
- add HTTP_ONLY env variable for running server without TLS
- document new HTTP_ONLY option
- test HTTP/HTTPS/Greenlock server startup logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841aba8d0e0832d85d5cf03c11c2826