### PR TITLE
Add Express API server

### DIFF
--- a/__mocks__/cors.js
+++ b/__mocks__/cors.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn(() => (req, res, next) => next());

--- a/__mocks__/express.js
+++ b/__mocks__/express.js
@@ -1,0 +1,11 @@
+const express = jest.fn(() => {
+  const server = { on: jest.fn() };
+  const app = {
+    use: jest.fn(),
+    get: jest.fn(),
+    listen: jest.fn((port, cb) => { if (cb) cb(); return server; })
+  };
+  app.__server = server;
+  return app;
+});
+module.exports = express;

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -1,0 +1,49 @@
+jest.mock('express', () => {
+  const express = jest.fn(() => {
+    const server = { on: jest.fn() };
+    const app = {
+      use: jest.fn(),
+      get: jest.fn(),
+      listen: jest.fn((port, cb) => {
+        if (cb) cb();
+        return server;
+      })
+    };
+    app.__server = server;
+    return app;
+  });
+  return express;
+}, { virtual: true });
+
+jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: true });
+
+const express = require('express');
+const { startApi } = require('../../api/server');
+
+describe('api/server startApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('starts server and registers route', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    startApi();
+    const app = express.mock.results[0].value;
+    expect(app.use).toHaveBeenCalled();
+    expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));
+    expect(app.listen).toHaveBeenCalledWith(25566, expect.any(Function));
+    expect(logSpy).toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  test('logs warning on port in use', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    startApi();
+    const app = express.mock.results[0].value;
+    const server = app.__server;
+    const errorHandler = server.on.mock.calls[0][1];
+    errorHandler({ code: 'EADDRINUSE' });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/__tests__/bot.test.js
+++ b/__tests__/bot.test.js
@@ -31,6 +31,7 @@ jest.mock('../botactions/maintenance/logCleanup', () => ({ deleteOldLogs: jest.f
 jest.mock('../botactions/eventHandling/memberJoinEvent', () => ({ handleMemberJoin: jest.fn() }));
 jest.mock('../botactions/orgTagSync/syncScheduler', () => ({ startOrgTagSyncScheduler: jest.fn() }));
 jest.mock('../jobs', () => ({ startAllScheduledJobs: jest.fn() }));
+jest.mock('../api/server', () => ({ startApi: jest.fn() }));
 
 
 let bot;

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const cors = require('cors');
+
+function createApp() {
+  const app = express();
+  app.use(cors());
+
+  // GET /api/data - placeholder for future Sequelize queries
+  app.get('/api/data', async (req, res) => {
+    res.json({ success: true, message: 'API is working' });
+  });
+
+  return app;
+}
+
+function startApi() {
+  const port = process.env.API_PORT || 25566;
+  const app = createApp();
+  const server = app.listen(port, () => {
+    console.log(`\uD83C\uDF10 API server running on port ${port}`); // 🌐
+  });
+
+  server.on('error', err => {
+    if (err.code === 'EADDRINUSE') {
+      console.warn(`\u26A0\uFE0F API server port ${port} already in use`); // ⚠️
+    } else {
+      console.error('❌ API server error:', err);
+    }
+  });
+
+  return server;
+}
+
+module.exports = { createApp, startApi };

--- a/bot.js
+++ b/bot.js
@@ -18,6 +18,7 @@ const { handleMemberJoin } = require('./botactions/eventHandling/memberJoinEvent
 const { startOrgTagSyncScheduler } = require('./botactions/orgTagSync/syncScheduler');
 const { startAllScheduledJobs } = require('./jobs');
 const { pendingLogs } = require('./jobs/logState')
+const { startApi } = require('./api/server');
 
 const botType = process.env.BOT_TYPE;
 
@@ -177,6 +178,7 @@ const initializeBot = async () => {
 };
 
 if (require.main === module) {
+  startApi();
   initializeBot();
 }
 


### PR DESCRIPTION
## Summary
- add Express API server at `api/server.js`
- run API server from `bot.js`
- mock API server in tests
- add unit tests for API server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841dc20864c832d96468e2a4c653afe