### PR TITLE
Add activity log and Discord info endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@
 - `/api/token` endpoint for JWT exchange
 - Swagger UI now supports Bearer token authentication via the **Authorize** button
 - `/apitoken` command for generating JWTs via Discord
+- Activity log search and Discord member/command endpoints under `/api`
 

--- a/__tests__/api/activityLog.test.js
+++ b/__tests__/api/activityLog.test.js
@@ -1,0 +1,209 @@
+jest.mock('../../config/database', () => ({ UsageLog: { findAll: jest.fn() } }));
+jest.mock('../../discordClient', () => ({ getClient: jest.fn() }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+
+const { Op } = require('sequelize');
+const {
+  searchLogs,
+  searchLogsPost,
+  listCommands,
+  getCommand,
+  listMembers,
+  getMember
+} = require('../../api/activityLog');
+const { UsageLog } = require('../../config/database');
+const { getClient } = require('../../discordClient');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+const makeCollection = arr => ({ map: fn => arr.map(fn) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('api/activityLog searchLogs', () => {
+  test('returns logs with filters', async () => {
+    const req = { query: { page: '2', limit: '1', type: 'LOGIN', userId: 'u1', command: 'ping', message: 'hi' } };
+    const res = mockRes();
+    UsageLog.findAll.mockResolvedValue(['x']);
+
+    await searchLogs(req, res);
+
+    expect(UsageLog.findAll).toHaveBeenCalledWith({
+      where: {
+        server_id: 'g1',
+        event_type: 'LOGIN',
+        user_id: 'u1',
+        command_name: 'ping',
+        message_content: { [Op.like]: '%hi%' }
+      },
+      limit: 1,
+      offset: 1,
+      order: [['timestamp', 'DESC']]
+    });
+    expect(res.json).toHaveBeenCalledWith({ logs: ['x'] });
+  });
+
+  test('handles errors', async () => {
+    const req = { query: {} };
+    const res = mockRes();
+    UsageLog.findAll.mockRejectedValue(new Error('fail'));
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await searchLogs(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/activityLog searchLogsPost', () => {
+  test('returns logs using body', async () => {
+    const req = { body: { page: 1, limit: 2, filters: { command: 'trade' } } };
+    const res = mockRes();
+    UsageLog.findAll.mockResolvedValue(['y']);
+
+    await searchLogsPost(req, res);
+
+    expect(UsageLog.findAll).toHaveBeenCalledWith({
+      where: { server_id: 'g1', command_name: 'trade' },
+      limit: 2,
+      offset: 0,
+      order: [['timestamp', 'DESC']]
+    });
+    expect(res.json).toHaveBeenCalledWith({ logs: ['y'] });
+  });
+});
+
+describe('api/activityLog listCommands', () => {
+  test('returns command list', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map([['ping', {}], ['trade', {}]]) });
+    const req = {};
+    const res = mockRes();
+
+    await listCommands(req, res);
+    expect(res.json).toHaveBeenCalledWith({ commands: ['/ping', '/trade'] });
+  });
+
+  test('returns 500 when client missing', async () => {
+    getClient.mockReturnValue(null);
+    const req = {};
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listCommands(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/activityLog getCommand', () => {
+  test('returns command info', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    const cmd = { data: { name: 'ping', description: 'desc' }, aliases: ['pong'], cooldown: 5 };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map([['ping', cmd]]) });
+    const req = { params: { command: 'ping' } };
+    const res = mockRes();
+
+    await getCommand(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ command: { command: '/ping', description: 'desc', aliases: ['pong'], cooldown: '5s' } });
+  });
+
+  test('returns 404 when missing', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map() });
+    const req = { params: { command: 'x' } };
+    const res = mockRes();
+
+    await getCommand(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+});
+
+describe('api/activityLog listMembers', () => {
+  test('returns members', async () => {
+    const members = [
+      { id: '1', user: { username: 'A' } },
+      { id: '2', user: { username: 'B' } }
+    ];
+    const guild = { members: { fetch: jest.fn().mockResolvedValue(), cache: makeCollection(members) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = {};
+    const res = mockRes();
+
+    await listMembers(req, res);
+
+    expect(guild.members.fetch).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ members: [{ userId: '1', username: 'A' }, { userId: '2', username: 'B' }] });
+  });
+
+  test('handles errors', async () => {
+    const guild = { members: { fetch: jest.fn().mockRejectedValue(new Error('fail')), cache: makeCollection([]) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = {};
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listMembers(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/activityLog getMember', () => {
+  test('returns member info', async () => {
+    const member = {
+      id: '1',
+      user: { username: 'A' },
+      joinedAt: new Date('2023-01-01'),
+      roles: { cache: [{ name: 'R' }] },
+      presence: { status: 'online' }
+    };
+    const guild = { members: { fetch: jest.fn().mockResolvedValue(member) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = { params: { userId: '1' } };
+    const res = mockRes();
+
+    await getMember(req, res);
+
+    expect(guild.members.fetch).toHaveBeenCalledWith('1');
+    expect(res.json).toHaveBeenCalledWith({
+      member: {
+        userId: '1',
+        username: 'A',
+        joinDate: '2023-01-01',
+        roles: ['R'],
+        isActive: true
+      }
+    });
+  });
+
+  test('returns 404 when missing', async () => {
+    const guild = { members: { fetch: jest.fn().mockRejectedValue(new Error('fail')) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = { params: { userId: 'x' } };
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getMember(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+    spy.mockRestore();
+  });
+});

--- a/api/activityLog.js
+++ b/api/activityLog.js
@@ -1,0 +1,138 @@
+const express = require('express');
+const { Op } = require('sequelize');
+const router = express.Router();
+router.use(express.json());
+
+const { UsageLog } = require('../config/database');
+const { getClient } = require('../discordClient');
+const config = require('../config.json');
+
+function buildFilters({ type, userId, command, message }) {
+  const where = { server_id: config.guildId };
+  if (type) where.event_type = type;
+  if (userId) where.user_id = userId;
+  if (command) where.command_name = command;
+  if (message) where.message_content = { [Op.like]: `%${message}%` };
+  return where;
+}
+
+async function executeSearch(opts, res) {
+  const page = parseInt(opts.page, 10) || 1;
+  const limit = parseInt(opts.limit, 10) || 25;
+  const where = buildFilters(opts);
+  try {
+    const logs = await UsageLog.findAll({
+      where,
+      limit,
+      offset: (page - 1) * limit,
+      order: [['timestamp', 'DESC']]
+    });
+    res.json({ logs });
+  } catch (err) {
+    console.error('Failed to search logs:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+async function searchLogs(req, res) {
+  await executeSearch(req.query || {}, res);
+}
+
+async function searchLogsPost(req, res) {
+  const { page, limit, filters = {} } = req.body || {};
+  await executeSearch({ page, limit, ...filters }, res);
+}
+
+async function listCommands(req, res) {
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for commands endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  const commands = Array.from(client.commands?.keys() || []).map(n => `/${n}`);
+  res.json({ commands });
+}
+
+async function getCommand(req, res) {
+  const { command } = req.params;
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for commands endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  const cmd = client.commands?.get(command);
+  if (!cmd) return res.status(404).json({ error: 'Not found' });
+  res.json({
+    command: {
+      command: `/${cmd.data.name}`,
+      description: cmd.data.description,
+      aliases: cmd.aliases || [],
+      cooldown: cmd.cooldown ? `${cmd.cooldown}s` : undefined
+    }
+  });
+}
+
+async function listMembers(req, res) {
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for members endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  try {
+    await guild.members.fetch();
+    const members = guild.members.cache.map(m => ({
+      userId: m.id,
+      username: m.user.username
+    }));
+    res.json({ members });
+  } catch (err) {
+    console.error('Failed to fetch members:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+async function getMember(req, res) {
+  const { userId } = req.params;
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for members endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  try {
+    const member = await guild.members.fetch(userId);
+    if (!member) return res.status(404).json({ error: 'Not found' });
+    res.json({
+      member: {
+        userId: member.id,
+        username: member.user.username,
+        joinDate: member.joinedAt?.toISOString().split('T')[0],
+        roles: member.roles.cache.map(r => r.name),
+        isActive: member.presence ? member.presence.status !== 'offline' : false
+      }
+    });
+  } catch (err) {
+    console.error('Failed to fetch member:', err);
+    res.status(404).json({ error: 'Not found' });
+  }
+}
+
+router.get('/activity-log/search', searchLogs);
+router.post('/activity-log/search', searchLogsPost);
+router.get('/commands', listCommands);
+router.get('/command/:command', getCommand);
+router.get('/members', listMembers);
+router.get('/member/:userId', getMember);
+
+module.exports = {
+  router,
+  searchLogs,
+  searchLogsPost,
+  listCommands,
+  getCommand,
+  listMembers,
+  getMember
+};

--- a/api/server.js
+++ b/api/server.js
@@ -6,6 +6,7 @@ const { router: accoladesRouter } = require('./accolades');
 const { router: docsRouter } = require('./docs');
 const { router: uexRouter } = require('./uex');
 const { router: loginRouter } = require('./login');
+const { router: activityLogRouter } = require('./activityLog');
 const { authMiddleware } = require('./auth');
 
 function createApp() {
@@ -24,6 +25,7 @@ function createApp() {
 
   // Protected endpoints
   app.use('/api', authMiddleware);
+  app.use('/api', activityLogRouter);
   app.use('/api/accolades', accoladesRouter);
   app.use('/api/uex', uexRouter);
 


### PR DESCRIPTION
## Summary
- add activity log API with search and Discord info endpoints
- register new router in API server
- document new endpoints in CHANGELOG
- test activity log and Discord info endpoints

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6845c3b5b110832d83c42058d072ef54