### PR TITLE
Add IP whitelist to JWT token exchange endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ project root, or you can export them in your shell before running the bot.
 - `UEX_API_TOKEN` - Authentication token for the UEX trading API.
 - `JWT_SECRET` - Secret used to sign API tokens.
 - `JWT_SIGNING_SECRET` - Shared secret for exchanging short-lived JWTs.
+- `TOKEN_IP_WHITELIST` - Comma separated list of IPs allowed to exchange tokens.
 - `GOOGLE_SERVICE_ACCOUNT_FILE` - Path to your service account JSON key for Google Drive access.
 
 ## 🔑 Obtaining an API Token

--- a/__tests__/api/token.test.js
+++ b/__tests__/api/token.test.js
@@ -10,16 +10,18 @@ describe('api/token exchangeToken', () => {
     jest.clearAllMocks();
     process.env.JWT_SECRET = 'server';
     process.env.JWT_SIGNING_SECRET = 'signer';
+    process.env.TOKEN_IP_WHITELIST = '1.1.1.1';
   });
 
   afterEach(() => {
     delete process.env.JWT_SECRET;
     delete process.env.JWT_SIGNING_SECRET;
+    delete process.env.TOKEN_IP_WHITELIST;
   });
 
   test('returns new token for valid jwt', () => {
     const token = sign({ id: 1 }, 'signer');
-    const req = { body: { token } };
+    const req = { body: { token }, ip: '1.1.1.1' };
     const res = mockRes();
     exchangeToken(req, res);
     const newToken = res.json.mock.calls[0][0].token;
@@ -27,7 +29,7 @@ describe('api/token exchangeToken', () => {
   });
 
   test('rejects missing token', () => {
-    const req = { body: {} };
+    const req = { body: {}, ip: '1.1.1.1' };
     const res = mockRes();
     exchangeToken(req, res);
     expect(res.status).toHaveBeenCalledWith(400);
@@ -36,7 +38,7 @@ describe('api/token exchangeToken', () => {
 
   test('rejects invalid token', () => {
     const bad = sign({ id: 1 }, 'bad');
-    const req = { body: { token: bad } };
+    const req = { body: { token: bad }, ip: '1.1.1.1' };
     const res = mockRes();
     exchangeToken(req, res);
     expect(res.status).toHaveBeenCalledWith(403);
@@ -46,7 +48,29 @@ describe('api/token exchangeToken', () => {
   test('returns 500 when secrets missing', () => {
     delete process.env.JWT_SECRET;
     delete process.env.JWT_SIGNING_SECRET;
-    const req = { body: { token: 'x' } };
+    const req = { body: { token: 'x' }, ip: '1.1.1.1' };
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    exchangeToken(req, res);
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server misconfiguration' });
+    spy.mockRestore();
+  });
+
+  test('rejects unauthorized ip', () => {
+    const token = sign({ id: 1 }, 'signer');
+    const req = { body: { token }, ip: '2.2.2.2' };
+    const res = mockRes();
+    exchangeToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized IP' });
+  });
+
+  test('returns 500 when whitelist missing', () => {
+    delete process.env.TOKEN_IP_WHITELIST;
+    const token = sign({ id: 1 }, 'signer');
+    const req = { body: { token }, ip: '1.1.1.1' };
     const res = mockRes();
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     exchangeToken(req, res);


### PR DESCRIPTION
## Summary
- restrict /api/token to requests from allowed IP addresses
- test new whitelist behaviour
- document `TOKEN_IP_WHITELIST` environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68444084340c832d80f23e3e551896d1