### PR TITLE
Fix activity log endpoints

### DIFF
--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -43,6 +43,7 @@ describe('api/server startApi', () => {
     expect(app.use).toHaveBeenCalledWith('/api/login', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/docs', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api', expect.any(Function));
+    expect(app.use).toHaveBeenCalledWith('/api/activity-log', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));

--- a/api/activityLog.js
+++ b/api/activityLog.js
@@ -120,8 +120,8 @@ async function getMember(req, res) {
   }
 }
 
-router.get('/activity-log/search', searchLogs);
-router.post('/activity-log/search', searchLogsPost);
+router.get('/search', searchLogs);
+router.post('/search', searchLogsPost);
 router.get('/commands', listCommands);
 router.get('/command/:command', getCommand);
 router.get('/members', listMembers);

--- a/api/server.js
+++ b/api/server.js
@@ -26,6 +26,7 @@ function createApp() {
 
   // Protected endpoints
   app.use('/api', authMiddleware);
+  app.use('/api/activity-log', activityLogRouter);
   app.use('/api/uex', uexRouter);
 
   return app;

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -140,6 +140,86 @@
         "security": []
       }
     },
+    "/api/activity-log/search": {
+      "get": {
+        "summary": "GET /api/activity-log/search",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "summary": "POST /api/activity-log/search",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/activity-log/commands": {
+      "get": {
+        "summary": "GET /api/activity-log/commands",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/activity-log/command/{command}": {
+      "get": {
+        "summary": "GET /api/activity-log/command/{command}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "command",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The command"
+          }
+        ]
+      }
+    },
+    "/api/activity-log/members": {
+      "get": {
+        "summary": "GET /api/activity-log/members",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/activity-log/member/{userId}": {
+      "get": {
+        "summary": "GET /api/activity-log/member/{userId}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The userId"
+          }
+        ]
+      }
+    },
     "/api/uex/terminals": {
       "get": {
         "summary": "GET /api/uex/terminals",


### PR DESCRIPTION
## Summary
- mount the activity log router so its routes are served
- simplify router paths to avoid duplication
- update unit tests and regenerate swagger spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d12f24c4832d87c2efe5fec48000