### PR TITLE
feat: add jwt auth for API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@
 - `/api/uex` search endpoints for terminals and inventory
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
+- JWT authentication middleware for API routes
 

--- a/__tests__/api/auth.test.js
+++ b/__tests__/api/auth.test.js
@@ -1,0 +1,47 @@
+const { authMiddleware } = require('../../api/auth');
+const { sign } = require('../../utils/jwt');
+
+describe('api/auth authMiddleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  function mockRes() {
+    return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  }
+
+  test('passes through with valid token', () => {
+    const token = sign({ id: 1 }, 'secret');
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = mockRes();
+    const next = jest.fn();
+    authMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('rejects missing token', () => {
+    const req = { headers: {} };
+    const res = mockRes();
+    const next = jest.fn();
+    authMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('rejects invalid token', () => {
+    const badToken = sign({ id: 1 }, 'other');
+    const req = { headers: { authorization: `Bearer ${badToken}` } };
+    const res = mockRes();
+    const next = jest.fn();
+    authMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -21,6 +21,7 @@ jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: tr
 jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {}, Accolade: {} }));
 jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
 jest.mock('../../api/docs', () => ({ router: {} }), { virtual: true });
+jest.mock('../../api/auth', () => ({ authMiddleware: jest.fn((req, res, next) => next()) }));
 
 const express = require('express');
 const { startApi } = require('../../api/server');
@@ -35,6 +36,7 @@ describe('api/server startApi', () => {
     startApi();
     const app = express.mock.results[0].value;
     expect(app.use).toHaveBeenCalledWith('/api/docs', expect.anything());
+    expect(app.use).toHaveBeenCalledWith('/api', expect.any(Function));
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,22 @@
+const { verify } = require('../utils/jwt');
+
+function authMiddleware(req, res, next) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    console.error('JWT_SECRET not configured');
+    return res.status(500).json({ error: 'Server misconfiguration' });
+  }
+  const auth = req.headers.authorization || '';
+  if (!auth.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing token' });
+  }
+  const token = auth.slice(7);
+  const payload = verify(token, secret);
+  if (!payload) {
+    return res.status(403).json({ error: 'Invalid token' });
+  }
+  req.user = payload;
+  next();
+}
+
+module.exports = { authMiddleware };

--- a/api/server.js
+++ b/api/server.js
@@ -5,12 +5,14 @@ const { router: eventsRouter } = require('./events');
 const { router: accoladesRouter } = require('./accolades');
 const { router: docsRouter } = require('./docs');
 const { router: uexRouter } = require('./uex');
+const { authMiddleware } = require('./auth');
 
 function createApp() {
   const app = express();
   app.use(cors());
 
   app.use('/api/docs', docsRouter);
+  app.use('/api', authMiddleware);
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
   app.use('/api/accolades', accoladesRouter);

--- a/utils/jwt.js
+++ b/utils/jwt.js
@@ -1,0 +1,31 @@
+const crypto = require('crypto');
+
+function sign(payload, secret) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadB64 = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest('base64url');
+  return `${headerB64}.${payloadB64}.${signature}`;
+}
+
+function verify(token, secret) {
+  if (typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, signature] = parts;
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest('base64url');
+  if (signature !== expected) return null;
+  try {
+    return JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { sign, verify };


### PR DESCRIPTION
## Summary
- add simple JWT utils
- add auth middleware using JWT_SECRET
- secure API routes with auth middleware
- test auth middleware and server changes
- document auth in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843970cb404832d9764c2ab97c1e804