### PR TITLE
Add UEX search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 - Automatic OpenAPI documentation generation
 - `/api/docs` endpoint serving Swagger UI
 - `GET /api/events/:id` and `GET /api/accolades/:id` endpoints
+- `/api/uex` search endpoints for terminals and inventory
 

--- a/__tests__/api/uex.test.js
+++ b/__tests__/api/uex.test.js
@@ -1,0 +1,143 @@
+jest.mock('../../config/database', () => ({
+  UexTerminal: { findAll: jest.fn(), findByPk: jest.fn() },
+  UexItemPrice: { findAll: jest.fn() },
+  UexCommodityPrice: { findAll: jest.fn() },
+  UexFuelPrice: { findAll: jest.fn() },
+  UexVehiclePurchasePrice: { findAll: jest.fn() },
+  UexVehicleRentalPrice: { findAll: jest.fn() }
+}));
+
+const { Op } = require('sequelize');
+const {
+  searchTerminals,
+  getTerminalInventory,
+  getTerminalsForItem
+} = require('../../api/uex');
+const {
+  UexTerminal,
+  UexItemPrice,
+  UexCommodityPrice,
+  UexFuelPrice,
+  UexVehiclePurchasePrice,
+  UexVehicleRentalPrice
+} = require('../../config/database');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+describe('api/uex searchTerminals', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns terminal list', async () => {
+    const req = { query: { name: 'T1' } };
+    const res = mockRes();
+    UexTerminal.findAll.mockResolvedValue([{ id: 1 }]);
+
+    await searchTerminals(req, res);
+
+    expect(UexTerminal.findAll).toHaveBeenCalledWith({
+      where: { [Op.and]: [{ name: { [Op.like]: '%T1%' } }] }
+    });
+    expect(res.json).toHaveBeenCalledWith({ terminals: [{ id: 1 }] });
+  });
+
+  test('handles errors', async () => {
+    const req = { query: {} };
+    const res = mockRes();
+    const err = new Error('fail');
+    UexTerminal.findAll.mockRejectedValue(err);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await searchTerminals(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/uex getTerminalInventory', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns 404 when terminal missing', async () => {
+    const req = { params: { id: '1' } };
+    const res = mockRes();
+    UexTerminal.findByPk.mockResolvedValue(null);
+
+    await getTerminalInventory(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  test('returns inventory for terminal', async () => {
+    const req = { params: { id: '1' } };
+    const res = mockRes();
+    UexTerminal.findByPk.mockResolvedValue({ id: 1 });
+    UexItemPrice.findAll.mockResolvedValue(['i']);
+    UexCommodityPrice.findAll.mockResolvedValue(['c']);
+    UexFuelPrice.findAll.mockResolvedValue(['f']);
+    UexVehiclePurchasePrice.findAll.mockResolvedValue(['pb']);
+    UexVehicleRentalPrice.findAll.mockResolvedValue(['pr']);
+
+    await getTerminalInventory(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      terminal: { id: 1 },
+      inventory: {
+        items: ['i'],
+        commodities: ['c'],
+        fuel: ['f'],
+        vehicles_buy: ['pb'],
+        vehicles_rent: ['pr']
+      }
+    });
+  });
+
+  test('handles errors', async () => {
+    const req = { params: { id: '1' } };
+    const res = mockRes();
+    const err = new Error('fail');
+    UexTerminal.findByPk.mockRejectedValue(err);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getTerminalInventory(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/uex getTerminalsForItem', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('aggregates terminals from all tables', async () => {
+    const req = { params: { name: 'foo' } };
+    const res = mockRes();
+    UexItemPrice.findAll.mockResolvedValue([{ terminal: { id: 1 } }]);
+    UexCommodityPrice.findAll.mockResolvedValue([{ terminal: { id: 2 } }]);
+    UexVehiclePurchasePrice.findAll.mockResolvedValue([{ terminal: { id: 3 } }]);
+
+    await getTerminalsForItem(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ terminals: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+  });
+
+  test('handles errors', async () => {
+    const req = { params: { name: 'foo' } };
+    const res = mockRes();
+    UexItemPrice.findAll.mockRejectedValue(new Error('fail'));
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getTerminalsForItem(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});

--- a/api/server.js
+++ b/api/server.js
@@ -4,6 +4,7 @@ const { router: contentRouter } = require('./content');
 const { router: eventsRouter } = require('./events');
 const { router: accoladesRouter } = require('./accolades');
 const { router: docsRouter } = require('./docs');
+const { router: uexRouter } = require('./uex');
 
 function createApp() {
   const app = express();
@@ -13,6 +14,7 @@ function createApp() {
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
   app.use('/api/accolades', accoladesRouter);
+  app.use('/api/uex', uexRouter);
 
   // GET /api/data - placeholder for future Sequelize queries
   app.get('/api/data', async (req, res) => {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -107,6 +107,58 @@
           }
         ]
       }
+    },
+    "/api/uex/terminals": {
+      "get": {
+        "summary": "GET /api/uex/terminals",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/uex/terminals/{id}/inventory": {
+      "get": {
+        "summary": "GET /api/uex/terminals/{id}/inventory",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id"
+          }
+        ]
+      }
+    },
+    "/api/uex/items/{name}/terminals": {
+      "get": {
+        "summary": "GET /api/uex/items/{name}/terminals",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name"
+          }
+        ]
+      }
     }
   }
 }

--- a/api/uex.js
+++ b/api/uex.js
@@ -1,0 +1,104 @@
+const express = require('express');
+const router = express.Router();
+const { Op } = require('sequelize');
+const {
+  UexTerminal,
+  UexItemPrice,
+  UexCommodityPrice,
+  UexFuelPrice,
+  UexVehiclePurchasePrice,
+  UexVehicleRentalPrice
+} = require('../config/database');
+
+async function searchTerminals(req, res) {
+  const { name, location } = req.query;
+  const filters = [];
+
+  if (name) {
+    filters.push({ name: { [Op.like]: `%${name}%` } });
+  }
+
+  if (location) {
+    const pattern = { [Op.like]: `%${location}%` };
+    filters.push({
+      [Op.or]: [
+        { star_system_name: pattern },
+        { planet_name: pattern },
+        { orbit_name: pattern },
+        { space_station_name: pattern },
+        { outpost_name: pattern },
+        { city_name: pattern }
+      ]
+    });
+  }
+
+  try {
+    const terminals = await UexTerminal.findAll({
+      where: filters.length ? { [Op.and]: filters } : undefined
+    });
+    res.json({ terminals });
+  } catch (err) {
+    console.error('Failed to search terminals:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+async function getTerminalInventory(req, res) {
+  const { id } = req.params;
+  try {
+    const terminal = await UexTerminal.findByPk(id);
+    if (!terminal) return res.status(404).json({ error: 'Not found' });
+
+    const [items, commodities, fuel, vehicleBuy, vehicleRent] = await Promise.all([
+      UexItemPrice.findAll({ where: { id_terminal: id } }),
+      UexCommodityPrice.findAll({ where: { id_terminal: id } }),
+      UexFuelPrice.findAll({ where: { id_terminal: id } }),
+      UexVehiclePurchasePrice.findAll({ where: { id_terminal: id } }),
+      UexVehicleRentalPrice.findAll({ where: { id_terminal: id } })
+    ]);
+
+    res.json({
+      terminal,
+      inventory: {
+        items,
+        commodities,
+        fuel,
+        vehicles_buy: vehicleBuy,
+        vehicles_rent: vehicleRent
+      }
+    });
+  } catch (err) {
+    console.error('Failed to load terminal inventory:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+async function getTerminalsForItem(req, res) {
+  const { name } = req.params;
+  const search = { [Op.like]: `%${name}%` };
+
+  try {
+    const [items, commodities, vehicles] = await Promise.all([
+      UexItemPrice.findAll({ where: { item_name: search }, include: { model: UexTerminal, as: 'terminal' } }),
+      UexCommodityPrice.findAll({ where: { commodity_name: search }, include: { model: UexTerminal, as: 'terminal' } }),
+      UexVehiclePurchasePrice.findAll({ where: { vehicle_name: search }, include: { model: UexTerminal, as: 'terminal' } })
+    ]);
+
+    const terminals = [
+      ...items.map(r => r.terminal).filter(Boolean),
+      ...commodities.map(r => r.terminal).filter(Boolean),
+      ...vehicles.map(r => r.terminal).filter(Boolean)
+    ];
+
+    res.json({ terminals });
+  } catch (err) {
+    console.error('Failed to load terminals for item:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/terminals', searchTerminals);
+router.get('/terminals/:id/inventory', getTerminalInventory);
+router.get('/items/:name/terminals', getTerminalsForItem);
+
+module.exports = { router, searchTerminals, getTerminalInventory, getTerminalsForItem };


### PR DESCRIPTION
## Summary
- implement `/api/uex` routes for searching terminals and inventory
- expose UEX router from api server
- test all new route handlers
- document endpoints in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843462c00ec832d8bca14a9c4ad96c8