### PR TITLE
Add admin API token command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@
 - JWT authentication middleware for API routes
 - `/api/token` endpoint for JWT exchange
 - Swagger UI now supports Bearer token authentication via the **Authorize** button
+- `/apitoken` command for generating JWTs via Discord
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful Discord bot built for the **Pyro Freelancers Corps**, designed to man
 - ✅ Handles guild member updates & role assignments
 - ✅ Modular design for scalability
 - ✅ `/loglookup` command with user lookup and event dropdown (admin only)
+- ✅ `/apitoken` command to generate a JWT for API testing (admin only)
 
 ## 🛠️ Installation
 

--- a/__tests__/commands/admin/apitoken.test.js
+++ b/__tests__/commands/admin/apitoken.test.js
@@ -1,0 +1,42 @@
+jest.mock('../../../botactions/userManagement/permissions', () => ({ isAdmin: jest.fn() }));
+const jwt = require('jsonwebtoken');
+
+const { isAdmin } = require('../../../botactions/userManagement/permissions');
+const { execute } = require('../../../commands/admin/apitoken');
+const { MessageFlags } = require('discord.js');
+
+describe('/apitoken command', () => {
+  const makeInteraction = () => ({
+    reply: jest.fn(),
+    user: { id: '1', username: 'Tester' },
+    member: {},
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.JWT_SECRET = 'secret';
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  test('blocks non-admin users', async () => {
+    isAdmin.mockReturnValue(false);
+    const interaction = makeInteraction();
+    await execute(interaction);
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('permission'),
+      flags: MessageFlags.Ephemeral
+    });
+  });
+
+  test('returns a signed token for admins', async () => {
+    isAdmin.mockReturnValue(true);
+    const interaction = makeInteraction();
+    await execute(interaction);
+    const [[{ content }]] = interaction.reply.mock.calls;
+    const token = content.replace('Bearer ', '');
+    expect(jwt.verify(token, 'secret')).toMatchObject({ id: '1', username: 'Tester' });
+  });
+});


### PR DESCRIPTION
## Summary
- add `/apitoken` admin command for JWT generation
- document the new command in README and CHANGELOG
- cover `/apitoken` command with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68459226fac8832db54a2f57120fefec