### PR TITLE
Add displayName and roles to login JWT

### DIFF
--- a/__tests__/commands/admin/apitoken.test.js
+++ b/__tests__/commands/admin/apitoken.test.js
@@ -9,7 +9,7 @@ describe('/apitoken command', () => {
   const makeInteraction = () => ({
     reply: jest.fn(),
     user: { id: '1', username: 'Tester' },
-    member: {},
+    member: { displayName: 'Display', roles: { cache: [{ name: 'Admin' }] } },
   });
 
   beforeEach(() => {
@@ -37,6 +37,11 @@ describe('/apitoken command', () => {
     await execute(interaction);
     const [[{ content }]] = interaction.reply.mock.calls;
     const token = content.replace('Bearer ', '');
-    expect(jwt.verify(token, 'secret')).toMatchObject({ id: '1', username: 'Tester' });
+    expect(jwt.verify(token, 'secret')).toMatchObject({
+      id: '1',
+      username: 'Tester',
+      displayName: 'Display',
+      roles: ['Admin']
+    });
   });
 });

--- a/commands/admin/apitoken.js
+++ b/commands/admin/apitoken.js
@@ -26,9 +26,13 @@ module.exports = {
       });
     }
 
+    const member = interaction.member || await interaction.guild.members.fetch(interaction.user.id);
+    const roles = member.roles?.cache?.map(r => r.name) || [];
     const payload = {
       id: interaction.user.id,
-      username: interaction.user.username
+      username: interaction.user.username,
+      displayName: member.displayName,
+      roles
     };
     const token = jwt.sign(payload, secret);
 


### PR DESCRIPTION
## Summary
- extend /api/login to include member displayName and roles in the JWT
- update admin `/apitoken` command to match new JWT structure
- adjust unit tests for login and apitoken to verify the new payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845ae0715bc832d8c97e04e928d5e6e