### PR TITLE
feat(api): add single org endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `GET /api/officers` endpoint listing officers and their bios
 - `/api/officers` endpoint is now public (no JWT required)
 - `GET /api/orgs` endpoint returning data for organizations listed in `org_tags`
+- `GET /api/orgs/{sid}` endpoint returning a single organization by ID
 - `/officerbio` slash command allowing officers to set their bio
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`

--- a/__tests__/api/orgs.test.js
+++ b/__tests__/api/orgs.test.js
@@ -2,7 +2,7 @@ jest.mock('node-fetch');
 jest.mock('../../config/database', () => ({ OrgTag: { findAll: jest.fn() } }));
 
 const fetch = require('node-fetch');
-const { listOrgs } = require('../../api/orgs');
+const { listOrgs, getOrg } = require('../../api/orgs');
 const { OrgTag } = require('../../config/database');
 
 function mockRes() {
@@ -36,6 +36,47 @@ describe('api/orgs listOrgs', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     await listOrgs(req, res);
+
+    expect(spy).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Server error' });
+    spy.mockRestore();
+  });
+});
+
+describe('api/orgs getOrg', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('returns org data', async () => {
+    fetch.mockResolvedValue({ text: async () => JSON.stringify({ data: { name: 'PFC' } }) });
+    const req = { params: { sid: 'PFCS' } };
+    const res = mockRes();
+
+    await getOrg(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('PFCS'));
+    expect(res.json).toHaveBeenCalledWith({ org: { name: 'PFC' } });
+  });
+
+  test('returns 404 when not found', async () => {
+    fetch.mockResolvedValue({ text: async () => JSON.stringify({}) });
+    const req = { params: { sid: 'XYZ' } };
+    const res = mockRes();
+
+    await getOrg(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not found' });
+  });
+
+  test('handles errors', async () => {
+    const err = new Error('fail');
+    fetch.mockRejectedValue(err);
+    const req = { params: { sid: 'PFCS' } };
+    const res = mockRes();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await getOrg(req, res);
 
     expect(spy).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(500);

--- a/api/orgs.js
+++ b/api/orgs.js
@@ -30,4 +30,21 @@ async function listOrgs(req, res) {
 
 router.get('/', listOrgs);
 
-module.exports = { router, listOrgs };
+async function getOrg(req, res) {
+  const { sid } = req.params;
+  try {
+    const base = 'https://api.starcitizen-api.com/77210b95720bd50b3584ead32936dfd4/v1/';
+    const url = `${base}live/organization/${sid.toUpperCase()}`;
+    const text = await fetch(url).then(r => r.text());
+    const data = JSON.parse(text);
+    if (!data?.data) return res.status(404).json({ error: 'Not found' });
+    res.json({ org: data.data });
+  } catch (err) {
+    console.error('Failed to fetch org', sid, err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}
+
+router.get('/:sid', getOrg);
+
+module.exports = { router, listOrgs, getOrg };

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -170,6 +170,27 @@
         }
       }
     },
+    "/api/orgs/{sid}": {
+      "get": {
+        "summary": "GET /api/orgs/{sid}",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "parameters": [
+          {
+            "name": "sid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The sid"
+          }
+        ]
+      }
+    },
     "/api/officers": {
       "get": {
         "summary": "GET /api/officers",


### PR DESCRIPTION
## Summary
- implement `/api/orgs/{sid}` route to fetch one org
- test new route and document in changelog
- regenerate Swagger docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851736c59e0832d80a9a82d3db629c1