### PR TITLE
Remove unused UEX token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ project root, or you can export them in your shell before running the bot.
   settings. Defaults to `development` if not provided.
 - `OPENAI_API_KEY` - API key used for OpenAI requests.
 - `OPENAI_MODEL` - Model name to use when calling the OpenAI API.
-- `UEX_API_TOKEN` - Authentication token for the UEX trading API.
 - `JWT_SECRET` - Secret used to sign API tokens.
 - `DISCORD_CLIENT_ID` - OAuth2 client ID for Discord login.
 - `DISCORD_CLIENT_SECRET` - OAuth2 client secret for Discord login.
@@ -122,6 +121,15 @@ project root, or you can export them in your shell before running the bot.
 3. Send a `POST` request to `/api/login` with `{ "code": "<code>", "redirectUri": "<your redirect>" }`.
 4. The API exchanges the code for the user's Discord info and returns a JWT signed with `JWT_SECRET`.
 5. Use this token in the `Authorization: Bearer` header when calling protected `/api/*` endpoints.
+
+## 🌐 Integrating Discord Login on a Website
+
+1. Ensure `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, and `JWT_SECRET` are set in your environment.
+2. Add a login link on your site that points to:
+   `https://discord.com/api/oauth2/authorize?client_id=<CLIENT_ID>&redirect_uri=<REDIRECT>&response_type=code&scope=identify`.
+3. After Discord redirects back to `<REDIRECT>` with a `?code=...` parameter, POST that code to `/api/login` with `{ code, redirectUri: '<REDIRECT>' }`.
+4. Store the returned JWT (e.g. in `localStorage`) and include it in an `Authorization: Bearer` header when calling any `/api/*` routes.
+5. Optionally decode the JWT on the client to display the user's Discord username.
 
 ## 🗄️ Google Drive Setup
 

--- a/__tests__/utils/fetchUexData.test.js
+++ b/__tests__/utils/fetchUexData.test.js
@@ -8,7 +8,6 @@ describe('fetchUexData', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    process.env.UEX_API_TOKEN = 'token';
   });
 
   afterEach(() => {
@@ -24,7 +23,7 @@ describe('fetchUexData', () => {
     const data = await fetchUexData('vehicles');
 
     expect(fetch).toHaveBeenCalledWith('https://api.uexcorp.space/2.0/vehicles', {
-      headers: { Authorization: 'Bearer token', Accept: 'application/json' }
+      headers: { Accept: 'application/json' }
     });
     expect(data).toEqual({ success: true });
   });

--- a/utils/fetchUexData.js
+++ b/utils/fetchUexData.js
@@ -15,7 +15,6 @@ async function fetchUexData(endpoint) {
 
     const response = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${process.env.UEX_API_TOKEN}`,
         Accept: 'application/json'
       }
     });


### PR DESCRIPTION
## Summary
- drop Authorization header in `fetchUexData`
- update fetchUexData tests accordingly
- remove UEX token from documentation
- document how to integrate Discord login on a website

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68447020844c832d8eeca69a6f0f2949