### PR TITLE
Cache org data in DB and update sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - `/api/officers` endpoint is now public (no JWT required)
 - `GET /api/orgs` endpoint returning data for organizations listed in `org_tags`
 - `GET /api/orgs/{sid}` endpoint returning a single organization by ID
+- Organization data now cached in database and retrieved from local storage
+- API sync job updated to populate organization cache
 - `/officerbio` slash command allowing officers to set their bio
 - Removed `GET /api/uex/items/{name}/terminals` endpoint
 - Renamed `GET /api/uex/terminals/{id}/inventory` to `GET /api/uex/terminals/{id}`

--- a/__tests__/api/orgs.test.js
+++ b/__tests__/api/orgs.test.js
@@ -1,9 +1,10 @@
-jest.mock('node-fetch');
-jest.mock('../../config/database', () => ({ OrgTag: { findAll: jest.fn() } }));
+jest.mock('../../config/database', () => ({
+  OrgTag: { findAll: jest.fn() },
+  Org: { findByPk: jest.fn() }
+}));
 
-const fetch = require('node-fetch');
 const { listOrgs, getOrg } = require('../../api/orgs');
-const { OrgTag } = require('../../config/database');
+const { OrgTag, Org } = require('../../config/database');
 
 function mockRes() {
   return { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -14,15 +15,15 @@ beforeEach(() => { jest.clearAllMocks(); });
 describe('api/orgs listOrgs', () => {
   test('returns org data', async () => {
     OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }, { rsiOrgId: 'ABC' }]);
-    fetch
-      .mockResolvedValueOnce({ text: async () => JSON.stringify({ data: { name: 'PFC' } }) })
-      .mockResolvedValueOnce({ text: async () => JSON.stringify({ data: { name: 'A' } }) });
+    Org.findByPk
+      .mockResolvedValueOnce({ data: JSON.stringify({ name: 'PFC' }) })
+      .mockResolvedValueOnce({ data: JSON.stringify({ name: 'A' }) });
     const req = {}; const res = mockRes();
 
     await listOrgs(req, res);
 
     expect(OrgTag.findAll).toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(Org.findByPk).toHaveBeenCalledTimes(2);
     expect(res.json).toHaveBeenCalledWith({ orgs: [
       { name: 'PFC' },
       { name: 'A' }
@@ -48,18 +49,18 @@ describe('api/orgs getOrg', () => {
   beforeEach(() => { jest.clearAllMocks(); });
 
   test('returns org data', async () => {
-    fetch.mockResolvedValue({ text: async () => JSON.stringify({ data: { name: 'PFC' } }) });
+    Org.findByPk.mockResolvedValue({ data: JSON.stringify({ name: 'PFC' }) });
     const req = { params: { sid: 'PFCS' } };
     const res = mockRes();
 
     await getOrg(req, res);
 
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('PFCS'));
+    expect(Org.findByPk).toHaveBeenCalledWith('PFCS');
     expect(res.json).toHaveBeenCalledWith({ org: { name: 'PFC' } });
   });
 
   test('returns 404 when not found', async () => {
-    fetch.mockResolvedValue({ text: async () => JSON.stringify({}) });
+    Org.findByPk.mockResolvedValue(null);
     const req = { params: { sid: 'XYZ' } };
     const res = mockRes();
 
@@ -71,7 +72,7 @@ describe('api/orgs getOrg', () => {
 
   test('handles errors', async () => {
     const err = new Error('fail');
-    fetch.mockRejectedValue(err);
+    Org.findByPk.mockRejectedValue(err);
     const req = { params: { sid: 'PFCS' } };
     const res = mockRes();
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/__tests__/botactions/api/syncEndpoints.test.js
+++ b/__tests__/botactions/api/syncEndpoints.test.js
@@ -11,7 +11,8 @@ const {
   syncUexFuelPrices,
   syncUexVehiclePurchasePrices,
   syncUexVehicleRentalPrices,
-  syncUexPois
+  syncUexPois,
+  syncOrgs
 } = require('../../../botactions/api/syncEndpoints');
 
 jest.mock('../../../utils/apiSync/manufacturers', () => ({ syncManufacturers: jest.fn() }));
@@ -26,6 +27,7 @@ jest.mock('../../../utils/apiSync/syncUexFuelPrices', () => ({ syncUexFuelPrices
 jest.mock('../../../utils/apiSync/syncUexVehiclePurchasePrices', () => ({ syncUexVehiclePurchasePrices: jest.fn() }));
 jest.mock('../../../utils/apiSync/syncUexVehicleRentalPrices', () => ({ syncUexVehicleRentalPrices: jest.fn() }));
 jest.mock('../../../utils/apiSync/syncUexPoi', () => ({ syncUexPois: jest.fn() }));
+jest.mock('../../../utils/apiSync/orgs', () => ({ syncOrgs: jest.fn() }));
 
 const manufacturers = require('../../../utils/apiSync/manufacturers');
 const vehicles = require('../../../utils/apiSync/vehicles');
@@ -39,6 +41,7 @@ const uexFuelPrices = require('../../../utils/apiSync/syncUexFuelPrices');
 const uexVehiclePurchasePrices = require('../../../utils/apiSync/syncUexVehiclePurchasePrices');
 const uexVehicleRentalPrices = require('../../../utils/apiSync/syncUexVehicleRentalPrices');
 const uexPois = require('../../../utils/apiSync/syncUexPoi');
+const orgs = require('../../../utils/apiSync/orgs');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -59,7 +62,8 @@ describe('syncAllEndpoints', () => {
       uexFuelPrices.syncUexFuelPrices,
       uexVehiclePurchasePrices.syncUexVehiclePurchasePrices,
       uexVehicleRentalPrices.syncUexVehicleRentalPrices,
-      uexPois.syncUexPois
+      uexPois.syncUexPois,
+      orgs.syncOrgs
     ];
     fns.forEach((fn, i) => fn.mockResolvedValue({ id: i }));
 
@@ -82,11 +86,12 @@ describe('syncAllEndpoints', () => {
     uexVehiclePurchasePrices.syncUexVehiclePurchasePrices.mockResolvedValue('i');
     uexVehicleRentalPrices.syncUexVehicleRentalPrices.mockResolvedValue('j');
     uexPois.syncUexPois.mockResolvedValue('k');
+    orgs.syncOrgs.mockResolvedValue('l');
 
     const res = await syncAllEndpoints();
 
     expect(res[0]).toEqual({ endpoint: 'terminals', success: false, error: 'fail' });
-    expect(res.slice(1)).toEqual(['a','b','c','d','e','f','g','h','i','j','k']);
+    expect(res.slice(1)).toEqual(['a','b','c','d','e','f','g','h','i','j','k','l']);
     expect(uexTerminals.syncUexTerminals).toHaveBeenCalled();
     expect(uexPois.syncUexPois).toHaveBeenCalled();
   });

--- a/__tests__/utils/apiSync/orgs.test.js
+++ b/__tests__/utils/apiSync/orgs.test.js
@@ -1,0 +1,64 @@
+jest.mock('../../../config/database', () => ({
+  OrgTag: { findAll: jest.fn() },
+  Org: { upsert: jest.fn() }
+}));
+jest.mock('node-fetch');
+
+const fetch = require('node-fetch');
+const { OrgTag, Org } = require('../../../config/database');
+const { syncOrgs } = require('../../../utils/apiSync/orgs');
+
+describe('syncOrgs', () => {
+  let logSpy, errorSpy, warnSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  test('upserts orgs', async () => {
+    OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }]);
+    fetch.mockResolvedValue({ text: async () => JSON.stringify({ data: { id: 1 } }) });
+    Org.upsert.mockResolvedValue([{}, true]);
+
+    const res = await syncOrgs();
+    expect(fetch).toHaveBeenCalled();
+    expect(Org.upsert).toHaveBeenCalledWith({ rsiOrgId: 'PFCS', data: expect.any(String) });
+    expect(res).toEqual({ created: 1, updated: 0, skipped: 0, total: 1 });
+  });
+
+  test('skips entries without data', async () => {
+    OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }]);
+    fetch.mockResolvedValue({ text: async () => JSON.stringify({}) });
+
+    const res = await syncOrgs();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(Org.upsert).not.toHaveBeenCalled();
+    expect(res).toEqual({ created: 0, updated: 0, skipped: 1, total: 1 });
+  });
+
+  test('throws when upsert fails', async () => {
+    OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }]);
+    fetch.mockResolvedValue({ text: async () => JSON.stringify({ data: { id: 1 } }) });
+    Org.upsert.mockRejectedValue(new Error('fail'));
+
+    await expect(syncOrgs()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test('throws on fetch error', async () => {
+    OrgTag.findAll.mockResolvedValue([{ rsiOrgId: 'PFCS' }]);
+    fetch.mockRejectedValue(new Error('fail'));
+
+    await expect(syncOrgs()).rejects.toThrow('fail');
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/utils/apiSync/syncApiData.test.js
+++ b/__tests__/utils/apiSync/syncApiData.test.js
@@ -15,6 +15,7 @@ jest.mock('../../../botactions/api/syncEndpoints', () => ({
   syncUexVehiclePurchasePrices: jest.fn().mockResolvedValue({}),
   syncUexVehicleRentalPrices: jest.fn().mockResolvedValue({}),
   syncUexPois: jest.fn().mockResolvedValue({}),
+  syncOrgs: jest.fn().mockResolvedValue({}),
 }));
 
 describe('runFullApiSync', () => {
@@ -51,7 +52,7 @@ describe('runFullApiSync', () => {
     const interaction = new MockInteraction({});
     const editSpy = jest.spyOn(interaction, 'editReply');
     const results = await runFullApiSync(interaction);
-    expect(editSpy).toHaveBeenCalledTimes(14);
+    expect(editSpy).toHaveBeenCalledTimes(15);
     const lastCall = editSpy.mock.calls.at(-1)[0];
     const embedData = lastCall.embeds[0].toJSON();
     expect(embedData.title).toBe('✅ API Sync Complete');

--- a/api/orgs.js
+++ b/api/orgs.js
@@ -1,23 +1,19 @@
 const express = require('express');
 const router = express.Router();
-const fetch = require('node-fetch');
-const { OrgTag } = require('../config/database');
+const { OrgTag, Org } = require('../config/database');
 
 async function listOrgs(req, res) {
   try {
     const tags = await OrgTag.findAll();
-    const base = 'https://api.starcitizen-api.com/77210b95720bd50b3584ead32936dfd4/v1/';
-    const orgEndpoint = `${base}live/organization/`;
-
     const orgs = [];
     for (const tag of tags) {
       try {
-        const url = `${orgEndpoint}${tag.rsiOrgId.toUpperCase()}`;
-        const text = await fetch(url).then(r => r.text());
-        const data = JSON.parse(text);
-        if (data?.data) orgs.push(data.data);
+        const record = await Org.findByPk(tag.rsiOrgId.toUpperCase());
+        if (record?.data) {
+          orgs.push(JSON.parse(record.data));
+        }
       } catch (err) {
-        console.error('Failed to fetch org', tag.rsiOrgId, err);
+        console.error('Failed to load org', tag.rsiOrgId, err);
       }
     }
 
@@ -33,14 +29,12 @@ router.get('/', listOrgs);
 async function getOrg(req, res) {
   const { sid } = req.params;
   try {
-    const base = 'https://api.starcitizen-api.com/77210b95720bd50b3584ead32936dfd4/v1/';
-    const url = `${base}live/organization/${sid.toUpperCase()}`;
-    const text = await fetch(url).then(r => r.text());
-    const data = JSON.parse(text);
-    if (!data?.data) return res.status(404).json({ error: 'Not found' });
-    res.json({ org: data.data });
+    const record = await Org.findByPk(sid.toUpperCase());
+    if (!record) return res.status(404).json({ error: 'Not found' });
+    const data = JSON.parse(record.data);
+    res.json({ org: data });
   } catch (err) {
-    console.error('Failed to fetch org', sid, err);
+    console.error('Failed to load org', sid, err);
     res.status(500).json({ error: 'Server error' });
   }
 }

--- a/botactions/api/syncEndpoints.js
+++ b/botactions/api/syncEndpoints.js
@@ -10,6 +10,7 @@ const { syncUexFuelPrices } = require('../../utils/apiSync/syncUexFuelPrices');
 const { syncUexVehiclePurchasePrices } = require('../../utils/apiSync/syncUexVehiclePurchasePrices');
 const { syncUexVehicleRentalPrices } = require('../../utils/apiSync/syncUexVehicleRentalPrices');
 const { syncUexPois } = require('../../utils/apiSync/syncUexPoi');
+const { syncOrgs } = require('../../utils/apiSync/orgs');
 
 async function syncAllEndpoints() {
   const results = [];
@@ -98,6 +99,13 @@ async function syncAllEndpoints() {
     results.push({endpoint: 'poi', success: false, error: error.message });
   }
 
+  try {
+    const syncOrgResult = await syncOrgs();
+    results.push(syncOrgResult);
+  } catch (error) {
+    results.push({ endpoint: 'orgs', success: false, error: error.message });
+  }
+
   return results;
 }
 
@@ -114,5 +122,6 @@ module.exports = {
     syncUexFuelPrices,
     syncUexVehiclePurchasePrices,
     syncUexVehicleRentalPrices,
-    syncUexPois
+    syncUexPois,
+    syncOrgs
 };

--- a/config/database.js
+++ b/config/database.js
@@ -37,6 +37,7 @@ const UexVehicleRentalPrice = require('../models/uexVehicleRentalPrice')(sequeli
 const UexPoi = require('../models/uexPoi')(sequelize);
 const Accolade = require('../models/accolade')(sequelize);
 const OrgTag = require('../models/orgTag')(sequelize);
+const Org = require('../models/org')(sequelize);
 const VerificationCode = require('../models/verificationCode')(sequelize);
 const VerifiedUser = require('../models/verifiedUser')(sequelize);
 const OfficerBio = require('../models/officerBio')(sequelize);
@@ -101,6 +102,7 @@ module.exports = {
     UexPoi,
     Accolade,
     OrgTag,
+    Org,
     VerificationCode,
     VerifiedUser,
     OfficerBio,

--- a/models/org.js
+++ b/models/org.js
@@ -1,0 +1,21 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+  const Org = sequelize.define('Org', {
+    rsiOrgId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true
+    },
+    data: {
+      type: DataTypes.TEXT,
+      allowNull: false
+    }
+  }, {
+    tableName: 'orgs',
+    charset: 'utf8mb4',
+    collate: 'utf8mb4_unicode_ci'
+  });
+
+  return Org;
+};

--- a/utils/apiSync/orgs.js
+++ b/utils/apiSync/orgs.js
@@ -1,0 +1,37 @@
+const fetch = require('node-fetch');
+const { OrgTag, Org } = require('../../config/database');
+
+async function syncOrgs() {
+  console.log('[API SYNC] Syncing orgs...');
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  try {
+    const tags = await OrgTag.findAll();
+    const base = 'https://api.starcitizen-api.com/77210b95720bd50b3584ead32936dfd4/v1/live/organization/';
+
+    for (const tag of tags) {
+      const id = tag.rsiOrgId.toUpperCase();
+      const url = `${base}${id}`;
+      const text = await fetch(url).then(r => r.text());
+      const data = JSON.parse(text);
+      if (!data?.data) {
+        console.warn(`[SKIPPED] Missing data for org ${id}`);
+        skipped++;
+        continue;
+      }
+      const [record, wasCreated] = await Org.upsert({ rsiOrgId: id, data: text });
+      wasCreated ? created++ : updated++;
+    }
+
+    console.log(`[API SYNC] Orgs synced — Created: ${created}, Updated: ${updated}, Skipped: ${skipped}`);
+    return { created, updated, skipped, total: tags.length };
+  } catch (err) {
+    console.error('[API SYNC] Error syncing orgs:', err);
+    throw err;
+  }
+}
+
+module.exports = { syncOrgs };

--- a/utils/apiSync/syncApiData.js
+++ b/utils/apiSync/syncApiData.js
@@ -11,6 +11,7 @@ const {
     syncUexVehiclePurchasePrices,
     syncUexVehicleRentalPrices,
     syncUexPois,
+    syncOrgs,
   } = require('../../botactions/api/syncEndpoints');
 
   const { EmbedBuilder } = require('discord.js');
@@ -77,6 +78,7 @@ const {
       await updateStep('Vehicle Prices', syncUexVehiclePurchasePrices);
       await updateStep('Vehicle Rentals', syncUexVehicleRentalPrices);
       await updateStep('Points of Interest', syncUexPois);
+      await updateStep('Organizations', syncOrgs);
     
       if (interaction) {
         embed.setTitle('✅ API Sync Complete').setTimestamp();


### PR DESCRIPTION
## Summary
- add `Org` Sequelize model
- fetch organization info from DB instead of remote API
- sync org data during scheduled API sync
- export new sync step and update sync logic
- test org sync utility and endpoints
- document change in CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68518fb1c6e4832da4284283d837f1ec