### PR TITLE
Fix Jest transform error

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [require('babel-preset-jest')],
+};


### PR DESCRIPTION
## Summary
- add Babel config so Jest doesn't throw plugin errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841ba1b7c64832da85c241634725bb9