### PR TITLE
Make accolades endpoints public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `/api/docs` endpoint serving Swagger UI
 - `GET /api/events/:id` and `GET /api/accolades/:id` endpoints
 - `/api/uex` search endpoints for terminals and inventory
+- `/api/accolades` endpoints are now public (no JWT required)
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
 - JWT authentication middleware for API routes

--- a/api/server.js
+++ b/api/server.js
@@ -16,6 +16,7 @@ function createApp() {
   app.use('/api/docs', docsRouter);
 
   // Public endpoints
+  app.use('/api/accolades', accoladesRouter);
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
   app.get('/api/data', async (req, res) => {
@@ -24,7 +25,6 @@ function createApp() {
 
   // Protected endpoints
   app.use('/api', authMiddleware);
-  app.use('/api/accolades', accoladesRouter);
   app.use('/api/uex', uexRouter);
 
   return app;

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -30,6 +30,39 @@
         "security": []
       }
     },
+    "/api/accolades": {
+      "get": {
+        "summary": "GET /api/accolades",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
+    "/api/accolades/{id}": {
+      "get": {
+        "summary": "GET /api/accolades/{id}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id"
+          }
+        ],
+        "security": []
+      }
+    },
     "/api/content": {
       "get": {
         "summary": "GET /api/content",
@@ -94,37 +127,6 @@
           }
         ],
         "security": []
-      }
-    },
-    "/api/accolades": {
-      "get": {
-        "summary": "GET /api/accolades",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
-    "/api/accolades/{id}": {
-      "get": {
-        "summary": "GET /api/accolades/{id}",
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        },
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "The id"
-          }
-        ]
       }
     },
     "/api/uex/terminals": {

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -88,7 +88,9 @@ const publicPaths = [
   '/api/content',
   '/api/content/{section}',
   '/api/events',
-  '/api/events/{id}'
+  '/api/events/{id}',
+  '/api/accolades',
+  '/api/accolades/{id}'
 ];
 
 for (const pathKey of publicPaths) {


### PR DESCRIPTION
## Summary
- expose `/api/accolades` routes without auth
- flag accolades paths as public in swagger generator
- regenerate API docs
- note change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845c3ce04a8832d89378291eebbddeb