### PR TITLE
fix admin apitoken expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `/api/token` endpoint for JWT exchange
 - Swagger UI now supports Bearer token authentication via the **Authorize** button
 - `/apitoken` command for generating JWTs via Discord
+- `/apitoken` tokens now expire after 30 minutes
 - Activity log search endpoint under `/api`
 - Activity log search results now include channel and member details
 - `GET /api/members` endpoint to list Discord guild members

--- a/__tests__/commands/admin/apitoken.test.js
+++ b/__tests__/commands/admin/apitoken.test.js
@@ -37,11 +37,13 @@ describe('/apitoken command', () => {
     await execute(interaction);
     const [[{ content }]] = interaction.reply.mock.calls;
     const token = content.replace('Bearer ', '');
-    expect(jwt.verify(token, 'secret')).toMatchObject({
+    const decoded = jwt.verify(token, 'secret');
+    expect(decoded).toMatchObject({
       id: '1',
       username: 'Tester',
       displayName: 'Display',
       roles: ['Admin']
     });
+    expect(decoded.exp - decoded.iat).toBe(1800);
   });
 });

--- a/commands/admin/apitoken.js
+++ b/commands/admin/apitoken.js
@@ -34,7 +34,7 @@ module.exports = {
       displayName: member.displayName,
       roles
     };
-    const token = jwt.sign(payload, secret);
+    const token = jwt.sign(payload, secret, { expiresIn: '30m' });
 
     await interaction.reply({
       content: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- set `/apitoken` token expiration to 30m
- test JWT expiration
- document new expiration behavior in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845ead01754832dac8ab8d20f2355ad