### PR TITLE
feat(api): add content endpoint

### DIFF
--- a/__mocks__/config/database.js
+++ b/__mocks__/config/database.js
@@ -30,6 +30,10 @@ const VoiceLog = {
   findAll: jest.fn()
 };
 
+const SiteContent = {
+  findOne: jest.fn()
+};
+
 const Hunt = {
   findAll: jest.fn(),
   create: jest.fn(),
@@ -88,6 +92,7 @@ module.exports = {
   OrgTag,
   UsageLog,
   VoiceLog,
+  SiteContent,
   sequelize,
   initializeDatabase,
   Hunt,

--- a/__tests__/api/content.test.js
+++ b/__tests__/api/content.test.js
@@ -1,0 +1,51 @@
+const { getContent } = require('../../api/content');
+
+jest.mock('../../config/database', () => ({ SiteContent: { findOne: jest.fn() } }));
+const { SiteContent } = require('../../config/database');
+
+function mockRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn()
+  };
+}
+
+describe('api/content getContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns content when found', async () => {
+    const req = { params: { section: 'about' } };
+    const res = mockRes();
+    SiteContent.findOne.mockResolvedValue({ content: 'hello' });
+
+    await getContent(req, res);
+    expect(SiteContent.findOne).toHaveBeenCalledWith({ where: { section: 'about' } });
+    expect(res.json).toHaveBeenCalledWith({ content: 'hello' });
+  });
+
+  test('returns 404 when not found', async () => {
+    const req = { params: { section: 'missing' } };
+    const res = mockRes();
+    SiteContent.findOne.mockResolvedValue(null);
+
+    await getContent(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  test('handles errors', async () => {
+    const req = { params: { section: 'x' } };
+    const res = mockRes();
+    const err = new Error('fail');
+    SiteContent.findOne.mockRejectedValue(err);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getContent(req, res);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -12,10 +12,13 @@ jest.mock('express', () => {
     app.__server = server;
     return app;
   });
+  express.Router = jest.fn(() => ({ get: jest.fn(), use: jest.fn() }));
   return express;
 }, { virtual: true });
 
 jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: true });
+
+jest.mock('../../config/database', () => ({ SiteContent: {} }), { virtual: true });
 
 const express = require('express');
 const { startApi } = require('../../api/server');
@@ -29,7 +32,7 @@ describe('api/server startApi', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     startApi();
     const app = express.mock.results[0].value;
-    expect(app.use).toHaveBeenCalled();
+    expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));
     expect(app.listen).toHaveBeenCalledWith(8003, expect.any(Function));
     expect(logSpy).toHaveBeenCalled();

--- a/api/content.js
+++ b/api/content.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const { SiteContent } = require('../config/database');
+
+async function getContent(req, res) {
+  const { section } = req.params;
+  try {
+    const record = await SiteContent.findOne({ where: { section } });
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    res.json({ content: record.content });
+  } catch (err) {
+    console.error('Failed to load content:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/:section', getContent);
+
+module.exports = { router, getContent };

--- a/api/server.js
+++ b/api/server.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const cors = require('cors');
+const { router: contentRouter } = require('./content');
 
 function createApp() {
   const app = express();
   app.use(cors());
+
+  app.use('/api/content', contentRouter);
 
   // GET /api/data - placeholder for future Sequelize queries
   app.get('/api/data', async (req, res) => {


### PR DESCRIPTION
## Summary
- add API endpoint for fetching site content
- wire router into server
- mock SiteContent in database mocks
- test API content handler and server updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68425f455f50832d9761802305205c44