### PR TITLE
Implement accolades API endpoint

### DIFF
--- a/__tests__/api/accolades.test.js
+++ b/__tests__/api/accolades.test.js
@@ -1,0 +1,79 @@
+jest.mock('../../config/database', () => ({ Accolade: { findAll: jest.fn() } }));
+jest.mock('../../discordClient', () => ({ getClient: jest.fn() }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+
+const { listAccolades } = require('../../api/accolades');
+const { Accolade } = require('../../config/database');
+const { getClient } = require('../../discordClient');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+const makeCollection = arr => ({
+  filter: fn => makeCollection(arr.filter(fn)),
+  map: fn => arr.map(fn)
+});
+
+describe('api/accolades listAccolades', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('returns accolades with recipients', async () => {
+    const req = {};
+    const res = mockRes();
+    Accolade.findAll.mockResolvedValue([
+      { id: 1, role_id: 'r1', name: 'A' },
+      { id: 2, role_id: 'r2', name: 'B' }
+    ]);
+
+    const members = [
+      { id: 'u1', displayName: 'Alice', roles: { cache: [{ id: 'r1' }] } },
+      { id: 'u2', displayName: 'Bob', roles: { cache: [{ id: 'r2' }] } },
+      { id: 'u3', displayName: 'Charlie', roles: { cache: [] } }
+    ];
+    const guild = { members: { fetch: jest.fn().mockResolvedValue(), cache: makeCollection(members) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+
+    await listAccolades(req, res);
+
+    expect(Accolade.findAll).toHaveBeenCalled();
+    expect(guild.members.fetch).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({
+      accolades: [
+        { id: 1, role_id: 'r1', name: 'A', recipients: [{ id: 'u1', displayName: 'Alice' }] },
+        { id: 2, role_id: 'r2', name: 'B', recipients: [{ id: 'u2', displayName: 'Bob' }] }
+      ]
+    });
+  });
+
+  test('handles database errors', async () => {
+    const req = {};
+    const res = mockRes();
+    const err = new Error('fail');
+    Accolade.findAll.mockRejectedValue(err);
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => ({ members: { fetch: jest.fn(), cache: makeCollection([]) } })) } } });
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listAccolades(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+
+  test('returns 500 when client missing', async () => {
+    const req = {};
+    const res = mockRes();
+    Accolade.findAll.mockResolvedValue([]);
+    getClient.mockReturnValue(null);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listAccolades(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -18,7 +18,8 @@ jest.mock('express', () => {
 
 jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: true });
 
-jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {} }), { virtual: true });
+jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {}, Accolade: {} }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
 
 const express = require('express');
 const { startApi } = require('../../api/server');

--- a/api/accolades.js
+++ b/api/accolades.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const { Accolade } = require('../config/database');
+const { getClient } = require('../discordClient');
+const config = require('../config.json');
+
+async function listAccolades(req, res) {
+  try {
+    const accolades = await Accolade.findAll();
+    const client = getClient();
+    const guild = client?.guilds?.cache.get(config.guildId);
+    if (!client || !guild) {
+      console.error('Discord client unavailable for accolades endpoint');
+      return res.status(500).json({ error: 'Discord client unavailable' });
+    }
+    await guild.members.fetch();
+    const result = accolades.map(a => {
+      const data = a.get ? a.get({ plain: true }) : a;
+      const members = guild.members.cache
+        .filter(m => m.roles.cache.some(r => r.id === data.role_id))
+        .map(m => ({ id: m.id, displayName: m.displayName }));
+      return { ...data, recipients: members };
+    });
+    res.json({ accolades: result });
+  } catch (err) {
+    console.error('Failed to load accolades:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/', listAccolades);
+
+module.exports = { router, listAccolades };

--- a/api/server.js
+++ b/api/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const { router: contentRouter } = require('./content');
 const { router: eventsRouter } = require('./events');
+const { router: accoladesRouter } = require('./accolades');
 
 function createApp() {
   const app = express();
@@ -9,6 +10,7 @@ function createApp() {
 
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
+  app.use('/api/accolades', accoladesRouter);
 
   // GET /api/data - placeholder for future Sequelize queries
   app.get('/api/data', async (req, res) => {

--- a/bot.js
+++ b/bot.js
@@ -19,6 +19,7 @@ const { startOrgTagSyncScheduler } = require('./botactions/orgTagSync/syncSchedu
 const { startAllScheduledJobs } = require('./jobs');
 const { pendingLogs } = require('./jobs/logState')
 const { startApi } = require('./api/server');
+const { setClient } = require('./discordClient');
 
 const botType = process.env.BOT_TYPE;
 
@@ -108,6 +109,7 @@ const initializeBot = async () => {
   }
 
   const client = initClient();
+  setClient(client);
   client.config = config;
 
   client.on('interactionCreate', async interaction => {

--- a/discordClient.js
+++ b/discordClient.js
@@ -1,0 +1,4 @@
+let client = null;
+function setClient(c) { client = c; }
+function getClient() { return client; }
+module.exports = { setClient, getClient };


### PR DESCRIPTION
## Summary
- expose `setClient`/`getClient` helpers
- register Discord client for later use
- add `/api/accolades` route
- mount accolades route in API server
- test accolades endpoint and update server tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684319ec5380832da4a72679ac331649