### PR TITLE
Add docs tests for TLS troubleshooting

### DIFF
--- a/__tests__/docs/ssl_troubleshooting.test.js
+++ b/__tests__/docs/ssl_troubleshooting.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('SSL troubleshooting documentation', () => {
+  let content;
+  let readme;
+
+  beforeAll(() => {
+    const docPath = path.join(__dirname, '../../docs/ssl_troubleshooting.md');
+    content = fs.readFileSync(docPath, 'utf8');
+    const readmePath = path.join(__dirname, '../../README.md');
+    readme = fs.readFileSync(readmePath, 'utf8');
+  });
+
+  test('lists common ACME failure causes', () => {
+    expect(content).toContain('Port **80** blocked by a firewall or already in use');
+    expect(content).toContain('Domain DNS records pointing to the wrong IP');
+    expect(content).toContain('A redirect or proxy preventing access to `/.well-known/acme-challenge/*`');
+  });
+
+  test('README links to troubleshooting guide', () => {
+    expect(readme).toContain('docs/ssl_troubleshooting.md');
+  });
+});


### PR DESCRIPTION
## Summary
- add test for TLS troubleshooting doc content
- ensure README references the doc

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841c8ee3eb4832d89776c679a7b7cda