### PR TITLE
feat(api): add orgs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `/api/accolades` endpoints are now public (no JWT required)
 - `GET /api/officers` endpoint listing officers and their bios
 - `/api/officers` endpoint is now public (no JWT required)
+- `GET /api/orgs` endpoint returning data for organizations listed in `org_tags`
 - `/officerbio` slash command allowing officers to set their bio
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`

--- a/__tests__/api/orgs.test.js
+++ b/__tests__/api/orgs.test.js
@@ -1,0 +1,45 @@
+jest.mock('node-fetch');
+jest.mock('../../config/database', () => ({ OrgTag: { findAll: jest.fn() } }));
+
+const fetch = require('node-fetch');
+const { listOrgs } = require('../../api/orgs');
+const { OrgTag } = require('../../config/database');
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('api/orgs listOrgs', () => {
+  test('returns org data', async () => {
+    OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }, { rsiOrgId: 'ABC' }]);
+    fetch
+      .mockResolvedValueOnce({ text: async () => JSON.stringify({ data: { name: 'PFC' } }) })
+      .mockResolvedValueOnce({ text: async () => JSON.stringify({ data: { name: 'A' } }) });
+    const req = {}; const res = mockRes();
+
+    await listOrgs(req, res);
+
+    expect(OrgTag.findAll).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith({ orgs: [
+      { name: 'PFC' },
+      { name: 'A' }
+    ] });
+  });
+
+  test('handles db errors', async () => {
+    const err = new Error('fail');
+    OrgTag.findAll.mockRejectedValue(err);
+    const req = {}; const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await listOrgs(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/api/server.test.js
+++ b/__tests__/api/server.test.js
@@ -50,6 +50,7 @@ describe('api/server startApi', () => {
     expect(app.use).toHaveBeenCalledWith('/api/activity-log', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/content', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/events', expect.anything());
+    expect(app.use).toHaveBeenCalledWith('/api/orgs', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/officers', expect.anything());
     expect(app.use).toHaveBeenCalledWith('/api/members', expect.anything());
     expect(app.get).toHaveBeenCalledWith('/api/data', expect.any(Function));

--- a/api/orgs.js
+++ b/api/orgs.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const fetch = require('node-fetch');
+const { OrgTag } = require('../config/database');
+
+async function listOrgs(req, res) {
+  try {
+    const tags = await OrgTag.findAll();
+    const base = 'https://api.starcitizen-api.com/77210b95720bd50b3584ead32936dfd4/v1/';
+    const orgEndpoint = `${base}live/organization/`;
+
+    const orgs = [];
+    for (const tag of tags) {
+      try {
+        const url = `${orgEndpoint}${tag.rsiOrgId.toUpperCase()}`;
+        const text = await fetch(url).then(r => r.text());
+        const data = JSON.parse(text);
+        if (data?.data) orgs.push(data.data);
+      } catch (err) {
+        console.error('Failed to fetch org', tag.rsiOrgId, err);
+      }
+    }
+
+    res.json({ orgs });
+  } catch (err) {
+    console.error('Failed to load orgs:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/', listOrgs);
+
+module.exports = { router, listOrgs };

--- a/api/server.js
+++ b/api/server.js
@@ -10,6 +10,7 @@ const { router: profileRouter } = require('./profile');
 const { router: activityLogRouter } = require('./activityLog');
 const { router: membersRouter } = require('./members');
 const { router: officersRouter } = require('./officers');
+const { router: orgsRouter } = require('./orgs');
 const { router: commandsRouter } = require('./commands');
 const { authMiddleware } = require('./auth');
 
@@ -24,6 +25,7 @@ function createApp() {
   app.use('/api/accolades', accoladesRouter);
   app.use('/api/content', contentRouter);
   app.use('/api/events', eventsRouter);
+  app.use('/api/orgs', orgsRouter);
   app.use('/api/officers', officersRouter);
   app.get('/api/data', async (req, res) => {
     res.json({ success: true, message: 'API is working' });

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -160,6 +160,16 @@
         "security": []
       }
     },
+    "/api/orgs": {
+      "get": {
+        "summary": "GET /api/orgs",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/api/officers": {
       "get": {
         "summary": "GET /api/officers",


### PR DESCRIPTION
## Summary
- expose new `/api/orgs` route
- implement API handler to fetch organization info from the Star Citizen API for each entry in `org_tags`
- test new router and ensure server registers the route
- document the endpoint in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851643d05c4832d930241215393e479