### PR TITLE
Add HTTPS server export and route tests

### DIFF
--- a/__tests__/server.routes.test.js
+++ b/__tests__/server.routes.test.js
@@ -1,0 +1,56 @@
+const mockFindOne = jest.fn();
+jest.mock('../db', () => ({ sequelize: {} }));
+jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: mockFindOne })));
+jest.mock('../config.json', () => ({ clientId: 'id', clientSecret: 'secret', callbackURL: 'url' }), { virtual: true });
+
+let app;
+let server;
+let port;
+let logSpy;
+let warnSpy;
+let errorSpy;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockFindOne.mockReset();
+  ({ app } = require('../server'));
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  port = server.address().port;
+});
+
+afterEach((done) => {
+  server.close(() => done());
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe('GET /api/content/:section', () => {
+  test('returns content when found', async () => {
+    mockFindOne.mockResolvedValue({ section: 'home', content: 'hello' });
+    const res = await fetch(`http://127.0.0.1:${port}/api/content/home`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ section: 'home', content: 'hello' });
+  });
+
+  test('returns 404 when content missing', async () => {
+    mockFindOne.mockResolvedValue(null);
+    const res = await fetch(`http://127.0.0.1:${port}/api/content/missing`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Content not found' });
+  });
+
+  test('returns 500 on error', async () => {
+    mockFindOne.mockRejectedValue(new Error('db fail'));
+    const res = await fetch(`http://127.0.0.1:${port}/api/content/home`);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 
 jest.mock('../db', () => ({ sequelize: {} }));
-jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: jest.fn() })));
+const mockFindOne = jest.fn();
+jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: mockFindOne })));
 jest.mock('../config.json', () => ({ clientId: 'id', clientSecret: 'secret', callbackURL: 'url' }), { virtual: true });
 
 jest.mock('http', () => ({
@@ -34,7 +35,8 @@ afterEach(() => {
 describe('server startup modes', () => {
   test('starts HTTP server when HTTP_ONLY is true', () => {
     process.env.HTTP_ONLY = 'true';
-    require('../server');
+    const { startServer } = require('../server');
+    startServer();
     const http = require('http');
     const https = require('https');
     const greenlock = require('greenlock-express');
@@ -46,7 +48,8 @@ describe('server startup modes', () => {
 
   test('starts HTTPS server when certs exist', () => {
     fs.existsSync.mockReturnValue(true);
-    require('../server');
+    const { startServer } = require('../server');
+    startServer();
     const https = require('https');
     const http = require('http');
     const greenlock = require('greenlock-express');
@@ -57,7 +60,8 @@ describe('server startup modes', () => {
   });
 
   test('falls back to greenlock when no certs', () => {
-    require('../server');
+    const { startServer } = require('../server');
+    startServer();
     const greenlock = require('greenlock-express');
     const http = require('http');
     const https = require('https');

--- a/server.js
+++ b/server.js
@@ -98,30 +98,39 @@ app.get('/logout', (req, res) => {
   });
 });
 
+// ===== Server Startup =====
 const PORT = process.env.PORT || 3000;
 const keyPath = process.env.HTTPS_KEY_PATH || 'key.pem';
 const certPath = process.env.HTTPS_CERT_PATH || 'cert.pem';
 const HTTP_ONLY = process.env.HTTP_ONLY === 'true';
 
-if (HTTP_ONLY) {
-  http.createServer(app).listen(PORT, () => {
-    console.log(`🚀 HTTP server running on port ${PORT}`);
-  });
-} else if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
-  const httpsOptions = {
-    key: fs.readFileSync(keyPath),
-    cert: fs.readFileSync(certPath)
-  };
+function startServer() {
+  if (HTTP_ONLY) {
+    http.createServer(app).listen(PORT, () => {
+      console.log(`🚀 HTTP server running on port ${PORT}`);
+    });
+  } else if (fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+    const httpsOptions = {
+      key: fs.readFileSync(keyPath),
+      cert: fs.readFileSync(certPath)
+    };
 
-  https.createServer(httpsOptions, app).listen(PORT, () => {
-    console.log(`🚀 HTTPS server running on port ${PORT}`);
-  });
-} else {
-  // Integrate Greenlock if no local certs are found
-  require('greenlock-express').init({
-    packageRoot: __dirname,
-    configDir: './greenlock.d',
-    maintainerEmail: 'you@example.com',
-    cluster: false
-  }).serve(app);
+    https.createServer(httpsOptions, app).listen(PORT, () => {
+      console.log(`🚀 HTTPS server running on port ${PORT}`);
+    });
+  } else {
+    // Integrate Greenlock if no local certs are found
+    require('greenlock-express').init({
+      packageRoot: __dirname,
+      configDir: './greenlock.d',
+      maintainerEmail: 'you@example.com',
+      cluster: false
+    }).serve(app);
+  }
 }
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, startServer };


### PR DESCRIPTION
## Summary
- export Express app and `startServer` from `server.js`
- update server startup tests to use the exported `startServer`
- add new tests exercising `/api/content/:section` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841ae932c94832db026aae4d9b50128