### PR TITLE
Add events API endpoint

### DIFF
--- a/__tests__/api/events.test.js
+++ b/__tests__/api/events.test.js
@@ -1,0 +1,40 @@
+jest.mock('../../config/database', () => ({ Event: { findAll: jest.fn() } }));
+const { listEvents } = require('../../api/events');
+const { Event } = require('../../config/database');
+
+function mockRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn()
+  };
+}
+
+describe('api/events listEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns event list', async () => {
+    const req = {};
+    const res = mockRes();
+    Event.findAll.mockResolvedValue([{ event_id: 1 }]);
+
+    await listEvents(req, res);
+    expect(Event.findAll).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ events: [{ event_id: 1 }] });
+  });
+
+  test('handles errors', async () => {
+    const req = {};
+    const res = mockRes();
+    const err = new Error('fail');
+    Event.findAll.mockRejectedValue(err);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listEvents(req, res);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -18,7 +18,7 @@ jest.mock('express', () => {
 
 jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: true });
 
-jest.mock('../../config/database', () => ({ SiteContent: {} }), { virtual: true });
+jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {} }), { virtual: true });
 
 const express = require('express');
 const { startApi } = require('../../api/server');
@@ -33,6 +33,7 @@ describe('api/server startApi', () => {
     startApi();
     const app = express.mock.results[0].value;
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
+    expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));
     expect(app.listen).toHaveBeenCalledWith(8003, expect.any(Function));
     expect(logSpy).toHaveBeenCalled();

--- a/api/events.js
+++ b/api/events.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const { Event } = require('../config/database');
+
+async function listEvents(req, res) {
+  try {
+    const events = await Event.findAll();
+    res.json({ events });
+  } catch (err) {
+    console.error('Failed to load events:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/', listEvents);
+
+module.exports = { router, listEvents };

--- a/api/server.js
+++ b/api/server.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const cors = require('cors');
 const { router: contentRouter } = require('./content');
+const { router: eventsRouter } = require('./events');
 
 function createApp() {
   const app = express();
   app.use(cors());
 
   app.use('/api/content', contentRouter);
+  app.use('/api/events', eventsRouter);
 
   // GET /api/data - placeholder for future Sequelize queries
   app.get('/api/data', async (req, res) => {


### PR DESCRIPTION
## Summary
- serve events at `/api/events`
- implement events router for fetching all events
- test events route and update server tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68430eec4c9c832d9d0993ebceeac4d2