### PR TITLE
docs: add TLS challenge troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ node server.js
 If no certificates are found, the server will attempt to acquire them
 automatically using **Greenlock**. Set `HTTP_ONLY=true` to disable TLS
 entirely and serve the API over plain HTTP (useful when certificate
-issuance isn't possible).
+issuance isn't possible). For tips on resolving failed certificate challenges, see [docs/ssl_troubleshooting.md](docs/ssl_troubleshooting.md).
 
 ## 📂 Project Structure
 

--- a/__tests__/server.port.test.js
+++ b/__tests__/server.port.test.js
@@ -1,0 +1,40 @@
+jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
+  readFileSync: jest.fn(() => '')
+}));
+
+jest.mock('../db', () => ({ sequelize: {} }));
+const mockFindOne = jest.fn();
+jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: mockFindOne })));
+jest.mock('../config.json', () => ({ clientId: 'id', clientSecret: 'secret', callbackURL: 'url' }), { virtual: true });
+
+jest.mock('http', () => {
+  return {
+    createServer: jest.fn(() => ({
+      listen: jest.fn((port, cb) => cb && cb())
+    }))
+  };
+});
+jest.mock('https', () => ({ createServer: jest.fn() }));
+jest.mock('greenlock-express', () => {
+  const serve = jest.fn();
+  return { init: jest.fn(() => ({ serve })), _serve: serve };
+});
+
+afterEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+});
+
+test('uses greenlock on port 80', () => {
+  process.env.PORT = '80';
+  const { startServer } = require('../server');
+  startServer();
+  const http = require('http');
+  const gl = require('greenlock-express');
+  expect(gl.init).toHaveBeenCalledWith(expect.objectContaining({ packageRoot: expect.any(String) }));
+  expect(gl._serve).toHaveBeenCalledWith(expect.any(Function));
+  expect(http.createServer).not.toHaveBeenCalled();
+  delete process.env.PORT;
+});
+

--- a/__tests__/ssl_acme.test.js
+++ b/__tests__/ssl_acme.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const mockFindOne = jest.fn();
+jest.mock('../db', () => ({ sequelize: {} }));
+jest.mock('../models/siteContent', () => jest.fn(() => ({ findOne: mockFindOne })));
+jest.mock('../config.json', () => ({ clientId: 'id', clientSecret: 'secret', callbackURL: 'url' }), { virtual: true });
+
+let server;
+let port;
+let logSpy;
+let warnSpy;
+let errorSpy;
+
+beforeEach(async () => {
+  jest.resetModules();
+  fs.mkdirSync(path.join(__dirname, '../public/.well-known/acme-challenge'), { recursive: true });
+  fs.writeFileSync(path.join(__dirname, '../public/.well-known/acme-challenge/test'), 'challenge');
+  process.env.HTTP_ONLY = 'true';
+  const { app } = require('../server');
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  port = server.address().port;
+});
+
+afterEach(done => {
+  server.close(() => done());
+  fs.rmSync(path.join(__dirname, '../public'), { recursive: true, force: true });
+  delete process.env.HTTP_ONLY;
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+test('serves acme challenge over HTTP', async () => {
+  const res = await fetch(`http://127.0.0.1:${port}/.well-known/acme-challenge/test`);
+  const text = await res.text();
+  expect(res.status).toBe(200);
+  expect(text).toBe('challenge');
+});

--- a/docs/ssl_troubleshooting.md
+++ b/docs/ssl_troubleshooting.md
@@ -1,0 +1,17 @@
+# Troubleshooting Automatic TLS
+
+This project uses **Greenlock** to automatically obtain certificates from Let's Encrypt. During the "ACME" verification process, Let's Encrypt checks that your domain serves a challenge file over **HTTP**. If this file cannot be reached, the challenge moves from `pending` to `invalid`, and certificate issuance fails.
+
+Common causes include:
+
+- Port **80** blocked by a firewall or already in use
+- Domain DNS records pointing to the wrong IP
+- A redirect or proxy preventing access to `/.well-known/acme-challenge/*`
+
+Make sure your site is reachable on port 80 and that the challenge path returns the value that Greenlock provides. You can test by visiting:
+
+```
+http://<your-domain>/.well-known/acme-challenge/test
+```
+
+You should see the test content without a redirect. Once the challenge succeeds, Let's Encrypt will issue the certificate and Greenlock will start the HTTPS server automatically.

--- a/server.js
+++ b/server.js
@@ -57,8 +57,8 @@ app.get('/api/content/:section', async (req, res) => {
   }
 });
 
-// Static files
-app.use(express.static(path.join(__dirname, 'public')));
+// Static files (allow dotfiles for ACME challenges)
+app.use(express.static(path.join(__dirname, 'public'), { dotfiles: 'allow' }));
 
 // Routes
 app.get('/', (req, res) => res.sendFile(path.join(__dirname, 'public', 'index.html')));


### PR DESCRIPTION
## Summary
- document potential issues when Let's Encrypt challenges fail
- reference new troubleshooting guide from README
- serve ACME challenge files
- test ACME challenge path and server port

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6841b556516c832dab6edcd250761c32