### PR TITLE
feat(api): include display name in members list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Activity log search endpoint under `/api`
 - Activity log search results now include channel and member details
 - `GET /api/members` endpoint to list Discord guild members
+- `GET /api/members` now includes each member's displayName
 - `GET /api/profile/{userId}` endpoint for member profile info
 - `/api/commands` and `/api/command/{command}` endpoints for command details
 - `/api/commands` now returns command names without the leading `/`

--- a/__tests__/api/members.test.js
+++ b/__tests__/api/members.test.js
@@ -17,8 +17,8 @@ beforeEach(() => {
 describe('api/members listMembers', () => {
   test('returns members', async () => {
     const members = [
-      { id: '1', user: { username: 'A' } },
-      { id: '2', user: { username: 'B' } }
+      { id: '1', user: { username: 'A' }, displayName: 'A' },
+      { id: '2', user: { username: 'B' }, displayName: 'B' }
     ];
     const guild = {
       members: { fetch: jest.fn().mockResolvedValue(), cache: makeCollection(members) }
@@ -30,7 +30,10 @@ describe('api/members listMembers', () => {
     await listMembers(req, res);
 
     expect(guild.members.fetch).toHaveBeenCalled();
-    expect(res.json).toHaveBeenCalledWith({ members: [{ userId: '1', username: 'A' }, { userId: '2', username: 'B' }] });
+    expect(res.json).toHaveBeenCalledWith({ members: [
+      { userId: '1', username: 'A', displayName: 'A' },
+      { userId: '2', username: 'B', displayName: 'B' }
+    ] });
   });
 
   test('handles fetch errors', async () => {

--- a/api/members.js
+++ b/api/members.js
@@ -14,7 +14,8 @@ async function listMembers(req, res) {
     await guild.members.fetch();
     const members = guild.members.cache.map(m => ({
       userId: m.id,
-      username: m.user.username
+      username: m.user.username,
+      displayName: m.displayName
     }));
     res.json({ members });
   } catch (err) {


### PR DESCRIPTION
## Summary
- update `GET /api/members` to return each member's display name
- test the new behaviour in members API tests
- document the new field in `CHANGELOG.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845f54ac474832da5b81803d46755b4