### PR TITLE
feat(api): add commands endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Activity log search endpoint under `/api`
 - `GET /api/members` endpoint to list Discord guild members
 - `GET /api/profile/{userId}` endpoint for member profile info
+- `/api/commands` and `/api/command/{command}` endpoints for command details

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ watch your files and automatically restart the bot during development.
 
 API endpoints are documented using the OpenAPI specification. After running the tests or starting the server, `api/swagger.json` is regenerated automatically. To view the interactive documentation, start the API and visit [`/api/docs`](http://localhost:8003/api/docs).
 Since the API is secured with JWTs, obtain a token via `POST /api/login` and click **Authorize** in the Swagger UI to enter `Bearer <token>` for testing.
+The API now includes a `/api/commands` endpoint that lists all registered slash commands and `/api/command/{commandName}` for details about a specific command.
 
 ## 🧪 Testing
 

--- a/__tests__/api/commands.test.js
+++ b/__tests__/api/commands.test.js
@@ -1,0 +1,78 @@
+jest.mock('../../discordClient', () => ({ getClient: jest.fn() }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+
+const { listCommands, getCommand } = require('../../api/commands');
+const { getClient } = require('../../discordClient');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('api/commands listCommands', () => {
+  test('returns command list', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map([['ping', {}], ['trade', {}]]) });
+    const req = {};
+    const res = mockRes();
+
+    await listCommands(req, res);
+    expect(res.json).toHaveBeenCalledWith({ commands: ['/ping', '/trade'] });
+  });
+
+  test('returns 500 when client missing', async () => {
+    getClient.mockReturnValue(null);
+    const req = {};
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listCommands(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/commands getCommand', () => {
+  test('returns command info', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    const cmd = { data: { name: 'ping', description: 'desc' }, aliases: ['pong'], cooldown: 5 };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map([['ping', cmd]]) });
+    const req = { params: { command: 'ping' } };
+    const res = mockRes();
+
+    await getCommand(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ command: { command: '/ping', description: 'desc', aliases: ['pong'], cooldown: '5s' } });
+  });
+
+  test('returns 404 when missing', async () => {
+    const guild = { members: { fetch: jest.fn() } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } }, commands: new Map() });
+    const req = { params: { command: 'x' } };
+    const res = mockRes();
+
+    await getCommand(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  test('returns 500 when client missing', async () => {
+    getClient.mockReturnValue(null);
+    const req = { params: { command: 'ping' } };
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getCommand(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});

--- a/api/commands.js
+++ b/api/commands.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const router = express.Router();
+const { getClient } = require('../discordClient');
+const config = require('../config.json');
+
+async function listCommands(req, res) {
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for commands endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  const commands = Array.from(client.commands?.keys() || []).map(n => `/${n}`);
+  res.json({ commands });
+}
+
+async function getCommand(req, res) {
+  const { command } = req.params;
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for commands endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  const cmd = client.commands?.get(command);
+  if (!cmd) return res.status(404).json({ error: 'Not found' });
+  res.json({
+    command: {
+      command: `/${cmd.data.name}`,
+      description: cmd.data.description,
+      aliases: cmd.aliases || [],
+      cooldown: cmd.cooldown ? `${cmd.cooldown}s` : undefined
+    }
+  });
+}
+
+router.get('/commands', listCommands);
+router.get('/command/:command', getCommand);
+
+module.exports = { router, listCommands, getCommand };

--- a/api/server.js
+++ b/api/server.js
@@ -9,6 +9,7 @@ const { router: loginRouter } = require("./login");
 const { router: profileRouter } = require('./profile');
 const { router: activityLogRouter } = require('./activityLog');
 const { router: membersRouter } = require('./members');
+const { router: commandsRouter } = require('./commands');
 const { authMiddleware } = require('./auth');
 
 function createApp() {
@@ -29,6 +30,7 @@ function createApp() {
   // Protected endpoints
   app.use('/api', authMiddleware);
   app.use('/api/profile', profileRouter);
+  app.use('/api', commandsRouter);
   app.use('/api/activity-log', activityLogRouter);
   app.use('/api/members', membersRouter);
 

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -161,6 +161,37 @@
         ]
       }
     },
+    "/api/commands": {
+      "get": {
+        "summary": "GET /api/commands",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/command/{command}": {
+      "get": {
+        "summary": "GET /api/command/{command}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "command",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The command"
+          }
+        ]
+      }
+    },
     "/api/activity-log/search": {
       "get": {
         "summary": "GET /api/activity-log/search",


### PR DESCRIPTION
## Summary
- expose `/api/commands` for listing slash commands
- expose `/api/command/{commandName}` for command details
- document the new endpoints
- add tests for commands API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d915a2ac832daa8e9c6ac72c8424