### PR TITLE
feat(api): add JWT exchange endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
 - JWT authentication middleware for API routes
+- `/api/token` endpoint for JWT exchange
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,16 @@ project root, or you can export them in your shell before running the bot.
 - `OPENAI_API_KEY` - API key used for OpenAI requests.
 - `OPENAI_MODEL` - Model name to use when calling the OpenAI API.
 - `UEX_API_TOKEN` - Authentication token for the UEX trading API.
+- `JWT_SECRET` - Secret used to sign API tokens.
+- `JWT_SIGNING_SECRET` - Shared secret for exchanging short-lived JWTs.
 - `GOOGLE_SERVICE_ACCOUNT_FILE` - Path to your service account JSON key for Google Drive access.
+
+## 🔑 Obtaining an API Token
+
+1. Create a JWT in your website using `JWT_SIGNING_SECRET`. The payload can include any user data.
+2. Send a `POST` request to `/api/token` with a JSON body `{ "token": "<jwt>" }`.
+3. The API validates the token and responds with a new token signed using `JWT_SECRET`.
+4. Use this returned token in the `Authorization: Bearer` header when calling other `/api/*` endpoints.
 
 ## 🗄️ Google Drive Setup
 

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -12,7 +12,12 @@ jest.mock('express', () => {
     app.__server = server;
     return app;
   });
-  express.Router = jest.fn(() => ({ get: jest.fn(), use: jest.fn() }));
+  express.Router = jest.fn(() => ({
+    get: jest.fn(),
+    use: jest.fn(),
+    post: jest.fn()
+  }));
+  express.json = jest.fn(() => (req, res, next) => next());
   return express;
 }, { virtual: true });
 
@@ -35,6 +40,7 @@ describe('api/server startApi', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     startApi();
     const app = express.mock.results[0].value;
+    expect(app.use).toHaveBeenCalledWith('/api/token', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/docs', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api', expect.any(Function));
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());

--- a/__tests__/api/token.test.js
+++ b/__tests__/api/token.test.js
@@ -1,0 +1,58 @@
+const { exchangeToken } = require('../../api/token');
+const { sign, verify } = require('../../utils/jwt');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+describe('api/token exchangeToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'server';
+    process.env.JWT_SIGNING_SECRET = 'signer';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+    delete process.env.JWT_SIGNING_SECRET;
+  });
+
+  test('returns new token for valid jwt', () => {
+    const token = sign({ id: 1 }, 'signer');
+    const req = { body: { token } };
+    const res = mockRes();
+    exchangeToken(req, res);
+    const newToken = res.json.mock.calls[0][0].token;
+    expect(verify(newToken, 'server')).toEqual({ id: 1 });
+  });
+
+  test('rejects missing token', () => {
+    const req = { body: {} };
+    const res = mockRes();
+    exchangeToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Missing token' });
+  });
+
+  test('rejects invalid token', () => {
+    const bad = sign({ id: 1 }, 'bad');
+    const req = { body: { token: bad } };
+    const res = mockRes();
+    exchangeToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid token' });
+  });
+
+  test('returns 500 when secrets missing', () => {
+    delete process.env.JWT_SECRET;
+    delete process.env.JWT_SIGNING_SECRET;
+    const req = { body: { token: 'x' } };
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    exchangeToken(req, res);
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server misconfiguration' });
+    spy.mockRestore();
+  });
+});

--- a/api/server.js
+++ b/api/server.js
@@ -5,12 +5,14 @@ const { router: eventsRouter } = require('./events');
 const { router: accoladesRouter } = require('./accolades');
 const { router: docsRouter } = require('./docs');
 const { router: uexRouter } = require('./uex');
+const { router: tokenRouter } = require('./token');
 const { authMiddleware } = require('./auth');
 
 function createApp() {
   const app = express();
   app.use(cors());
 
+  app.use('/api/token', tokenRouter);
   app.use('/api/docs', docsRouter);
   app.use('/api', authMiddleware);
   app.use('/api/content', contentRouter);

--- a/api/token.js
+++ b/api/token.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+const { verify, sign } = require('../utils/jwt');
+
+router.use(express.json());
+
+function exchangeToken(req, res) {
+  const signingSecret = process.env.JWT_SIGNING_SECRET;
+  const secret = process.env.JWT_SECRET;
+  if (!signingSecret || !secret) {
+    console.error('JWT secrets not configured');
+    return res.status(500).json({ error: 'Server misconfiguration' });
+  }
+
+  const { token } = req.body || {};
+  if (!token) {
+    return res.status(400).json({ error: 'Missing token' });
+  }
+
+  const payload = verify(token, signingSecret);
+  if (!payload) {
+    return res.status(403).json({ error: 'Invalid token' });
+  }
+
+  const apiToken = sign(payload, secret);
+  res.json({ token: apiToken });
+}
+
+router.post('/', exchangeToken);
+
+module.exports = { router, exchangeToken };


### PR DESCRIPTION
## Summary
- allow exchanging short-lived JWTs for official API tokens
- document JWT env vars and how to obtain tokens
- test new `/api/token` route and update server tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843b2c13b24832d970a6df6c9868b1e