### PR TITLE
Make certain API routes public

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -14,16 +14,18 @@ function createApp() {
 
   app.use('/api/login', loginRouter);
   app.use('/api/docs', docsRouter);
-  app.use('/api', authMiddleware);
+
+  // Public endpoints
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
-  app.use('/api/accolades', accoladesRouter);
-  app.use('/api/uex', uexRouter);
-
-  // GET /api/data - placeholder for future Sequelize queries
   app.get('/api/data', async (req, res) => {
     res.json({ success: true, message: 'API is working' });
   });
+
+  // Protected endpoints
+  app.use('/api', authMiddleware);
+  app.use('/api/accolades', accoladesRouter);
+  app.use('/api/uex', uexRouter);
 
   return app;
 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -26,7 +26,8 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": []
       }
     },
     "/api/content": {
@@ -36,7 +37,8 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": []
       }
     },
     "/api/content/{section}": {
@@ -57,7 +59,8 @@
             },
             "description": "The section"
           }
-        ]
+        ],
+        "security": []
       }
     },
     "/api/events": {
@@ -67,7 +70,8 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": []
       }
     },
     "/api/events/{id}": {
@@ -88,7 +92,8 @@
             },
             "description": "The id"
           }
-        ]
+        ],
+        "security": []
       }
     },
     "/api/accolades": {

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -82,5 +82,20 @@ for (const [routerVar, base] of Object.entries(basePaths)) {
   }
 }
 
+// Paths that should be publicly accessible (no auth required)
+const publicPaths = [
+  '/api/data',
+  '/api/content',
+  '/api/content/{section}',
+  '/api/events',
+  '/api/events/{id}'
+];
+
+for (const pathKey of publicPaths) {
+  if (spec.paths[pathKey] && spec.paths[pathKey].get) {
+    spec.paths[pathKey].get.security = [];
+  }
+}
+
 fs.writeFileSync(path.join(apiDir, 'swagger.json'), JSON.stringify(spec, null, 2));
 console.log('\uD83D\uDCDD Swagger docs generated'); // 📝


### PR DESCRIPTION
## Summary
- expose `/api/data`, `/api/content`, and `/api/events` routes without auth middleware
- generate Swagger docs with no security for those public paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684593155ac4832dbddc347ad7a41972