### PR TITLE
Update terminal inventory endpoint path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@
 - `GET /api/events/:id` and `GET /api/accolades/:id` endpoints
 - `/api/uex` search endpoints for terminals and inventory
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
+- Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
 

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -118,9 +118,9 @@
         }
       }
     },
-    "/api/uex/terminals/{id}/inventory": {
+    "/api/uex/terminals/{id}": {
       "get": {
-        "summary": "GET /api/uex/terminals/{id}/inventory",
+        "summary": "GET /api/uex/terminals/{id}",
         "responses": {
           "200": {
             "description": "Success"

--- a/api/uex.js
+++ b/api/uex.js
@@ -74,6 +74,6 @@ async function getTerminalInventory(req, res) {
 }
 
 router.get('/terminals', searchTerminals);
-router.get('/terminals/:id/inventory', getTerminalInventory);
+router.get('/terminals/:id', getTerminalInventory);
 
 module.exports = { router, searchTerminals, getTerminalInventory };


### PR DESCRIPTION
## Summary
- rename terminal inventory route to `/api/uex/terminals/:id`
- document new route in swagger spec
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684392f542d4832db1e2109688ea4880