### PR TITLE
Fix server startup test console logs

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -26,10 +26,12 @@ beforeEach(() => {
   delete process.env.HTTP_ONLY;
   jest.spyOn(fs, 'existsSync').mockReturnValue(false);
   jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+  jest.spyOn(console, 'log').mockImplementation(() => {});
 });
 
 afterEach(() => {
   jest.resetModules();
+  jest.restoreAllMocks();
 });
 
 describe('server startup modes', () => {


### PR DESCRIPTION
## Summary
- suppress server log output in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841be33ca70832d899276de09eb3849