### PR TITLE
Fix commands endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - `GET /api/members` endpoint to list Discord guild members
 - `GET /api/profile/{userId}` endpoint for member profile info
 - `/api/commands` and `/api/command/{command}` endpoints for command details
+- `/api/commands` now returns command names without the leading `/`

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ watch your files and automatically restart the bot during development.
 
 API endpoints are documented using the OpenAPI specification. After running the tests or starting the server, `api/swagger.json` is regenerated automatically. To view the interactive documentation, start the API and visit [`/api/docs`](http://localhost:8003/api/docs).
 Since the API is secured with JWTs, obtain a token via `POST /api/login` and click **Authorize** in the Swagger UI to enter `Bearer <token>` for testing.
-The API now includes a `/api/commands` endpoint that lists all registered slash commands and `/api/command/{commandName}` for details about a specific command.
+The API now includes a `/api/commands` endpoint that lists all registered slash commands and `/api/command/{commandName}` for details about a specific command. The command names in the response are returned without the leading `/`.
 
 ## 🧪 Testing
 

--- a/__tests__/api/commands.test.js
+++ b/__tests__/api/commands.test.js
@@ -20,7 +20,7 @@ describe('api/commands listCommands', () => {
     const res = mockRes();
 
     await listCommands(req, res);
-    expect(res.json).toHaveBeenCalledWith({ commands: ['/ping', '/trade'] });
+    expect(res.json).toHaveBeenCalledWith({ commands: ['ping', 'trade'] });
   });
 
   test('returns 500 when client missing', async () => {
@@ -48,7 +48,7 @@ describe('api/commands getCommand', () => {
 
     await getCommand(req, res);
 
-    expect(res.json).toHaveBeenCalledWith({ command: { command: '/ping', description: 'desc', aliases: ['pong'], cooldown: '5s' } });
+    expect(res.json).toHaveBeenCalledWith({ command: { command: 'ping', description: 'desc', aliases: ['pong'], cooldown: '5s' } });
   });
 
   test('returns 404 when missing', async () => {

--- a/api/commands.js
+++ b/api/commands.js
@@ -10,7 +10,7 @@ async function listCommands(req, res) {
     console.error('Discord client unavailable for commands endpoint');
     return res.status(500).json({ error: 'Discord client unavailable' });
   }
-  const commands = Array.from(client.commands?.keys() || []).map(n => `/${n}`);
+  const commands = Array.from(client.commands?.keys() || []);
   res.json({ commands });
 }
 
@@ -26,7 +26,7 @@ async function getCommand(req, res) {
   if (!cmd) return res.status(404).json({ error: 'Not found' });
   res.json({
     command: {
-      command: `/${cmd.data.name}`,
+      command: cmd.data.name,
       description: cmd.data.description,
       aliases: cmd.aliases || [],
       cooldown: cmd.cooldown ? `${cmd.cooldown}s` : undefined


### PR DESCRIPTION
## Summary
- return command names without a leading slash
- update tests
- document new response behavior in the README and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845e4701670832db2f36828ec575829