### PR TITLE
feat: officers bio API and command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `GET /api/activity-log/event-types` endpoint returning unique event types
 - Removed `/api/uex/terminals` and `/api/uex/terminals/{id}` endpoints
 - `/api/accolades` endpoints are now public (no JWT required)
+- `GET /api/officers` endpoint listing officers and their bios
+- `/officerbio` slash command allowing officers to set their bio
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`
 - JWT authentication middleware for API routes

--- a/__tests__/api/officers.test.js
+++ b/__tests__/api/officers.test.js
@@ -1,0 +1,72 @@
+jest.mock('../../discordClient', () => ({ getClient: jest.fn() }));
+jest.mock('../../config/database', () => ({ OfficerBio: { findByPk: jest.fn() } }));
+jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
+
+const { listOfficers } = require('../../api/officers');
+const { getClient } = require('../../discordClient');
+const { OfficerBio } = require('../../config/database');
+const { PermissionFlagsBits } = require('discord.js');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+const makeCollection = arr => ({
+  filter: fn => makeCollection(arr.filter(fn)),
+  map: fn => arr.map(fn),
+  sort: fn => makeCollection(arr.sort(fn)),
+  first: function() { return arr[0]; }
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('api/officers listOfficers', () => {
+  test('returns officers with bios', async () => {
+    const role = { name: 'Officer', permissions: { has: () => true }, hexColor: '#fff', position: 1 };
+    const members = [
+      { id: '1', user: { username: 'A' }, displayName: 'A', permissions: { has: perm => perm === PermissionFlagsBits.KickMembers }, roles: { cache: makeCollection([role]) } },
+      { id: '2', user: { username: 'B' }, displayName: 'B', permissions: { has: () => false }, roles: { cache: makeCollection([]) } }
+    ];
+    const guild = { members: { fetch: jest.fn().mockResolvedValue(), cache: makeCollection(members) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    OfficerBio.findByPk.mockResolvedValue({ bio: 'hi' });
+    const req = {}; const res = mockRes();
+
+    await listOfficers(req, res);
+
+    expect(guild.members.fetch).toHaveBeenCalled();
+    expect(OfficerBio.findByPk).toHaveBeenCalledWith('1');
+    expect(res.json).toHaveBeenCalledWith({ officers: [
+      { userId: '1', username: 'A', displayName: 'A', roleName: 'Officer', roleColor: '#fff', bio: 'hi' }
+    ] });
+  });
+
+  test('handles errors gracefully', async () => {
+    const guild = { members: { fetch: jest.fn().mockRejectedValue(new Error('fail')), cache: makeCollection([]) } };
+    getClient.mockReturnValue({ guilds: { cache: { get: jest.fn(() => guild) } } });
+    const req = {}; const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listOfficers(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+
+  test('returns 500 when client missing', async () => {
+    getClient.mockReturnValue(null);
+    const req = {}; const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listOfficers(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Discord client unavailable' });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/commands/admin/officerbio.test.js
+++ b/__tests__/commands/admin/officerbio.test.js
@@ -1,0 +1,32 @@
+const { execute } = require('../../../commands/admin/officerbio');
+const { OfficerBio } = require('../../../config/database');
+const { MessageFlags } = require('discord.js');
+
+jest.mock('../../../config/database', () => ({ OfficerBio: { upsert: jest.fn() } }));
+
+describe('/officerbio command', () => {
+  const makeInteraction = () => ({
+    options: { getString: jest.fn(() => 'new bio') },
+    user: { id: 'u1' },
+    reply: jest.fn()
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test('saves bio for officer', async () => {
+    const interaction = makeInteraction();
+    await execute(interaction);
+    expect(OfficerBio.upsert).toHaveBeenCalledWith({ discordUserId: 'u1', bio: 'new bio' });
+    expect(interaction.reply).toHaveBeenCalledWith({ content: '✅ Bio saved.', flags: MessageFlags.Ephemeral });
+  });
+
+  test('handles errors gracefully', async () => {
+    const interaction = makeInteraction();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    OfficerBio.upsert.mockRejectedValue(new Error('fail'));
+    await execute(interaction);
+    expect(spy).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({ content: '❌ Error saving bio.', flags: MessageFlags.Ephemeral });
+    spy.mockRestore();
+  });
+});

--- a/api/officers.js
+++ b/api/officers.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router();
+const { OfficerBio } = require('../config/database');
+const { getClient } = require('../discordClient');
+const config = require('../config.json');
+const { PermissionFlagsBits } = require('discord.js');
+
+async function listOfficers(req, res) {
+  const client = getClient();
+  const guild = client?.guilds?.cache.get(config.guildId);
+  if (!client || !guild) {
+    console.error('Discord client unavailable for officers endpoint');
+    return res.status(500).json({ error: 'Discord client unavailable' });
+  }
+  try {
+    await guild.members.fetch();
+    const officerMembers = guild.members.cache.filter(m => m.permissions.has(PermissionFlagsBits.KickMembers));
+
+    const officers = await Promise.all(officerMembers.map(async m => {
+      const kickRole = m.roles.cache
+        .filter(r => r.permissions.has(PermissionFlagsBits.KickMembers))
+        .sort((a, b) => b.position - a.position)
+        .first();
+      const bio = await OfficerBio.findByPk(m.id);
+      return {
+        userId: m.id,
+        username: m.user.username,
+        displayName: m.displayName,
+        roleName: kickRole?.name || null,
+        roleColor: kickRole?.hexColor || null,
+        bio: bio?.bio || null
+      };
+    }));
+
+    res.json({ officers });
+  } catch (err) {
+    console.error('Failed to fetch officers:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/', listOfficers);
+
+module.exports = { router, listOfficers };

--- a/api/server.js
+++ b/api/server.js
@@ -9,6 +9,7 @@ const { router: loginRouter } = require("./login");
 const { router: profileRouter } = require('./profile');
 const { router: activityLogRouter } = require('./activityLog');
 const { router: membersRouter } = require('./members');
+const { router: officersRouter } = require('./officers');
 const { router: commandsRouter } = require('./commands');
 const { authMiddleware } = require('./auth');
 
@@ -33,6 +34,7 @@ function createApp() {
   app.use('/api', commandsRouter);
   app.use('/api/activity-log', activityLogRouter);
   app.use('/api/members', membersRouter);
+  app.use('/api/officers', officersRouter);
 
   return app;
 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -324,6 +324,16 @@
           }
         }
       }
+    },
+    "/api/officers": {
+      "get": {
+        "summary": "GET /api/officers",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
     }
   }
 }

--- a/commands/admin/officerbio.js
+++ b/commands/admin/officerbio.js
@@ -1,0 +1,25 @@
+const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { OfficerBio } = require('../../config/database');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('officerbio')
+    .setDescription('Set your officer bio')
+    .addStringOption(option =>
+      option.setName('bio')
+        .setDescription('Your bio')
+        .setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+  help: 'Allows officers to set their bio for the public officer listing. Requires Kick Members permission.',
+  category: 'Admin',
+  async execute(interaction) {
+    const bio = interaction.options.getString('bio');
+    try {
+      await OfficerBio.upsert({ discordUserId: interaction.user.id, bio });
+      await interaction.reply({ content: '✅ Bio saved.', flags: MessageFlags.Ephemeral });
+    } catch (err) {
+      console.error('Failed to save officer bio:', err);
+      await interaction.reply({ content: '❌ Error saving bio.', flags: MessageFlags.Ephemeral });
+    }
+  }
+};

--- a/config/database.js
+++ b/config/database.js
@@ -39,6 +39,7 @@ const Accolade = require('../models/accolade')(sequelize);
 const OrgTag = require('../models/orgTag')(sequelize);
 const VerificationCode = require('../models/verificationCode')(sequelize);
 const VerifiedUser = require('../models/verifiedUser')(sequelize);
+const OfficerBio = require('../models/officerBio')(sequelize);
 const AmbientMessage = require('../models/ambiEntMessage')(sequelize);
 const AmbientChannel = require('../models/ambientChannel')(sequelize);
 const AmbientSetting = require('../models/ambientSetting')(sequelize);
@@ -102,6 +103,7 @@ module.exports = {
     OrgTag,
     VerificationCode,
     VerifiedUser,
+    OfficerBio,
     AmbientMessage,
     AmbientChannel,
     AmbientSetting,

--- a/models/officerBio.js
+++ b/models/officerBio.js
@@ -1,0 +1,21 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const OfficerBio = sequelize.define('OfficerBio', {
+    discordUserId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true
+    },
+    bio: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    }
+  }, {
+    tableName: 'officer_bios',
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
+  });
+
+  return OfficerBio;
+};


### PR DESCRIPTION
## Summary
- add OfficerBio model
- expose new officers API endpoint
- allow officers to set their bio via `/officerbio`
- register officers route in API server
- document new endpoint in swagger
- add unit tests for API and command
- update changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ecd75309c832dad43f644256a419c