### PR TITLE
Document log search parameters in Swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
 - `GET /api/profile/{userId}` endpoint for member profile info
 - `/api/commands` and `/api/command/{command}` endpoints for command details
 - `/api/commands` now returns command names without the leading `/`
+- Documented `/api/activity-log/search` parameters and request body in Swagger

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -199,13 +199,108 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            },
+            "description": "Page number"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 25
+            },
+            "description": "Results per page"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by event type"
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by user ID"
+          },
+          {
+            "name": "command",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by command name"
+          },
+          {
+            "name": "message",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search within message content"
+          }
+        ]
       },
       "post": {
         "summary": "POST /api/activity-log/search",
         "responses": {
           "200": {
             "description": "Success"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "page": {
+                    "type": "integer",
+                    "default": 1
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "default": 25
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "userId": {
+                        "type": "string"
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -109,5 +109,47 @@ for (const pathKey of publicPaths) {
   }
 }
 
+// Add detailed docs for log search endpoints
+if (spec.paths['/api/activity-log/search']) {
+  const logSearch = spec.paths['/api/activity-log/search'];
+
+  if (logSearch.get) {
+    logSearch.get.parameters = [
+      { name: 'page', in: 'query', required: false, schema: { type: 'integer', default: 1 }, description: 'Page number' },
+      { name: 'limit', in: 'query', required: false, schema: { type: 'integer', default: 25 }, description: 'Results per page' },
+      { name: 'type', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by event type' },
+      { name: 'userId', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by user ID' },
+      { name: 'command', in: 'query', required: false, schema: { type: 'string' }, description: 'Filter by command name' },
+      { name: 'message', in: 'query', required: false, schema: { type: 'string' }, description: 'Search within message content' }
+    ];
+  }
+
+  if (logSearch.post) {
+    logSearch.post.requestBody = {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              page: { type: 'integer', default: 1 },
+              limit: { type: 'integer', default: 25 },
+              filters: {
+                type: 'object',
+                properties: {
+                  type: { type: 'string' },
+                  userId: { type: 'string' },
+                  command: { type: 'string' },
+                  message: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+  }
+}
+
 fs.writeFileSync(path.join(apiDir, 'swagger.json'), JSON.stringify(spec, null, 2));
 console.log('\uD83D\uDCDD Swagger docs generated'); // 📝


### PR DESCRIPTION
## Summary
- expand swagger docs to include query params and request body for the activity log search endpoints
- update CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845ea84dac0832dbc3435607927a36e