### PR TITLE
Fix server startup when running bot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -160,7 +160,8 @@ const initializeBot = async () => {
 
       startOrgTagSyncScheduler(client);
 
-      require('./server');
+      const { startServer } = require('./server');
+      startServer();
 
       console.log('🚀 Bot setup complete and ready to go!');
 


### PR DESCRIPTION
## Summary
- call `startServer()` during bot initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841b09ce740832da915f3971575582e