### PR TITLE
Add event types API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Automatic OpenAPI documentation generation
 - `/api/docs` endpoint serving Swagger UI
 - `GET /api/events/:id` and `GET /api/accolades/:id` endpoints
+- `GET /api/activity-log/event-types` endpoint returning unique event types
 - Removed `/api/uex/terminals` and `/api/uex/terminals/{id}` endpoints
 - `/api/accolades` endpoints are now public (no JWT required)
 - Removed `GET /api/uex/items/{name}/terminals` endpoint

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -210,6 +210,16 @@
         }
       }
     },
+    "/api/activity-log/event-types": {
+      "get": {
+        "summary": "GET /api/activity-log/event-types",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/members": {
       "get": {
         "summary": "GET /api/members",


### PR DESCRIPTION
## Summary
- add `GET /api/activity-log/event-types` endpoint
- document the endpoint in Swagger and changelog
- test `listEventTypes` API logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845e7634f44832dbaa05b682e1949d6