### PR TITLE
Update swagger generator to include all methods

### DIFF
--- a/__tests__/scripts/generateSwagger.test.js
+++ b/__tests__/scripts/generateSwagger.test.js
@@ -15,4 +15,15 @@ describe('scripts/generateSwagger', () => {
     expect(spec.security).toEqual([{ bearerAuth: [] }]);
     logSpy.mockRestore();
   });
+
+  test('captures POST endpoints', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.isolateModules(() => {
+      require('../../scripts/generateSwagger');
+    });
+    const specPath = path.join(__dirname, '../../api/swagger.json');
+    const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+    expect(spec.paths['/api/login'].post).toBeDefined();
+    logSpy.mockRestore();
+  });
 });

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -30,6 +30,17 @@
         "security": []
       }
     },
+    "/api/login": {
+      "post": {
+        "summary": "POST /api/login",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "security": []
+      }
+    },
     "/api/accolades": {
       "get": {
         "summary": "GET /api/accolades",

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -40,14 +40,14 @@ const spec = {
   paths: {}
 };
 
-function buildPathDetails(path) {
+function buildPathDetails(path, method = 'get') {
   const params = [];
   const openPath = path.replace(/:([^/]+)/g, (_, name) => {
     params.push(name);
     return `{${name}}`;
   });
   const operation = {
-    summary: `GET ${openPath}`,
+    summary: `${method.toUpperCase()} ${openPath}`,
     responses: { 200: { description: 'Success' } }
   };
   if (params.length) {
@@ -62,23 +62,30 @@ function buildPathDetails(path) {
   return { openPath, operation };
 }
 
-const directRegex = /app\.get\(['"`]([^'"`]+)['"`]/g;
+const methods = ['get', 'post', 'put', 'patch', 'delete'];
+const directPattern = 'app\\.(' + methods.join('|') + ')\\([\'"\\`]([^\'"\\`]+)[\'"\\`]';
+const directRegex = new RegExp(directPattern, 'g');
 while ((m = directRegex.exec(serverSrc))) {
-  const { openPath, operation } = buildPathDetails(m[1]);
-  spec.paths[openPath] = { get: operation };
+  const method = m[1];
+  const { openPath, operation } = buildPathDetails(m[2], method);
+  if (!spec.paths[openPath]) spec.paths[openPath] = {};
+  spec.paths[openPath][method] = operation;
 }
 
 for (const [routerVar, base] of Object.entries(basePaths)) {
   const file = routerFiles[routerVar];
   if (!file) continue;
   const src = fs.readFileSync(path.join(apiDir, file), 'utf8');
-  const routeRegex = /router\.get\(['"`]([^'"`]+)['"`]/g;
+  const routePattern = 'router\\.(' + methods.join('|') + ')\\([\'"\\`]([^\'"\\`]+)[\'"\\`]';
+  const routeRegex = new RegExp(routePattern, 'g');
   let routeMatch;
   while ((routeMatch = routeRegex.exec(src))) {
-    let route = routeMatch[1];
+    const method = routeMatch[1];
+    let route = routeMatch[2];
     if (route === '/') route = '';
-    const { openPath, operation } = buildPathDetails(`${base}${route}`);
-    spec.paths[openPath] = { get: operation };
+    const { openPath, operation } = buildPathDetails(`${base}${route}`, method);
+    if (!spec.paths[openPath]) spec.paths[openPath] = {};
+    spec.paths[openPath][method] = operation;
   }
 }
 
@@ -90,12 +97,15 @@ const publicPaths = [
   '/api/events',
   '/api/events/{id}',
   '/api/accolades',
-  '/api/accolades/{id}'
+  '/api/accolades/{id}',
+  '/api/login'
 ];
 
 for (const pathKey of publicPaths) {
-  if (spec.paths[pathKey] && spec.paths[pathKey].get) {
-    spec.paths[pathKey].get.security = [];
+  if (spec.paths[pathKey]) {
+    for (const method of Object.keys(spec.paths[pathKey])) {
+      spec.paths[pathKey][method].security = [];
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance Swagger generator to parse all HTTP methods
- allow POST login endpoint to be unauthenticated
- add test for POST endpoint detection
- regenerate swagger specification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845cef82db4832d8e979f819bed5f74