### PR TITLE
Add automated Swagger docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Automatic OpenAPI documentation generation
+- `/api/docs` endpoint serving Swagger UI
+

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ watch your files and automatically restart the bot during development.
 | /__tests__/ | Jest test suites |
 | /__mocks__/ | Mock data for tests |
 
+## 📖 API Documentation
+
+API endpoints are documented using the OpenAPI specification. After running the tests or starting the server, `api/swagger.json` is regenerated automatically. To view the interactive documentation, start the API and visit [`/api/docs`](http://localhost:8003/api/docs).
+
 ## 🧪 Testing
 
 Testing is configured with **Jest**. Run:

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -20,6 +20,7 @@ jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: tr
 
 jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {}, Accolade: {} }));
 jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+jest.mock('../../api/docs', () => ({ router: {} }), { virtual: true });
 
 const express = require('express');
 const { startApi } = require('../../api/server');
@@ -33,6 +34,7 @@ describe('api/server startApi', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     startApi();
     const app = express.mock.results[0].value;
+    expect(app.use).toHaveBeenCalledWith('/api/docs', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));

--- a/api/docs.js
+++ b/api/docs.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const path = require('path');
+const router = express.Router();
+
+router.get('/swagger.json', (req, res) => {
+  res.sendFile(path.join(__dirname, 'swagger.json'));
+});
+
+router.get('/', (req, res) => {
+  res.send(`<!DOCTYPE html>
+  <html>
+    <head>
+      <title>API Docs</title>
+      <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+    </head>
+    <body>
+      <div id="swagger-ui"></div>
+      <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+      <script>
+        window.onload = () => {
+          SwaggerUIBundle({ url: '/api/docs/swagger.json', dom_id: '#swagger-ui' });
+        };
+      </script>
+    </body>
+  </html>`);
+});
+
+module.exports = { router };

--- a/api/server.js
+++ b/api/server.js
@@ -3,11 +3,13 @@ const cors = require('cors');
 const { router: contentRouter } = require('./content');
 const { router: eventsRouter } = require('./events');
 const { router: accoladesRouter } = require('./accolades');
+const { router: docsRouter } = require('./docs');
 
 function createApp() {
   const app = express();
   app.use(cors());
 
+  app.use('/api/docs', docsRouter);
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
   app.use('/api/accolades', accoladesRouter);

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Quartermaster API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/data": {
+      "get": {
+        "summary": "GET /api/data",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/content": {
+      "get": {
+        "summary": "GET /api/content",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/content/:section": {
+      "get": {
+        "summary": "GET /api/content/:section",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/events": {
+      "get": {
+        "summary": "GET /api/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/accolades": {
+      "get": {
+        "summary": "GET /api/accolades",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bot.js",
   "scripts": {
     "prestart": "node -e \"process.stdout.write('\\x1Bc')\" && npm install",
+    "pretest": "node scripts/generateSwagger.js",
     "start": "node bot.js",
     "test": "node --no-deprecation -e \"process.stdout.write('\\x1Bc')\" && jest",
     "setup": "node -e \"process.stdout.write('\\x1Bc')\" && npm ci --no-audit && npm test"

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+const apiDir = path.join(__dirname, '../api');
+const serverSrc = fs.readFileSync(path.join(apiDir, 'server.js'), 'utf8');
+
+const importRegex = /\{\s*router:\s*(\w+)\s*\}\s*=\s*require\(['"`]\.\/(.+?)['"`]\)/g;
+const routerFiles = {};
+let m;
+while ((m = importRegex.exec(serverSrc))) {
+  if (m[1] !== 'docsRouter') {
+    routerFiles[m[1]] = `${m[2]}.js`;
+  }
+}
+
+const useRegex = /app\.use\(['"`]([^'"`]+)['"`],\s*(\w+)\)/g;
+const basePaths = {};
+while ((m = useRegex.exec(serverSrc))) {
+  if (m[2] !== 'docsRouter') {
+    basePaths[m[2]] = m[1];
+  }
+}
+
+const spec = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Quartermaster API',
+    version: '1.0.0'
+  },
+  paths: {}
+};
+
+const directRegex = /app\.get\(['"`]([^'"`]+)['"`]/g;
+while ((m = directRegex.exec(serverSrc))) {
+  spec.paths[m[1]] = {
+    get: {
+      summary: `GET ${m[1]}`,
+      responses: { 200: { description: 'Success' } }
+    }
+  };
+}
+
+for (const [routerVar, base] of Object.entries(basePaths)) {
+  const file = routerFiles[routerVar];
+  if (!file) continue;
+  const src = fs.readFileSync(path.join(apiDir, file), 'utf8');
+  const routeRegex = /router\.get\(['"`]([^'"`]+)['"`]/g;
+  let routeMatch;
+  while ((routeMatch = routeRegex.exec(src))) {
+    let route = routeMatch[1];
+    if (route === '/') route = '';
+    spec.paths[`${base}${route}`] = {
+      get: {
+        summary: `GET ${base}${route}`,
+        responses: { 200: { description: 'Success' } }
+      }
+    };
+  }
+}
+
+fs.writeFileSync(path.join(apiDir, 'swagger.json'), JSON.stringify(spec, null, 2));
+console.log('\uD83D\uDCDD Swagger docs generated'); // 📝


### PR DESCRIPTION
## Summary
- generate `api/swagger.json` before tests
- serve Swagger UI from `/api/docs`
- update API server and tests for docs route
- document API docs in README
- add changelog entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684321fd2400832d8c3e9488e3807d59