### PR TITLE
Add single resource endpoints for events and accolades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 ### Added
 - Automatic OpenAPI documentation generation
 - `/api/docs` endpoint serving Swagger UI
+- `GET /api/events/:id` and `GET /api/accolades/:id` endpoints
 

--- a/__tests__/api/events.test.js
+++ b/__tests__/api/events.test.js
@@ -1,5 +1,5 @@
-jest.mock('../../config/database', () => ({ Event: { findAll: jest.fn() } }));
-const { listEvents } = require('../../api/events');
+jest.mock('../../config/database', () => ({ Event: { findAll: jest.fn(), findByPk: jest.fn() } }));
+const { listEvents, getEvent } = require('../../api/events');
 const { Event } = require('../../config/database');
 
 function mockRes() {
@@ -36,5 +36,43 @@ describe('api/events listEvents', () => {
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
     errorSpy.mockRestore();
+  });
+});
+
+describe('api/events getEvent', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('returns single event', async () => {
+    const req = { params: { id: '1' } };
+    const res = mockRes();
+    Event.findByPk.mockResolvedValue({ event_id: 1 });
+
+    await getEvent(req, res);
+    expect(Event.findByPk).toHaveBeenCalledWith('1');
+    expect(res.json).toHaveBeenCalledWith({ event: { event_id: 1 } });
+  });
+
+  test('returns 404 when not found', async () => {
+    const req = { params: { id: '2' } };
+    const res = mockRes();
+    Event.findByPk.mockResolvedValue(null);
+
+    await getEvent(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  test('handles errors', async () => {
+    const req = { params: { id: '3' } };
+    const res = mockRes();
+    const err = new Error('fail');
+    Event.findByPk.mockRejectedValue(err);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getEvent(req, res);
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
   });
 });

--- a/api/accolades.js
+++ b/api/accolades.js
@@ -28,6 +28,30 @@ async function listAccolades(req, res) {
   }
 }
 
-router.get('/', listAccolades);
+async function getAccolade(req, res) {
+  const { id } = req.params;
+  try {
+    const accolade = await Accolade.findByPk(id);
+    if (!accolade) return res.status(404).json({ error: 'Not found' });
+    const client = getClient();
+    const guild = client?.guilds?.cache.get(config.guildId);
+    if (!client || !guild) {
+      console.error('Discord client unavailable for accolades endpoint');
+      return res.status(500).json({ error: 'Discord client unavailable' });
+    }
+    await guild.members.fetch();
+    const data = accolade.get ? accolade.get({ plain: true }) : accolade;
+    const members = guild.members.cache
+      .filter(m => m.roles.cache.some(r => r.id === data.role_id))
+      .map(m => ({ id: m.id, displayName: m.displayName }));
+    res.json({ accolade: { ...data, recipients: members } });
+  } catch (err) {
+    console.error('Failed to load accolade:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
 
-module.exports = { router, listAccolades };
+router.get('/', listAccolades);
+router.get('/:id', getAccolade);
+
+module.exports = { router, listAccolades, getAccolade };

--- a/api/events.js
+++ b/api/events.js
@@ -12,6 +12,19 @@ async function listEvents(req, res) {
   }
 }
 
-router.get('/', listEvents);
+async function getEvent(req, res) {
+  const { id } = req.params;
+  try {
+    const event = await Event.findByPk(id);
+    if (!event) return res.status(404).json({ error: 'Not found' });
+    res.json({ event });
+  } catch (err) {
+    console.error('Failed to load event:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
 
-module.exports = { router, listEvents };
+router.get('/', listEvents);
+router.get('/:id', getEvent);
+
+module.exports = { router, listEvents, getEvent };

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -28,6 +28,11 @@
     "/api/content/{section}": {
       "get": {
         "summary": "GET /api/content/{section}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
         "parameters": [
           {
             "name": "section",
@@ -36,14 +41,9 @@
             "schema": {
               "type": "string"
             },
-            "description": "The content section to retrieve"
+            "description": "The section"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
+        ]
       }
     },
     "/api/events": {
@@ -56,6 +56,27 @@
         }
       }
     },
+    "/api/events/{id}": {
+      "get": {
+        "summary": "GET /api/events/{id}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id"
+          }
+        ]
+      }
+    },
     "/api/accolades": {
       "get": {
         "summary": "GET /api/accolades",
@@ -64,6 +85,27 @@
             "description": "Success"
           }
         }
+      }
+    },
+    "/api/accolades/{id}": {
+      "get": {
+        "summary": "GET /api/accolades/{id}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id"
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `/api/events/:id` and `/api/accolades/:id` endpoints
- support fetching individual entries from the database
- extend API unit tests for new endpoints
- regenerate swagger docs
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68433c475c50832d838ebae842985fcb