### PR TITLE
Fix swagger auth and request body docs

### DIFF
--- a/__tests__/api/auth.test.js
+++ b/__tests__/api/auth.test.js
@@ -50,7 +50,7 @@ describe('api/auth requireServerAdmin', () => {
   function mockRes() { return { status: jest.fn().mockReturnThis(), json: jest.fn() }; }
 
   test('passes with Admin role', () => {
-    const req = { user: { roles: ['Admin'] } };
+    const req = { user: { roles: ['Fleet Admiral'] } };
     const res = mockRes();
     const next = jest.fn();
     requireServerAdmin(req, res, next);

--- a/__tests__/scripts/generateSwagger.test.js
+++ b/__tests__/scripts/generateSwagger.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 describe('scripts/generateSwagger', () => {
-  test('writes security scheme', () => {
+  test('writes security scheme and security per path', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.isolateModules(() => {
       require('../../scripts/generateSwagger');
@@ -12,11 +12,14 @@ describe('scripts/generateSwagger', () => {
     expect(spec.components.securitySchemes.bearerAuth).toEqual(
       expect.objectContaining({ type: 'http', scheme: 'bearer' })
     );
-    expect(spec.security).toEqual([{ bearerAuth: [] }]);
+    expect(spec.paths['/api/profile/{userId}'].get.security).toEqual([
+      { bearerAuth: [] }
+    ]);
+    expect(spec.paths['/api/data'].get.security).toBeUndefined();
     logSpy.mockRestore();
   });
 
-  test('captures POST endpoints', () => {
+  test('captures POST endpoints and request bodies', () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.isolateModules(() => {
       require('../../scripts/generateSwagger');
@@ -24,6 +27,8 @@ describe('scripts/generateSwagger', () => {
     const specPath = path.join(__dirname, '../../api/swagger.json');
     const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
     expect(spec.paths['/api/login'].post).toBeDefined();
+    expect(spec.paths['/api/login'].post.requestBody).toBeDefined();
+    expect(spec.paths['/api/content/{section}'].put.requestBody).toBeDefined();
     logSpy.mockRestore();
   });
 });

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -13,11 +13,6 @@
       }
     }
   },
-  "security": [
-    {
-      "bearerAuth": []
-    }
-  ],
   "paths": {
     "/api/data": {
       "get": {
@@ -26,8 +21,7 @@
           "200": {
             "description": "Success"
           }
-        },
-        "security": []
+        }
       }
     },
     "/api/login": {
@@ -38,7 +32,28 @@
             "description": "Success"
           }
         },
-        "security": []
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "redirectUri": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "redirectUri"
+                ]
+              }
+            }
+          }
+        }
       }
     },
     "/api/accolades": {
@@ -48,8 +63,7 @@
           "200": {
             "description": "Success"
           }
-        },
-        "security": []
+        }
       }
     },
     "/api/accolades/{id}": {
@@ -70,8 +84,7 @@
             },
             "description": "The id"
           }
-        ],
-        "security": []
+        ]
       }
     },
     "/api/content": {
@@ -81,8 +94,7 @@
           "200": {
             "description": "Success"
           }
-        },
-        "security": []
+        }
       }
     },
     "/api/content/{section}": {
@@ -103,8 +115,7 @@
             },
             "description": "The section"
           }
-        ],
-        "security": []
+        ]
       },
       "put": {
         "summary": "PUT /api/content/{section}",
@@ -128,7 +139,25 @@
           {
             "bearerAuth": []
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content"
+                ]
+              }
+            }
+          }
+        }
       }
     },
     "/api/events": {
@@ -138,8 +167,7 @@
           "200": {
             "description": "Success"
           }
-        },
-        "security": []
+        }
       }
     },
     "/api/events/{id}": {
@@ -160,8 +188,7 @@
             },
             "description": "The id"
           }
-        ],
-        "security": []
+        ]
       }
     },
     "/api/officers": {
@@ -171,8 +198,7 @@
           "200": {
             "description": "Success"
           }
-        },
-        "security": []
+        }
       }
     },
     "/api/profile/{userId}": {
@@ -193,6 +219,11 @@
             },
             "description": "The userId"
           }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
@@ -203,7 +234,12 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/command/{command}": {
@@ -224,6 +260,11 @@
             },
             "description": "The command"
           }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
@@ -235,6 +276,11 @@
             "description": "Success"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -301,6 +347,11 @@
             "description": "Success"
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -347,7 +398,12 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/members": {
@@ -357,7 +413,12 @@
           "200": {
             "description": "Success"
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
## Summary
- generate per-endpoint swagger auth instead of global
- document login and content update bodies
- update unit tests for new swagger generation
- fix admin role test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851710a75e8832dbce422ab1850ace2