### PR TITLE
Add Swagger auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
 - JWT authentication middleware for API routes
 - `/api/token` endpoint for JWT exchange
+- Swagger UI now supports Bearer token authentication via the **Authorize** button
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ watch your files and automatically restart the bot during development.
 ## 📖 API Documentation
 
 API endpoints are documented using the OpenAPI specification. After running the tests or starting the server, `api/swagger.json` is regenerated automatically. To view the interactive documentation, start the API and visit [`/api/docs`](http://localhost:8003/api/docs).
+Since the API is secured with JWTs, obtain a token via `POST /api/login` and click **Authorize** in the Swagger UI to enter `Bearer <token>` for testing.
 
 ## 🧪 Testing
 

--- a/__tests__/scripts/generateSwagger.test.js
+++ b/__tests__/scripts/generateSwagger.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('scripts/generateSwagger', () => {
+  test('writes security scheme', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.isolateModules(() => {
+      require('../../scripts/generateSwagger');
+    });
+    const specPath = path.join(__dirname, '../../api/swagger.json');
+    const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+    expect(spec.components.securitySchemes.bearerAuth).toEqual(
+      expect.objectContaining({ type: 'http', scheme: 'bearer' })
+    );
+    expect(spec.security).toEqual([{ bearerAuth: [] }]);
+    logSpy.mockRestore();
+  });
+});

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,6 +4,20 @@
     "title": "Quartermaster API",
     "version": "1.0.0"
   },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "paths": {
     "/api/data": {
       "get": {

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -27,6 +27,16 @@ const spec = {
     title: 'Quartermaster API',
     version: '1.0.0'
   },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT'
+      }
+    }
+  },
+  security: [{ bearerAuth: [] }],
   paths: {}
 };
 


### PR DESCRIPTION
## Summary
- support bearer auth in generateSwagger script
- document Swagger auth usage in README
- mention new auth ability in CHANGELOG
- regenerate swagger.json with bearer auth
- test swagger generator writes security scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684590ac584c832daadb2adb1a08ef09