### PR TITLE
Fix public officer endpoint in Swagger docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@
 - `/api/commands` and `/api/command/{command}` endpoints for command details
 - `/api/commands` now returns command names without the leading `/`
 - Documented `/api/activity-log/search` parameters and request body in Swagger
+
+### Fixed
+- Officer endpoint incorrectly marked as secured in Swagger docs

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -27,7 +27,10 @@ jest.mock('cors', () => jest.fn(() => (req, res, next) => next()), { virtual: tr
 jest.mock('../../config/database', () => ({ SiteContent: {}, Event: {}, Accolade: {} }));
 jest.mock('../../config.json', () => ({ guildId: 'g1' }), { virtual: true });
 jest.mock('../../api/docs', () => ({ router: {} }), { virtual: true });
-jest.mock('../../api/auth', () => ({ authMiddleware: jest.fn((req, res, next) => next()) }));
+jest.mock('../../api/auth', () => ({
+  authMiddleware: jest.fn((req, res, next) => next()),
+  requireServerAdmin: jest.fn((req, res, next) => next())
+}));
 
 const express = require('express');
 const { startApi } = require('../../api/server');

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -167,7 +167,8 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": []
       }
     },
     "/api/profile/{userId}": {

--- a/scripts/generateSwagger.js
+++ b/scripts/generateSwagger.js
@@ -98,7 +98,8 @@ const publicPaths = [
   '/api/events/{id}',
   '/api/accolades',
   '/api/accolades/{id}',
-  '/api/login'
+  '/api/login',
+  '/api/officers'
 ];
 
 for (const pathKey of publicPaths) {


### PR DESCRIPTION
## Summary
- ensure `/api/officers` is marked as public when generating Swagger spec
- update changelog
- mock `requireServerAdmin` in server tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ef5f6b6c0832d9bf7cf64bc59678c