### PR TITLE
Fix swagger parameter for content endpoint

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -25,9 +25,20 @@
         }
       }
     },
-    "/api/content/:section": {
+    "/api/content/{section}": {
       "get": {
-        "summary": "GET /api/content/:section",
+        "summary": "GET /api/content/{section}",
+        "parameters": [
+          {
+            "name": "section",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The content section to retrieve"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"


### PR DESCRIPTION
## Summary
- capture path parameters when generating OpenAPI docs
- include `section` parameter in swagger.json

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843256e9db8832dab32deb8c6c45cf9