### PR TITLE
feat(api): extend profile endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `GET /api/members` endpoint to list Discord guild members
 - `GET /api/members` now includes each member's displayName
 - `GET /api/profile/{userId}` endpoint for member profile info
+- `/api/profile/{userId}` now returns Discord profile details alongside RSI data
 - `/api/commands` and `/api/command/{command}` endpoints for command details
 - `/api/commands` now returns command names without the leading `/`
 - Documented `/api/activity-log/search` parameters and request body in Swagger

--- a/__mocks__/utils/discordProfile.js
+++ b/__mocks__/utils/discordProfile.js
@@ -1,0 +1,3 @@
+module.exports = {
+  fetchDiscordProfileInfo: jest.fn(),
+};

--- a/api/profile.js
+++ b/api/profile.js
@@ -2,14 +2,20 @@ const express = require('express');
 const router = express.Router();
 const { VerifiedUser } = require('../config/database');
 const { fetchRsiProfileInfo } = require('../utils/rsiProfileScraper');
+const { fetchDiscordProfileInfo } = require('../utils/discordProfile');
 
 async function getProfile(req, res) {
   const { userId } = req.params;
   try {
     const verified = await VerifiedUser.findByPk(userId);
     if (!verified) return res.status(404).json({ error: 'Not found' });
-    const profile = await fetchRsiProfileInfo(verified.rsiHandle);
-    res.json({ profile });
+
+    const [rsiProfile, discordProfile] = await Promise.all([
+      fetchRsiProfileInfo(verified.rsiHandle),
+      fetchDiscordProfileInfo(userId)
+    ]);
+
+    res.json({ rsiProfile, discordProfile });
   } catch (err) {
     console.error('Failed to fetch member profile:', err);
     res.status(500).json({ error: 'Server error' });

--- a/utils/discordProfile.js
+++ b/utils/discordProfile.js
@@ -1,0 +1,32 @@
+const { getClient } = require('../discordClient');
+
+/**
+ * Fetch Discord profile info for a user.
+ * @param {string} userId Discord user ID
+ * @returns {Promise<{ id: string, username: string, displayName: string, avatar: string, roles: string[], aboutMe: string|null }>}
+ */
+async function fetchDiscordProfileInfo(userId) {
+  const client = getClient();
+  const config = require('../config.json');
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    throw new Error('Discord client unavailable');
+  }
+
+  const member = await guild.members.fetch(userId);
+
+  const avatar = member.user.displayAvatarURL({ extension: 'png', size: 256 });
+  const roles = member.roles.cache.map(r => r.name);
+  const aboutMe = member.user?.bio || null;
+
+  return {
+    id: member.id,
+    username: member.user.username,
+    displayName: member.displayName,
+    avatar,
+    roles,
+    aboutMe
+  };
+}
+
+module.exports = { fetchDiscordProfileInfo };


### PR DESCRIPTION
## Summary
- include discord data in profile endpoint
- add discord profile fetcher
- test new profile response
- document profile enhancement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68466de360bc832db3aa450b9951fb4d