### PR TITLE
Add /api/commands endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Swagger UI now supports Bearer token authentication via the **Authorize** button
 - `/apitoken` command for generating JWTs via Discord
 - Activity log search and Discord member/command endpoints under `/api`
+- `/api/commands` endpoint for listing registered slash commands
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ watch your files and automatically restart the bot during development.
 
 API endpoints are documented using the OpenAPI specification. After running the tests or starting the server, `api/swagger.json` is regenerated automatically. To view the interactive documentation, start the API and visit [`/api/docs`](http://localhost:8003/api/docs).
 Since the API is secured with JWTs, obtain a token via `POST /api/login` and click **Authorize** in the Swagger UI to enter `Bearer <token>` for testing.
+The API now includes a `/api/commands` endpoint that lists all registered slash commands.
 
 ## 🧪 Testing
 

--- a/api/server.js
+++ b/api/server.js
@@ -27,6 +27,7 @@ function createApp() {
   // Protected endpoints
   app.use('/api', authMiddleware);
   app.use('/api/uex', uexRouter);
+  app.use('/api', activityLogRouter);
 
   return app;
 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -170,6 +170,86 @@
           }
         ]
       }
+    },
+    "/api/activity-log/search": {
+      "get": {
+        "summary": "GET /api/activity-log/search",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "summary": "POST /api/activity-log/search",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/commands": {
+      "get": {
+        "summary": "GET /api/commands",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/command/{command}": {
+      "get": {
+        "summary": "GET /api/command/{command}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "command",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The command"
+          }
+        ]
+      }
+    },
+    "/api/members": {
+      "get": {
+        "summary": "GET /api/members",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/member/{userId}": {
+      "get": {
+        "summary": "GET /api/member/{userId}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The userId"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- expose activity log router so `/api/commands` works
- document the new commands endpoint in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d18fd46c832d87e411e085a19df1