### PR TITLE
Add members listing endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Swagger UI now supports Bearer token authentication via the **Authorize** button
 - `/apitoken` command for generating JWTs via Discord
 - Activity log search and Discord member/command endpoints under `/api`
+- `GET /api/members` endpoint to list Discord guild members
 

--- a/__tests__/api/members.test.js
+++ b/__tests__/api/members.test.js
@@ -1,0 +1,66 @@
+jest.mock('../../discordClient', () => ({ getClient: jest.fn() }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+
+const { listMembers } = require('../../api/members');
+const { getClient } = require('../../discordClient');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+const makeCollection = arr => ({ map: fn => arr.map(fn) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('api/members listMembers', () => {
+  test('returns members', async () => {
+    const members = [
+      { id: '1', user: { username: 'A' } },
+      { id: '2', user: { username: 'B' } }
+    ];
+    const guild = {
+      members: { fetch: jest.fn().mockResolvedValue(), cache: makeCollection(members) }
+    };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = {};
+    const res = mockRes();
+
+    await listMembers(req, res);
+
+    expect(guild.members.fetch).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ members: [{ userId: '1', username: 'A' }, { userId: '2', username: 'B' }] });
+  });
+
+  test('handles fetch errors', async () => {
+    const guild = {
+      members: { fetch: jest.fn().mockRejectedValue(new Error('fail')), cache: makeCollection([]) }
+    };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = {};
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listMembers(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+
+  test('returns 500 when client missing', async () => {
+    getClient.mockReturnValue(null);
+    const req = {};
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listMembers(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -45,6 +45,7 @@ describe('api/server startApi', () => {
     expect(app.use).toHaveBeenCalledWith('/api', expect.any(Function));
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
+    expect(app.use).toHaveBeenCalledWith('/api/members', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));
     expect(app.listen).toHaveBeenCalledWith(8003, expect.any(Function));
     expect(logSpy).toHaveBeenCalled();

--- a/api/members.js
+++ b/api/members.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const router = express.Router();
+const { getClient } = require('../discordClient');
+const config = require('../config.json');
+
+async function listMembers(req, res) {
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for members endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  try {
+    await guild.members.fetch();
+    const members = guild.members.cache.map(m => ({
+      userId: m.id,
+      username: m.user.username
+    }));
+    res.json({ members });
+  } catch (err) {
+    console.error('Failed to fetch members:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/', listMembers);
+
+module.exports = { router, listMembers };

--- a/api/server.js
+++ b/api/server.js
@@ -7,6 +7,7 @@ const { router: docsRouter } = require('./docs');
 const { router: uexRouter } = require('./uex');
 const { router: loginRouter } = require('./login');
 const { router: activityLogRouter } = require('./activityLog');
+const { router: membersRouter } = require('./members');
 const { authMiddleware } = require('./auth');
 
 function createApp() {
@@ -27,6 +28,7 @@ function createApp() {
   // Protected endpoints
   app.use('/api', authMiddleware);
   app.use('/api/uex', uexRouter);
+  app.use('/api/members', membersRouter);
 
   return app;
 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -170,6 +170,16 @@
           }
         ]
       }
+    },
+    "/api/members": {
+      "get": {
+        "summary": "GET /api/members",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `/api/members` router
- register members router in API server
- cover new members endpoint with tests
- document the new endpoint in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d171a588832d8afa4793a4ca00e2